### PR TITLE
Added sampler for testset.

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -32,6 +32,8 @@ Attributes in **bold** must be included in a configuration file, while attribute
 |ping_timeout| The time in seconds that the client waits for the server to respond before disconnecting. The default is 360 (seconds).||Increase this number when your session stops running when training larger models (but make sure it is not due to the *out of CUDA memory* error)|
 |synchronous|Synchronous or asynchronous federated learning|`true` or `false`|If `false`, must have **periodic_interval** attribute|
 |*periodic_interval*|The time interval for a server operating in asynchronous mode to aggregate received updates|Any positive integer||
+|do_test|Should the central server compute test accuracy locally?| `true` or `false`|| 
+|edge_do_test|Should an edge server compute test accuracy of its aggregated model locally?| `true` or `false`||
 
 ### data
 
@@ -44,6 +46,7 @@ Attributes in **bold** must be included in a configuration file, while attribute
 |||`noniid`|Could have *concentration* attribute to specify the concentration parameter in the Dirichlet distribution|
 |||`orthogonal`|Each insitution's clients have data of different classes. Could have *institution_class_ids* and *label_distribution* attributes|
 |||`mixed`|Some data are iid, while others are non-iid. Must have *non_iid_clients* attributes|
+|test_set_sampler|How to sample the test set when clients test locally|Could be any **sampler**|Without this parameter, every client's test set is the test set of the datasource|
 |random_seed|Use a fixed random seed so that experiments are reproducible (clients always have the same datasets)||
 |**partition_size**|Number of samples in each client's dataset|Any positive integer||
 |concentration| The concentration parameter of symmetric Dirichlet distribution, used by `noniid` **sampler** || Default value is 1|

--- a/plato/clients/edge.py
+++ b/plato/clients/edge.py
@@ -18,6 +18,7 @@ class Report:
     client_id: str
     num_samples: int
     accuracy: float
+    average_accuracy: float
     training_time: float
     data_loading_time: float
 
@@ -66,12 +67,18 @@ class Client(base.Client):
         weights = self.algorithm.extract_weights()
 
         # Generate a report for the server, performing model testing if applicable
-        if Config().clients.do_test:
+        if hasattr(Config().server,
+                   'edge_do_test') and Config().server.edge_do_test:
             accuracy = self.server.accuracy
         else:
             accuracy = 0
 
+        if Config().clients.do_test:
+            average_accuracy = self.server.average_client_accuracy
+        else:
+            average_accuracy = 0
+
         training_time = time.perf_counter() - training_start_time
 
         return Report(self.client_id, self.server.total_samples, accuracy,
-                      training_time, 0), weights
+                      average_accuracy, training_time, 0), weights

--- a/plato/clients/simple.py
+++ b/plato/clients/simple.py
@@ -37,6 +37,7 @@ class Client(base.Client):
         self.trainset = None  # Training dataset
         self.testset = None  # Testing dataset
         self.sampler = None
+        self.test_sampler = None  # Sampler for the testset
 
         self.data_loading_time = None
         self.data_loading_time_sent = False
@@ -60,7 +61,8 @@ class Client(base.Client):
         logging.info("[Client #%d] Loading its data source...", self.client_id)
 
         if self.datasource is None:
-            self.datasource = datasources_registry.get(client_id=self.client_id)
+            self.datasource = datasources_registry.get(
+                client_id=self.client_id)
 
         self.data_loaded = True
 
@@ -81,6 +83,10 @@ class Client(base.Client):
         if Config().clients.do_test:
             # Set the testset if local testing is needed
             self.testset = self.datasource.get_test_set()
+            # Set the sampler for testset
+            self.test_sampler = samplers_registry.get(self.datasource,
+                                                      self.client_id,
+                                                      testing=True)
 
         self.data_loading_time = time.perf_counter() - data_loading_start_time
 
@@ -103,7 +109,7 @@ class Client(base.Client):
 
         # Generate a report for the server, performing model testing if applicable
         if Config().clients.do_test:
-            accuracy = self.trainer.test(self.testset)
+            accuracy = self.trainer.test(self.testset, self.test_sampler)
 
             if accuracy == 0:
                 # The testing process failed, disconnect from the server

--- a/plato/clients/simple.py
+++ b/plato/clients/simple.py
@@ -37,7 +37,7 @@ class Client(base.Client):
         self.trainset = None  # Training dataset
         self.testset = None  # Testing dataset
         self.sampler = None
-        self.test_sampler = None  # Sampler for the testset
+        self.test_set_sampler = None  # Sampler for the test set
 
         self.data_loading_time = None
         self.data_loading_time_sent = False
@@ -83,10 +83,11 @@ class Client(base.Client):
         if Config().clients.do_test:
             # Set the testset if local testing is needed
             self.testset = self.datasource.get_test_set()
-            # Set the sampler for testset
-            self.test_sampler = samplers_registry.get(self.datasource,
-                                                      self.client_id,
-                                                      testing=True)
+            if hasattr(Config().data, 'test_set_sampler'):
+                # Set the sampler for test set
+                self.test_set_sampler = samplers_registry.get(self.datasource,
+                                                              self.client_id,
+                                                              testing=True)
 
         self.data_loading_time = time.perf_counter() - data_loading_start_time
 
@@ -109,7 +110,7 @@ class Client(base.Client):
 
         # Generate a report for the server, performing model testing if applicable
         if Config().clients.do_test:
-            accuracy = self.trainer.test(self.testset, self.test_sampler)
+            accuracy = self.trainer.test(self.testset, self.test_set_sampler)
 
             if accuracy == 0:
                 # The testing process failed, disconnect from the server

--- a/plato/samplers/all_inclusive.py
+++ b/plato/samplers/all_inclusive.py
@@ -11,11 +11,14 @@ class Sampler(base.Sampler):
     """Create a data sampler that samples all the data in the dataset.
        Used by the MistNet server.
     """
-    def __init__(self, dataset, client_id=0):
+    def __init__(self, dataset, client_id=0, testing=False):
         super().__init__()
         self.client_id = client_id
 
-        self.all_inclusive = range(dataset.num_train_examples())
+        if testing:
+            self.all_inclusive = range(dataset.num_test_examples())
+        else:
+            self.all_inclusive = range(dataset.num_train_examples())
 
     def get(self):
         # return random.shuffle(self.all_inclusive)

--- a/plato/samplers/dirichlet.py
+++ b/plato/samplers/dirichlet.py
@@ -13,7 +13,7 @@ from plato.samplers import base
 class Sampler(base.Sampler):
     """Create a data sampler for each client to use a divided partition of the
     dataset, biased across labels according to the Dirichlet distribution."""
-    def __init__(self, datasource, client_id):
+    def __init__(self, datasource, client_id, testing):
         super().__init__()
 
         # Different clients should have a different bias across the labels
@@ -25,8 +25,12 @@ class Sampler(base.Sampler):
         concentration = Config().data.concentration if hasattr(
             Config().data, 'concentration') else 1.0
 
