### PR TITLE
Added edge server and central server for cross-silo FL

### DIFF
--- a/clients/simple.py
+++ b/clients/simple.py
@@ -48,6 +48,12 @@ class SimpleClient:
     async def start_client(self):
         """Startup function for a client."""
         uri = 'ws://{}:{}'.format(Config().server.address, Config().server.port)
+
+        if Config().training.hierarchy:
+            # Use the uri of the client's edge server
+            # Haven't thought through how to implement this
+            uri = 'ws://{}:{}'.format(Config().server.address, Config().server.port)
+
         try:
             async with websockets.connect(uri, ping_interval=None, max_size=2 ** 30) as websocket:
                 logging.info("Signing in at the server with client ID %s...", self.client_id)
@@ -68,7 +74,7 @@ class SimpleClient:
                             self.load_data()
 
                         report = self.train()
-     
+
                         logging.info("Model trained on client with client ID %s.", self.client_id)
                         # Sending client ID as metadata to the server (payload to follow)
                         client_update = {'id': self.client_id, 'payload': True}

--- a/config.py
+++ b/config.py
@@ -24,6 +24,8 @@ class Config:
             parser = argparse.ArgumentParser()
             parser.add_argument('-i', '--id', type=str,
                                 help='Unique client ID.')
+            parser.add_argument('-e', '--edgeid', type=str,
+                                help='Unique edge server ID.')
             parser.add_argument('-c', '--config', type=str, default='./config.conf',
                                 help='Federated learning configuration file.')
             parser.add_argument('-l', '--log', type=str, default='info',
@@ -76,11 +78,11 @@ class Config:
         params = []
 
         for i, field in enumerate(fields):
-            if type(defaults[i]) is int:
+            if isinstance(defaults[i], int):
                 params.append(Config.config[section].getint(field, defaults[i]))
-            elif type(defaults[i]) is float:
+            elif isinstance(defaults[i], float):
                 params.append(Config.config[section].getfloat(field, defaults[i]))
-            elif type(defaults[i]) is bool:
+            elif isinstance(defaults[i], bool):
                 params.append(Config.config[section].getboolean(field, defaults[i]))
             else: # assuming that the parameter is a string
                 params.append(Config.config[section].get(field, defaults[i]))
@@ -110,9 +112,9 @@ class Config:
         # Training parameters for federated learning
         fields = ['rounds', 'target_accuracy', 'task', 'epochs', 'batch_size', 'dataset',
                   'data_path', 'num_layers', 'num_classes', 'model',
-                  'optimizer', 'learning_rate', 'momentum', 'server']
+                  'optimizer', 'learning_rate', 'momentum', 'server', 'hierarchy']
         defaults = (0, 0.9, 'train', 0, 0, 'MNIST', './data', 40, 10, 'mnist_cnn',
-                    'SGD', 0.01, 0.5, 'fedavg')
+                    'SGD', 0.01, 0.5, 'fedavg', False)
         params = Config.extract_section('training', fields, defaults)
 
         Config.training = namedtuple('training', fields)(*params)
@@ -123,3 +125,12 @@ class Config:
         params = Config.extract_section('server', fields, defaults)
 
         Config.server = namedtuple('server', fields)(*params)
+
+        # If the topology is hierarchy
+        if Config.training.hierarchy:
+            # Parameters for the federated learning edge servers
+            fields = ['total', 'aggregations', 'do_test']
+            defaults = (0, 0, False)
+            params = Config.extract_section('edges', fields, defaults)
+
+            Config.edges = namedtuple('edges', fields)(*params)

--- a/configs/MNIST/test.conf
+++ b/configs/MNIST/test.conf
@@ -1,0 +1,44 @@
+[clients]
+# The total number of clients
+total = 10
+
+# The number of clients selected in each round
+per_round = 4
+
+label_distribution = uniform
+do_test = false
+test_partition = 0.2
+
+[data]
+partition_size = 600
+iid = true
+bias = false
+shard = false
+
+[training]
+rounds = 2
+target_accuracy = 0.99
+task = train
+epochs = 5
+batch_size = 10
+dataset = MNIST
+data_path = ./data
+model = mnist_cnn
+optimizer = SGD
+learning_rate = 0.01
+momentum = 0.5
+server = fedcs
+hierarchy = true
+
+[server]
+address = localhost
+port = 8000
+
+[edges]
+# The total number of edge servers
+total = 2
+
+# The number of local aggregations on edge servers before sending aggreagted weights to the central server
+aggregations = 2
+
+do_test = false

