### PR TITLE
Correct the measure of client training time

### DIFF
--- a/plato/clients/simple.py
+++ b/plato/clients/simple.py
@@ -94,9 +94,9 @@ class Client(base.Client):
         logging.info("[Client #%d] Started training.", self.client_id)
 
         # Perform model training
-        training_time = self.trainer.train(self.trainset, self.sampler)
+        train_succeeded, training_time = self.trainer.train(self.trainset, self.sampler)
         # Training failed
-        if not training_time:
+        if not train_succeeded:
             await self.sio.disconnect()
 
         # Extract model weights and biases

--- a/plato/clients/simple.py
+++ b/plato/clients/simple.py
@@ -94,8 +94,9 @@ class Client(base.Client):
         logging.info("[Client #%d] Started training.", self.client_id)
 
         # Perform model training
-        if not self.trainer.train(self.trainset, self.sampler):
-            # Training failed
+        training_time = self.trainer.train(self.trainset, self.sampler)
+        # Training failed
+        if not training_time:
             await self.sio.disconnect()
 
         # Extract model weights and biases
@@ -114,7 +115,6 @@ class Client(base.Client):
         else:
             accuracy = 0
 
-        training_time = time.time() - training_start_time
         data_loading_time = 0
 
         if not self.data_loading_time_sent:

--- a/plato/clients/simple.py
+++ b/plato/clients/simple.py
@@ -90,12 +90,11 @@ class Client(base.Client):
 
     async def train(self):
         """The machine learning training workload on a client."""
-        training_start_time = time.time()
         logging.info("[Client #%d] Started training.", self.client_id)
 
         # Perform model training
         train_succeeded, training_time = self.trainer.train(self.trainset, self.sampler)
-        # Training failed
+
         if not train_succeeded:
             await self.sio.disconnect()
 

--- a/plato/trainers/base.py
+++ b/plato/trainers/base.py
@@ -7,6 +7,7 @@ import random
 import sqlite3
 import time
 from abc import ABC, abstractmethod
+from typing import Tuple
 
 from plato.config import Config
 
@@ -118,7 +119,7 @@ class Trainer(ABC):
             os.remove(accuracy_file)
 
     @abstractmethod
-    def train(self, trainset, sampler, cut_layer=None) -> bool:
+    def train(self, trainset, sampler, cut_layer=None) -> Tuple[bool, float]:
         """The main training loop in a federated learning workload.
 
         Arguments:
@@ -127,7 +128,8 @@ class Trainer(ABC):
         cut_layer (optional): The layer which training should start from.
 
         Returns:
-        Whether training was successfully completed.
+        bool: Whether training was successfully completed.
+        float: The training time.
         """
 
     @abstractmethod

--- a/plato/trainers/basic.py
+++ b/plato/trainers/basic.py
@@ -218,7 +218,8 @@ class Trainer(base.Trainer):
         cut_layer (optional): The layer which training should start from.
 
         Returns:
-        Whether training was successfully completed.
+        bool: Whether training was successfully completed.
+        float: The training time.
         """
         self.start_training()
         start_time = time.time()
@@ -249,7 +250,7 @@ class Trainer(base.Trainer):
                          self.client_id)
             self.run_sql_statement("DELETE FROM trainers WHERE run_id = (?)",
                                    (self.client_id, ))
-            return False, 0
+            return False, 0.0
 
         self.pause_training()
         training_time = time.time() - start_time

--- a/plato/trainers/basic.py
+++ b/plato/trainers/basic.py
@@ -249,11 +249,11 @@ class Trainer(base.Trainer):
                          self.client_id)
             self.run_sql_statement("DELETE FROM trainers WHERE run_id = (?)",
                                    (self.client_id, ))
-            return False
+            return False, 0
 
         self.pause_training()
         training_time = time.time() - start_time
-        return training_time
+        return True, training_time
 
     def test_process(self, config, testset):
         """The testing loop, run in a separate process with a new CUDA context,

--- a/plato/trainers/basic.py
+++ b/plato/trainers/basic.py
@@ -5,11 +5,13 @@ import asyncio
 import logging
 import multiprocessing as mp
 import os
+import time
 
 import numpy as np
 import torch
 import torch.nn as nn
 import wandb
+
 from plato.config import Config
 from plato.models import registry as models_registry
 from plato.trainers import base
@@ -219,6 +221,7 @@ class Trainer(base.Trainer):
         Whether training was successfully completed.
         """
         self.start_training()
+        start_time = time.time()
 
         if mp.get_start_method(allow_none=True) != 'spawn':
             mp.set_start_method('spawn', force=True)
@@ -249,7 +252,8 @@ class Trainer(base.Trainer):
             return False
 
         self.pause_training()
-        return True
+        training_time = time.time() - start_time
+        return training_time
 
     def test_process(self, config, testset):
         """The testing loop, run in a separate process with a new CUDA context,