-        # The list of labels (targets) for all the examples
-        target_list = datasource.targets()
+        if testing:
+            target_list = datasource.get_test_set().targets
+        else:
+            # The list of labels (targets) for all the examples
+            target_list = datasource.targets()
+
         class_list = datasource.classes()
 
         target_proportions = np.random.dirichlet(

--- a/plato/samplers/iid.py
+++ b/plato/samplers/iid.py
@@ -3,18 +3,22 @@ Samples data from a dataset in an independent and identically distributed fashio
 """
 import numpy as np
 import torch
-from plato.config import Config
 from torch.utils.data import SubsetRandomSampler
 
+from plato.config import Config
 from plato.samplers import base
 
 
 class Sampler(base.Sampler):
     """Create a data sampler for each client to use a randomly divided partition of the
     dataset."""
-    def __init__(self, datasource, client_id):
+    def __init__(self, datasource, client_id, testing):
         super().__init__()
-        dataset = datasource.get_train_set()
+        if testing:
+            dataset = datasource.get_test_set()
+        else:
+            dataset = datasource.get_train_set()
+
         self.dataset_size = len(dataset)
         indices = list(range(self.dataset_size))
         np.random.seed(self.random_seed)
@@ -48,4 +52,3 @@ class Sampler(base.Sampler):
     def trainset_size(self):
         """Returns the length of the dataset after sampling. """
         return len(self.subset_indices)
-    

--- a/plato/samplers/mixed.py
+++ b/plato/samplers/mixed.py
@@ -11,8 +11,8 @@ from plato.samplers import dirichlet
 class Sampler(dirichlet.Sampler):
     """Create a data sampler for each client to use a divided partition of the dataset,
     either biased across labels according to the Dirichlet distribution, or in an iid fashion."""
-    def __init__(self, datasource, client_id):
-        super().__init__(datasource, client_id)
+    def __init__(self, datasource, client_id, testing):
+        super().__init__(datasource, client_id, testing)
 
         assert hasattr(Config().data, 'non_iid_clients')
         non_iid_clients = Config().data.non_iid_clients
@@ -26,7 +26,10 @@ class Sampler(dirichlet.Sampler):
             ]
 
         if int(client_id) not in self.non_iid_clients_list:
-            target_list = datasource.targets()
+            if testing:
+                target_list = datasource.get_test_set().targets
+            else:
+                target_list = datasource.targets()
             class_list = datasource.classes()
             self.sample_weights = np.array([
                 1 / len(class_list) for _ in range(len(class_list))

--- a/plato/samplers/registry.py
+++ b/plato/samplers/registry.py
@@ -39,7 +39,7 @@ else:
     ])
 
 
-def get(datasource, client_id):
+def get(datasource, client_id, testing=False):
     """Get an instance of the sampler."""
     if hasattr(Config().data, 'sampler'):
         sampler_type = Config().data.sampler
@@ -50,7 +50,8 @@ def get(datasource, client_id):
 
     if sampler_type in registered_samplers:
         registered_sampler = registered_samplers[sampler_type](datasource,
-                                                               client_id)
+                                                               client_id,
+                                                               testing=testing)
     else:
         raise ValueError('No such sampler: {}'.format(sampler_type))
 

--- a/plato/samplers/registry.py
+++ b/plato/samplers/registry.py
@@ -41,12 +41,18 @@ else:
 
 def get(datasource, client_id, testing=False):
     """Get an instance of the sampler."""
-    if hasattr(Config().data, 'sampler'):
-        sampler_type = Config().data.sampler
+    if testing:
+        if hasattr(Config().data, 'test_set_sampler'):
+            sampler_type = Config().data.test_set_sampler
+            logging.info("[Client #%d] Test set sampler: %s", client_id,
+                         sampler_type)
     else:
-        sampler_type = 'iid'
+        if hasattr(Config().data, 'sampler'):
+            sampler_type = Config().data.sampler
+        else:
+            sampler_type = 'iid'
 
-    logging.info("[Client #%d] Sampler: %s", client_id, sampler_type)
+        logging.info("[Client #%d] Sampler: %s", client_id, sampler_type)
 
     if sampler_type in registered_samplers:
         registered_sampler = registered_samplers[sampler_type](datasource,

--- a/plato/servers/fedavg_cs.py
+++ b/plato/servers/fedavg_cs.py
@@ -30,7 +30,7 @@ class Server(fedavg.Server):
         if hasattr(Config().server,
                    'edge_do_test') and Config().server.edge_do_test:
             self.test_edge_model = True
-            self.test_sampler = None
+            self.test_set_sampler = None
         else:
             self.test_edge_model = False
 
@@ -88,10 +88,10 @@ class Server(fedavg.Server):
             if self.test_edge_model:
                 datasource = datasources_registry.get()
                 self.testset = datasource.get_test_set()
-                # Setting up the data sampler
-                self.test_sampler = samplers_registry.get(datasource,
-                                                          Config().args.id,
-                                                          testing=True)
+                # Set up the sampler of test set
+                if hasattr(Config().data, 'test_set_sampler'):
+                    self.test_set_sampler = samplers_registry.get(
+                        datasource, Config().args.id, testing=True)
 
             self.load_trainer()
 
@@ -164,7 +164,7 @@ class Server(fedavg.Server):
             if self.test_edge_model:
                 # Test the aggregated model directly at the edge server
                 self.accuracy = self.trainer.test(self.testset,
-                                                  self.test_sampler)
+                                                  self.test_set_sampler)
                 logging.info(
                     '[Edge Server #{:d}] Aggregated model accuracy: {:.2f}%\n'.
                     format(os.getpid(), 100 * self.accuracy))

--- a/plato/servers/fedavg_cs.py
+++ b/plato/servers/fedavg_cs.py
@@ -9,6 +9,7 @@ import time
 
 from plato.config import Config
 from plato.datasources import registry as datasources_registry
+from plato.samplers import registry as samplers_registry
 from plato.utils import csv_processor
 
 from plato.servers import fedavg
@@ -21,7 +22,25 @@ class Server(fedavg.Server):
 
         self.current_global_round = 0
         # Average accuracy from client reports
-        self.average_accuracy = 0
+        self.average_client_accuracy = 0
+        # Average accuracy from edge server reports
+        self.average_edge_accuracy = 0
+
+        # Should an edge server has its own testset to test the accuracy of its aggregated model
+        if hasattr(Config().server,
+                   'edge_do_test') and Config().server.edge_do_test:
+            self.test_edge_model = True
+            self.test_sampler = None
+        else:
+            self.test_edge_model = False
+
+        # Should the central server has its own testset to test the current global model
+        if (hasattr(Config().server, 'do_test')
+                and Config().server.do_test) or (not Config().clients.do_test
+                                                 and not self.do_edge_test):
+            self.test_central_model = True
+        else:
+            self.test_central_model = False
 
         if Config().is_edge_server():
             # An edge client waits for the event that a certain number of
@@ -66,10 +85,13 @@ class Server(fedavg.Server):
             logging.info("Training with %s local aggregation rounds.",
                          Config().algorithm.local_rounds)
 
-            if hasattr(Config().server, 'do_test'):
-                if not Config().clients.do_test or Config().server.do_test:
-                    datasource = datasources_registry.get()
-                    self.testset = datasource.get_test_set()
+            if self.test_edge_model:
+                datasource = datasources_registry.get()
+                self.testset = datasource.get_test_set()
+                # Setting up the data sampler
+                self.test_sampler = samplers_registry.get(datasource,
+                                                          Config().args.id,
+                                                          testing=True)
 
             self.load_trainer()
 
@@ -82,10 +104,9 @@ class Server(fedavg.Server):
         else:
             super().configure()
 
-            if hasattr(Config().server, 'do_test'):
-                if Config().clients.do_test and Config().server.do_test:
-                    datasource = datasources_registry.get()
-                    self.testset = datasource.get_test_set()
+            if self.test_central_model:
+                datasource = datasources_registry.get()
+                self.testset = datasource.get_test_set()
 
     async def select_clients(self):
         if Config().is_edge_server():
@@ -109,27 +130,44 @@ class Server(fedavg.Server):
         await self.aggregate_weights(self.updates)
 
         # Testing the global model accuracy
-        if Config().clients.do_test:
-            # Compute the average accuracy from client reports
-            self.average_accuracy = self.accuracy_averaging(self.updates)
-            logging.info(
-                '[Server #{:d}] Average client accuracy: {:.2f}%.'.format(
-                    os.getpid(), 100 * self.average_accuracy))
+        if Config().is_central_server():
+            if Config().clients.do_test:
+                # Compute the average accuracy from client reports
+                self.average_client_accuracy = self.client_accuracy_averaging(
+                    self.updates)
+                logging.info(
+                    '[Server #{:d}] Average client accuracy: {:.2f}%.'.format(
+                        os.getpid(), 100 * self.average_client_accuracy))
+            if self.test_edge_model:
+                # Compute the average accuracy from edge server reports
+                self.average_edge_accuracy = self.accuracy_averaging(
+                    self.updates)
+                logging.info(
+                    '[Server #{:d}] Average edge server accuracy: {:.2f}%.'.
+                    format(os.getpid(), 100 * self.average_edge_accuracy))
+            if self.test_central_model:
+                # Test the updated model directly at the central server
+                self.accuracy = await self.trainer.server_test(self.testset)
+                logging.info(
+                    '[Server #{:d}] Global model accuracy: {:.2f}%\n'.format(
+                        os.getpid(), 100 * self.accuracy))
 
-        if hasattr(Config().server, 'do_test'):
-            if not Config().clients.do_test or Config().server.do_test:
-                # Test the updated model directly at the server
-                self.accuracy = self.trainer.test(self.testset)
-                if Config().is_central_server():
-                    logging.info(
-                        '[Server #{:d}] Global model accuracy: {:.2f}%\n'.
-                        format(os.getpid(), 100 * self.accuracy))
-                else:
-                    logging.info(
-                        '[Edge Server #{:d}] Aggregated model accuracy: {:.2f}%\n'
-                        .format(os.getpid(), 100 * self.accuracy))
-        else:
-            self.accuracy = self.average_accuracy
+        # Testing the aggregated model accuracy
+        elif Config().is_edge_server():
+            if Config().clients.do_test:
+                # Compute the average accuracy from client reports
+                self.average_client_accuracy = self.accuracy_averaging(
+                    self.updates)
+                logging.info(
+                    '[Server #{:d}] Average client accuracy: {:.2f}%.'.format(
+                        os.getpid(), 100 * self.average_client_accuracy))
+            if self.test_edge_model:
+                # Test the aggregated model directly at the edge server
+                self.accuracy = self.trainer.test(self.testset,
+                                                  self.test_sampler)
+                logging.info(
+                    '[Edge Server #{:d}] Aggregated model accuracy: {:.2f}%\n'.
+                    format(os.getpid(), 100 * self.accuracy))
 
         await self.wrap_up_processing_reports()
 
@@ -145,8 +183,10 @@ class Server(fedavg.Server):
                     self.current_round,
                     'accuracy':
                     self.accuracy * 100,
-                    'average_accuracy':
-                    self.average_accuracy * 100,
+                    'average_edge_accuracy':
+                    self.average_edge_accuracy * 100,
+                    'average_client_accuracy':
+                    self.average_client_accuracy * 100,
                     'edge_agg_num':
                     Config().algorithm.local_rounds,
                     'local_epoch_num':
@@ -184,3 +224,17 @@ class Server(fedavg.Server):
         """Wrapping up when each round of training is done."""
         if Config().is_central_server():
             await super().wrap_up()
+
+    @staticmethod
+    def client_accuracy_averaging(reports):
+        """Compute the average accuracy of averaged client accuracy on edge servers."""
+        # Get total number of samples
+        total_samples = sum([report.num_samples for (report, __) in reports])
+
+        # Perform weighted averaging
+        average_client_accuracy = 0
+        for (report, __) in reports:
+            average_client_accuracy += report.average_accuracy * (
+                report.num_samples / total_samples)
+
+        return average_client_accuracy


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Use configuration parameter `test_set_sampler` under `data` to specify the sampler of clients' test sets . Without this parameter, clients' test sets will be the test set of datasource.

## Description
<!--- Describe your changes in detail -->
<!--- Describe motivation and context -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
All classes of Sampler take an additional parameter `testing`. If `testing` is true, it means that this sampler is for generating test set; otherwise it is for generating training set.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested iid, dirichlet, all_inclusive, mixed and orthogonal samplers under both two-layer and three-layer FL.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) Fixes #
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