--- a/edge_server.py
+++ b/edge_server.py
@@ -1,0 +1,33 @@
+"""
+Starting point for a Plato federated learning edge server.
+"""
+
+import asyncio
+import logging
+import websockets
+
+from config import Config
+from servers import EdgeServer
+
+
+def main():
+    """Starting an edge server to connect to the server via WebSockets."""
+    __ = Config()
+    edge = EdgeServer()
+    edge.configure()
+
+    # Will change to edge server's own address and port later
+    start_edge_server = websockets.serve(edge.start_edge_server,
+                    Config().server.address, Config().server.port,
+                    ping_interval=None, max_size=2 ** 30)
+
+    loop = asyncio.get_event_loop()
+    try:
+        loop.run_until_complete(start_edge_server)
+    except websockets.ConnectionClosed:
+        logging.info("Edge server #%s: connection to the central server is closed.",
+            edge.edge_id)
+
+
+if __name__ == "__main__":
+    main()

--- a/server.py
+++ b/server.py
@@ -4,7 +4,6 @@ Starting point for a Plato federated learning server.
 
 import asyncio
 import websockets
-import logging
 
 from config import Config
 import servers
@@ -14,8 +13,12 @@ def main():
     __ = Config()
 
     server = {
-        "fedavg": servers.fedavg.FedAvgServer
+        "fedavg": servers.fedavg.FedAvgServer,
+        "fedcs": servers.fedcs.CrossSiloServer
     }[Config().training.server]()
+
+    if Config().training.hierarchy:
+        server.start_edge_servers()
 
     server.start_clients()
 

--- a/servers/__init__.py
+++ b/servers/__init__.py
@@ -1,2 +1,4 @@
 from .base import Server
 from .fedavg import FedAvgServer
+from .fedcs import CrossSiloServer
+from .edge import EdgeServer

--- a/servers/base.py
+++ b/servers/base.py
@@ -104,6 +104,11 @@ class Server():
                             await self.close_connections()
                             sys.exit()
 
+                        if self.current_round == Config().training.rounds:
+                            logging.info('Target number of training rounds reached.')
+                            await self.close_connections()
+                            sys.exit()
+
                         await self.select_clients()
 
                 else:

--- a/servers/edge.py
+++ b/servers/edge.py
@@ -1,0 +1,190 @@
+"""
+A simple edge server supporting hierarchical federated learning.
+Edge servers are also clients to FedAvgServer as the root servers.
+Each edge server communicates with a subset of the clients within its own institution.
+"""
+
+import logging
+import random
+import json
+import pickle
+from dataclasses import dataclass
+import websockets
+
+from training import trainer
+from servers import FedAvgServer
+from servers.fedcs import CrossSiloServer
+from config import Config
+
+
+@dataclass
+class Report:
+    """Edge server report sent to the federated learning central server."""
+    edge_id: str
+    total_samples: int
+    weights: list
+    accuracy: float
+
+
+class EdgeServer(FedAvgServer):
+    """Federated learning edge server using federated averaging."""
+
+    def __init__(self):
+        super().__init__()
+        self.edge_id = Config().args.edgeid
+        self.clients = {} # Clients of this edge server
+        self.do_test = None # Should edge servers test the trained model?
+        self.testset = None # Testing dataset
+        self.report = None # Report to the central server
+        self.model = None # Machine learning model
+        self.aggregations = Config().edges.aggregations # Aggregation number on edge servers in one global training round
+        self.current_agg_round = 0
+
+        self.clients_id = CrossSiloServer().assign_clients_to_edge_servers()[self.edge_id]
+        self.clients_num = len(self.clients_id)
+        self.clients_per_round = CrossSiloServer().select_clients_for_edge_servers()[self.edge_id]
+        self.client_reports = [] # Reports from clients
+
+
+    def configure(self):
+        """
+        Booting the federated learning edge server by setting up the data, model, and
+        creating the clients.
+        """
+        logging.info('Configuring the edge server #%s...', self.edge_id)
+
+        self.assign_clients()
+
+        self.load_test_data()
+        self.load_model()
+
+
+    def assign_clients(self):
+        """Assign clients connected to this edge server."""
+
+
+
+
+    def choose_clients(self):
+        """Choose a subset of the clients to participate in each round."""
+        # Select clients randomly
+        assert self.clients_per_round <= self.clients_num
+        self.selected_clients = random.sample(list(self.clients), self.clients_per_round)
+
+
+    async def select_clients(self):
+        """Select a subset of its clients and send messages to them to start training."""
+        self.client_reports = []
+        self.current_agg_round += 1
+        logging.info('**** Aggreagtion round %s/%s ****',
+                    self.current_agg_round, Config().edges.aggregations)
+
+        self.choose_clients()
+
+        if len(self.selected_clients) > 0:
+            for client_id in self.selected_clients:
+                socket = self.clients[client_id]
+                logging.info("Selecting client with ID %s for training...", client_id)
+                server_response = {'id': client_id, 'payload': True}
+                await socket.send(json.dumps(server_response))
+
+                logging.info("Sending the current model...")
+                await socket.send(pickle.dumps(self.model.state_dict()))
+
+
+    async def run(self, websocket, path):
+        """Running a federated learning edge server for one round of global training."""
+
+        logging.info("Waiting for %s clients to arrive...", self.clients_num)
+        logging.info("Path: %s", path)
+
+        try:
+            async for message in websocket:
+                data = json.loads(message)
+                client_id = data['id']
+                logging.info("client data received with ID: %s", client_id)
+
+                if 'payload' in data:
+                    # an existing client reports new updates from local training
+                    client_update = await websocket.recv()
+                    client_report = pickle.loads(client_update)
+                    logging.info("Client update received. Accuracy = {:.2f}%\n"
+                        .format(100 * client_report.accuracy))
+
+                    self.client_reports.append(client_report)
+
+                    if len(self.client_reports) == len(self.selected_clients):
+                        total_samples, weights, accuracy = self.process_report()
+
+                        if self.current_agg_round == self.aggregations:
+                            # generate the report that will be sent to the central server
+                            self.report = Report(self.edge_id, total_samples, weights, accuracy)
+                            self.current_agg_round = 0
+
+                        await self.select_clients()
+                else:
+                    # a new client arrives
+                    self.register_client(client_id, websocket)
+
+                    if self.current_agg_round == 0 and len(self.clients) >= self.clients_num:
+                        logging.info('Starting FL training on edge server #%s...', self.edge_id)
+                        await self.select_clients()
+        except websockets.ConnectionClosed as exception:
+            logging.info("Edge Server WebSockets connection closed abnormally.")
+            logging.error(exception)
+
+
+    async def start_edge_server(self, websocket_with_clients, edge_server_path):
+        """Startup function for an edge server."""
+        uri = 'ws://{}:{}'.format(Config().server.address, Config().server.port)
+        try:
+            async with websockets.connect(uri, ping_interval=None, max_size=2 ** 30) as websocket:
+                logging.info("Signing in at the central server with edge server ID %s...",
+                            self.edge_id)
+                await websocket.send(json.dumps({'id': self.edge_id}))
+
+                while True:
+                    logging.info("Edge server %s is waiting for a new round of global training...",
+                                self.edge_id)
+                    server_response = await websocket.recv()
+                    data = json.loads(server_response)
+
+                    if data['id'] == self.edge_id and 'payload' in data:
+                        logging.info("Edge server %s is receiving the current global model...",
+                                    self.edge_id)
+                        server_model = await websocket.recv()
+                        self.model.load_state_dict(pickle.loads(server_model))
+
+                        await self.run(websocket_with_clients, edge_server_path)
+
+                        logging.info("Model aggregated on edge server #%s.", self.edge_id)
+                        # Sending edge server ID as metadata to the server (payload to follow)
+                        edge_update = {'id': self.edge_id, 'payload': True}
+                        await websocket.send(json.dumps(edge_update))
+
+                        # Sending the edge server report to the central server as payload
+                        await websocket.send(pickle.dumps(self.report))
+
+
+        except OSError as exception:
+            logging.info("Edge Server #%s: connection to the central server failed.", self.edge_id)
+            logging.error(exception)
+
+
+    def process_reports_from_clients(self):
+        """Process the client reports by aggregating their weights."""
+        updated_weights = self.aggregate_weights(self.client_reports)
+        total_samples = sum([client_report.num_samples for client_report in self.client_reports])
+        trainer.load_weights(self.model, updated_weights)
+
+        # Testing the aggregated model accuracy
+        if Config().clients.do_test:
+            # Compute the average accuracy from client reports
+            accuracy = self.accuracy_averaging(self.client_reports)
+            logging.info('Average client accuracy: {:.2f}%\n'.format(100 * accuracy))
+        elif Config().edges.do_test:
+            # Test the updated model directly at the edge server
+            accuracy = trainer.test(self.model, self.testset, Config().training.batch_size)
+            logging.info('Aggregated model accuracy: {:.2f}%\n'.format(100 * accuracy))
+
+        return total_samples, updated_weights, accuracy