--- a/plato/trainers/basic.py
+++ b/plato/trainers/basic.py
@@ -6,12 +6,12 @@ import logging
 import multiprocessing as mp
 import os
 import time
+from typing import Tuple
 
 import numpy as np
 import torch
 import torch.nn as nn
 import wandb
-
 from plato.config import Config
 from plato.models import registry as models_registry
 from plato.trainers import base
@@ -209,7 +209,7 @@ class Trainer(base.Trainer):
         if 'use_wandb' in config:
             run.finish()
 
-    def train(self, trainset, sampler, cut_layer=None) -> bool:
+    def train(self, trainset, sampler, cut_layer=None) -> Tuple[bool, float]:
         """The main training loop in a federated learning workload.
 
         Arguments:
@@ -222,7 +222,7 @@ class Trainer(base.Trainer):
         float: The training time.
         """
         self.start_training()
-        start_time = time.time()
+        tic = time.perf_counter()
 
         if mp.get_start_method(allow_none=True) != 'spawn':
             mp.set_start_method('spawn', force=True)
@@ -252,8 +252,10 @@ class Trainer(base.Trainer):
                                    (self.client_id, ))
             return False, 0.0
 
+        toc = time.perf_counter()
         self.pause_training()
-        training_time = time.time() - start_time
+        training_time = toc - tic
+
         return True, training_time
 
     def test_process(self, config, testset):

--- a/plato/utils/decorators.py
+++ b/plato/utils/decorators.py
@@ -1,0 +1,16 @@
+""" Useful decorators. """
+import time
+from functools import wraps
+
+
+def timeit(func_timed):
+    """ Measures the time elapsed for a particular function 'func_timed'. """
+    @wraps(func_timed)
+    def timed(*args, **kwargs):
+        started = time.perf_counter()
+        output = func_timed(*args, **kwargs)
+        ended = time.perf_counter()
+        elapsed = ended - started
+        print('"{}" took {:.3f} seconds to execute\n'.format(func_timed.__name__, elapsed))
+        return output, elapsed
+    return timed


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This change moves the client's training time recording from method `train()` in plato/clients/simple.py to method `train()` in plato/trainers/basic.py. The point is that excluding the call of method `start_training()` from this elapsed time measure. 
<!--- Describe motivation and context -->
The original way to measure client's training time in plato/clients/simple.py is incorrect as it also takes into account the corresponding trainer's waiting time for running, i.e. the process's sleep time in `start_training()` in plato/trainers/base.py.
<!--- Why is this change required? What problem does it solve? -->
Before the change, for example, if `max_concurrency` is set to `1` in the configuration file which means the maximum number of clients running concurrently is one, the recorded training time of all clients in each communication round is like:
<img width="576" alt="Screen Shot 2021-08-03 at 12 10 22 AM" src="https://user-images.githubusercontent.com/35632332/127896587-fa50afc3-1ea0-4e54-82cc-e10246a0fccc.png">
<img width="576" alt="Screen Shot 2021-08-03 at 12 10 33 AM" src="https://user-images.githubusercontent.com/35632332/127896655-2c8d3bc0-0b69-4ef1-a451-815b440153e7.png">
where the training time is extracted from the reports in clients' updates that server has received. The recorded training time of a client includes its waiting time which is almost the training time of earlier clients.

After the change, the measured training time in the same settings is like:
<img width="576" alt="Screen Shot 2021-08-03 at 12 21 48 AM" src="https://user-images.githubusercontent.com/35632332/127897763-0b7a0699-de36-4d5f-bbb8-8b918996f219.png">
<img width="576" alt="Screen Shot 2021-08-03 at 12 22 00 AM" src="https://user-images.githubusercontent.com/35632332/127897790-0d0f8b41-7036-4b2d-9e79-2c9a872cfe8b.png">


<!--- If it fixes an open issue, please link to the issue here. -->


## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
The change was tested by adding this piece of code in `wrap_up_processing_reports()` in plato/servers/fedavg.py and cmd `./run --config=configs/MNIST/fedavg_lenet5.yml`.
```python
training_times = [ report.training_time for (report, __) in self.updates]
for i, t in enumerate(training_times):
    logging.info("[Round %d] Training time of the %d-th selected client: %f s", self.current_round, i, t)
```
In the fedavg_lenet5.yml for my test, `total_clients:3`, `per_round:3`, `partition_size: 600`, `max_concurrency: 1`, `rounds: 10`, `epochs: 5`, `batch_size: 10`, and `types:training_time` is enabled in `results`.
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
**_Note: The training time measure also exists in `train()` in plato/clients/edge.py. I'm not sure if the measure here is also incorrect and my change does not cover this. I request the contributors for this file to have a check and make changes if necessary._**


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) Fixes #
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