--- a/servers/fedcs.py
+++ b/servers/fedcs.py
@@ -1,0 +1,175 @@
+"""
+A simple edge server supporting hierarchical federated learning.
+Edge servers are also clients to FedAvgServer as the root servers.
+Each edge server communicates with a subset of the clients within its own institution.
+"""
+
+import logging
+import json
+import pickle
+import subprocess
+import sys
+import websockets
+
+from servers import FedAvgServer
+from config import Config
+
+
+class CrossSiloServer(FedAvgServer):
+    """Cross silo federated learning central server."""
+
+    def __init__(self):
+        super().__init__()
+        self.edges = {}
+
+
+    def register_edge_servers(self, edge_id, websocket):
+        """Adding a newly arrived client to the list of edge_servers."""
+        if not edge_id in self.edges:
+            self.edges[edge_id] = websocket
+
+
+    def unregister_edge_servers(self, websocket):
+        """Removing an existing client from the list of edge_servers."""
+        for key, value in dict(self.edges).items():
+            if value == websocket:
+                del self.edges[key]
+
+
+    def start_edge_servers(self):
+        """Starting all the edge servers as separate processes."""
+        for edge_id in range(1, Config().edges.total + 1):
+            logging.info("Starting edge server #%s...", edge_id)
+            command = "python edge_server.py -e {}".format(edge_id)
+            subprocess.Popen(command, shell=True)
+
+
+    async def close_connections(self):
+        """Closing all WebSocket connections after training completes."""
+        for _, edge_socket in dict(self.edges).items():
+            await edge_socket.close()
+        for _, client_socket in dict(self.clients).items():
+            await client_socket.close()
+
+
+    def assign_clients_to_edge_servers(self):
+        """Assign clients to edge servers."""
+        clients_id_list = {}
+
+        edges_num = Config().edges.total
+        clients_num = Config().clients.total
+        per_clients_num = int(clients_num / edges_num)
+        residual_clients_num = int(clients_num % edges_num)
+
+        assigned_clients_num = 0
+
+        # Assign (almost) the same number of clients to edge servers
+        for edge_id in range(1, edges_num + 1):
+            if edge_id <= residual_clients_num:
+                clients_id_list[edge_id] = [assigned_clients_num + i for i in range(1, per_clients_num + 2)]
+            else:
+                clients_id_list[edge_id] = [assigned_clients_num + i for i in range(1, per_clients_num + 1)]
+
+            assigned_clients_num += len(clients_id_list[edge_id])
+
+        return clients_id_list
+
+
+    def select_clients_for_edge_servers(self):
+        """Determine the number of clients attending each round for each edge server."""
+        clients_per_round_list = {}
+
+        edges_num = Config().edges.total
+        clients_per_round_num = Config().clients.per_round
+        per_clients_num = int(clients_per_round_num / edges_num)
+        residual_clients_num = int(clients_per_round_num % edges_num)
+
+        assigned_clients_num = 0
+
+        for edge_id in range(1, edges_num + 1):
+            if edge_id <= residual_clients_num:
+                clients_per_round_list[edge_id] = [assigned_clients_num + per_clients_num + 1]
+            else:
+                clients_per_round_list[edge_id] = [assigned_clients_num + per_clients_num]
+
+            assigned_clients_num += clients_per_round_list[edge_id]
+
+        return clients_per_round_list
+
+
+    def configure(self):
+        """
+        Booting the cross-silo federated learning central server by setting up the data, model, and
+        creating the edge servers and clients.
+        """
+
+        logging.info('Configuring the %s server...', Config().training.server)
+
+        total_rounds = Config().training.rounds
+        target_accuracy = Config().training.target_accuracy
+
+        if target_accuracy:
+            logging.info('Training: %s rounds or %s%% accuracy\n',
+                total_rounds, 100 * target_accuracy)
+        else:
+            logging.info('Training: %s rounds\n', total_rounds)
+
+        logging.info("Starting training on %s edge servers and %s clients in total...",
+            Config().edges.total, Config().clients.per_round)
+
+        self.load_test_data()
+        self.load_model()
+
+
+    async def serve(self, websocket, path):
+        """Running a cross-silo federated learning server."""
+
+        logging.info("Waiting for %s edge servers to arrive...", Config().edges.total)
+        logging.info("Waiting for %s clients to arrive...", Config().clients.total)
+        logging.info("Path: %s", path)
+
+        self.configure()
+
+        try:
+            async for message in websocket:
+                data = json.loads(message)
+                edge_id = data['id']
+                logging.info("Edge server data received with ID: %s", edge_id)
+
+                if 'payload' in data:
+                    # An existing edge server reports new updates from local aggregation
+                    edge_update = await websocket.recv()
+                    report = pickle.loads(edge_update)
+                    logging.info("Edge server update received. Accuracy = {:.2f}%\n"
+                        .format(100 * report.accuracy))
+
+                    self.reports.append(report)
+
+                    if len(self.reports) == len(self.edges):
+                        accuracy = self.process_report()
+
+                        # Break the loop when the target accuracy is achieved
+                        target_accuracy = Config().training.target_accuracy
+
+                        if target_accuracy and (accuracy >= target_accuracy):
+                            logging.info('Target accuracy reached.')
+                            await self.close_connections()
+                            sys.exit()
+
+                        if self.current_round == Config().training.rounds:
+                            logging.info('Target number of training rounds reached.')
+                            await self.close_connections()
+                            sys.exit()
+
+                        await self.select_clients()
+
+                else:
+                    # a new edge server arrives
+                    self.register_edge_servers(edge_id, websocket)
+
+                    if self.current_round == 0 and len(self.edges) >= Config().edges.total:
+                        logging.info('Starting cross-silo FL training...')
+
+        except websockets.ConnectionClosed as exception:
+            logging.info("Server WebSockets connection closed abnormally.")
+            logging.error(exception)


### PR DESCRIPTION
1. I added EdgeServer (servers/edge.py), a client to FedAvgServer and a root server to its clients.
The way to start all the edge servers is similar to start all clients. The central server will call "python edge_server.py -e <edge server id>" to start all the edge servers as separate processes.

2. I added CrossSiloServer (servers/fedcs.py), which is the central server of cross-silo FL.
I found that I need to write a new central server to not make your FedAvgServer messy, as they work differently. E.g., CrossSiloServer needs to register, start, and unregister edge servers. And during its running (function server()), it receives reports from edge servers rather than clients.

3. In cross-silo FL, clients communicate with their edge servers, so in client/simple.py, function start_clients, uri needs to be edge server's. But I haven't thought through how to assign address and port for each edge server. So I still use the same one as the central server for now.

4. I changed config.py. I added a parameter 'hierarchy' in training parameters to determine if the FL topology is hierarchical. If so, parameters of edge servers will be extracted.
And pylint suggests using isinstance() is better than type() for type check. So I changed them.

5. I added several lines to servers/base.py as I did not find your code stop training when the target number of training rounds reached. But if I missed them, please ignore me.