### PR TITLE
Added basic support for bounded staleness in async mode.

### DIFF
--- a/configs/MNIST/fedavg_async_lenet5.yml
+++ b/configs/MNIST/fedavg_async_lenet5.yml
@@ -3,10 +3,10 @@ clients:
     type: simple
 
     # The total number of clients
-    total_clients: 10
+    total_clients: 2
 
     # The number of clients selected in each round
-    per_round: 5
+    per_round: 2
 
     # Should the clients compute test accuracy locally?
     do_test: false
@@ -18,7 +18,7 @@ server:
     address: 127.0.0.1
     port: 8000
     synchronous: false
-    periodic_interval: 20
+    periodic_interval: 3
 
 data:
     # The training and testing dataset
@@ -28,7 +28,7 @@ data:
     data_path: ./data
 
     # Number of samples in each partition
-    partition_size: 12000
+    partition_size: 2000
 
     # IID or non-IID?
     sampler: iid
@@ -41,7 +41,7 @@ trainer:
     type: basic
 
     # The maximum number of training rounds
-    rounds: 10
+    rounds: 2
 
     # Whether the training should use multiple GPUs if available
     parallelized: false

--- a/examples/cs_maml/cs_maml_server.py
+++ b/examples/cs_maml/cs_maml_server.py
@@ -124,9 +124,9 @@ class Server(fedavg_cs.Server):
             self.training_time = max(
                 [report.training_time for (report, __) in self.updates])
 
-    async def client_payload_done(self, sid, client_id, object_key):
+    async def client_payload_done(self, sid, client_id, s3_key=None):
         """ Upon receiving all the payload from a client, eithe via S3 or socket.io. """
-        if object_key is None:
+        if s3_key is None:
             assert self.client_payload[sid] is not None
 
             payload_size = 0
@@ -137,8 +137,7 @@ class Server(fedavg_cs.Server):
                 payload_size = sys.getsizeof(
                     pickle.dumps(self.client_payload[sid]))
         else:
-            self.client_payload[sid] = self.s3_client.receive_from_s3(
-                object_key)
+            self.client_payload[sid] = self.s3_client.receive_from_s3(s3_key)
             payload_size = sys.getsizeof(pickle.dumps(
                 self.client_payload[sid]))
 

--- a/examples/fl_maml/fl_maml_server.py
+++ b/examples/fl_maml/fl_maml_server.py
@@ -89,9 +89,9 @@ class Server(fedavg.Server):
             self.training_time = max(
                 [report.training_time for (report, __) in self.updates])
 
-    async def client_payload_done(self, sid, client_id, object_key):
+    async def client_payload_done(self, sid, client_id, s3_key=None):
         """ Upon receiving all the payload from a client, either via S3 or socket.io. """
-        if object_key is None:
+        if s3_key is None:
             assert self.client_payload[sid] is not None
 
             payload_size = 0
@@ -102,8 +102,7 @@ class Server(fedavg.Server):
                 payload_size = sys.getsizeof(
                     pickle.dumps(self.client_payload[sid]))
         else:
-            self.client_payload[sid] = self.s3_client.receive_from_s3(
-                object_key)
+            self.client_payload[sid] = self.s3_client.receive_from_s3(s3_key)
             payload_size = sys.getsizeof(pickle.dumps(
                 self.client_payload[sid]))
 

--- a/examples/split_learning/split_learning_server.py
+++ b/examples/split_learning/split_learning_server.py
@@ -61,13 +61,19 @@ class Server(fedavg.Server):
 
         return torch.load(model_path)
 
-    async def client_payload_done(self, sid, client_id):
-        assert self.client_payload[sid] is not None
-        payload_size = 0
-        if isinstance(self.client_payload[sid], list):
-            for _data in self.client_payload[sid]:
-                payload_size += sys.getsizeof(pickle.dumps(_data))
+    async def client_payload_done(self, sid, client_id, s3_key=None):
+        if s3_key is None:
+            assert self.client_payload[sid] is not None
+
+            payload_size = 0
+            if isinstance(self.client_payload[sid], list):
+                for _data in self.client_payload[sid]:
+                    payload_size += sys.getsizeof(pickle.dumps(_data))
+            else:
+                payload_size = sys.getsizeof(
+                    pickle.dumps(self.client_payload[sid]))
         else:
+            self.client_payload[sid] = self.s3_client.receive_from_s3(s3_key)
             payload_size = sys.getsizeof(pickle.dumps(
                 self.client_payload[sid]))
 

--- a/plato/servers/base.py
+++ b/plato/servers/base.py
@@ -128,7 +128,11 @@ class Server:
             Server.start_clients(client=self.client)
 
         if hasattr(Config().server, 'periodic_interval'):
-            asyncio.get_event_loop().create_task(self.periodic())
+            periodic_interval = Config().server.periodic_interval
+        else
+            periodic_interval = 5
+
+        asyncio.get_event_loop().create_task(self.periodic(periodic_interval))
 
         self.start()
 
@@ -321,17 +325,17 @@ class Server:
         # Select clients randomly
         return random.sample(clients_pool, clients_count)
 
-    async def periodic(self):
+    async def periodic(self, periodic_interval):
         """ Runs periodic_task() periodically on the server. The time interval between
             its execution is defined in 'server:periodic_interval'.
         """
         while True:
             await self.periodic_task()
-            await asyncio.sleep(Config().server.periodic_interval)
+            await asyncio.sleep(periodic_interval)
 
     async def periodic_task(self):
         """ A periodic task that is executed from time to time, determined by
-        'server:periodic_interval' in the configuration. """
+        'server:periodic_interval' with a default value of 5 seconds, in the configuration. """
         # Call the async function that defines a customized periodic task, if any
         _task = getattr(self, "customize_periodic_task", None)
         if callable(_task):

--- a/plato/servers/base.py
+++ b/plato/servers/base.py
@@ -55,8 +55,12 @@ class ServerEvents(socketio.AsyncNamespace):
 
     async def on_client_payload_done(self, sid, data):
         """ An existing client finished sending its payloads from local training. """
-        await self.plato_server.client_payload_done(sid, data['id'],
-                                                    data['obkey'])
+        if 's3_key' in data:
+            await self.plato_server.client_payload_done(sid,
+                                                        data['id'],
+                                                        s3_key=data['s3_key'])
+        else:
+            await self.plato_server.client_payload_done(sid, data['id'])
 
 
 class Server:
@@ -254,7 +258,7 @@ class Server:
             # Except for these two cases, we need to exclude the clients who are still
             # training.
             training_client_ids = [
-                self.training_clients[client_id]
+                self.training_clients[client_id]['id']
                 for client_id in list(self.training_clients.keys())
             ]
             selectable_clients = [
@@ -303,7 +307,10 @@ class Server:
                     os.getpid(), selected_client_id)
                 await self.send(sid, payload, selected_client_id)
 
-                self.training_clients[client_id] = selected_client_id
+                self.training_clients[client_id] = {
+                    'id': selected_client_id,
+                    'round': self.current_round
+                }
 
             self.reporting_clients = []
 
@@ -333,7 +340,29 @@ class Server:
         # If we are operating in asynchronous mode, aggregate the model updates received so far.
         if hasattr(Config().server,
                    'synchronous') and not Config().server.synchronous:
-            if len(self.updates) > 0:
+
+            # What is the minimum number of clients that must have reported before aggregation
+            # takes place?
+            minimum_clients = 0
+            if hasattr(Config().server, 'minimum_clients_aggregated'):
+                minimum_clients = Config().server.minimum_clients_aggregated
+
+            # Is there any training clients who are currently training on models that are too
+            # `stale,` as defined by the staleness threshold?
+            staleness = 0
+            if hasattr(Config().server, 'staleness'):
+                staleness = Config().server.staleness
+
+            for __, client_data in self.training_clients.items():
+                if client_data['round'] < self.current_round - staleness:
+                    logging.info(
+                        "[Server #%d] Client %s is still working at round %s, which is "
+                        "beyond the staleness threshold %s compared to the current round %s. "
+                        "Nothing to process.", os.getpid(), client_data['id'],
+                        client_data['round'], staleness, self.current_round)
+                return
+
+            if len(self.updates) > minimum_clients:
                 logging.info(
                     "[Server #%d] %d client reports received in asynchronous mode. Processing.",
                     os.getpid(), len(self.updates))
@@ -342,8 +371,8 @@ class Server:
                 await self.select_clients()
             else:
                 logging.info(
-                    "[Server #%d] No client reports have been received. Nothing to process."
-                )
+                    "[Server #%d] No sufficient number of client reports have been received. "
+                    "Nothing to process.")
 
     async def send_in_chunks(self, data, sid, client_id) -> None:
         """ Sending a bytes object in fixed-sized chunks to the client. """
@@ -360,12 +389,14 @@ class Server:
         # First apply outbound processors, if any
         payload = self.outbound_processor.process(payload)
 
+        metadata = {'id': client_id}
+
         if self.s3_client is not None:
-            payload_key = f'server_payload_{os.getpid()}_{self.current_round}'
-            self.s3_client.send_to_s3(payload_key, payload)
+            s3_key = f'server_payload_{os.getpid()}_{self.current_round}'
+            self.s3_client.send_to_s3(s3_key, payload)
             data_size = sys.getsizeof(pickle.dumps(payload))
+            metadata['s3_key'] = s3_key
         else:
-            payload_key = None
             data_size = 0
 
             if isinstance(payload, list):
@@ -379,11 +410,7 @@ class Server:
                 await self.send_in_chunks(_data, sid, client_id)
                 data_size = sys.getsizeof(_data)
 
-        await self.sio.emit('payload_done', {
-            'id': client_id,
-            'obkey': payload_key
-        },
-                            room=sid)
+        await self.sio.emit('payload_done', metadata, room=sid)
 
         logging.info("[Server #%d] Sent %s MB of payload data to client #%d.",
                      os.getpid(), round(data_size / 1024**2, 2), client_id)
@@ -415,9 +442,9 @@ class Server:
             self.client_payload[sid] = [self.client_payload[sid]]
             self.client_payload[sid].append(_data)
 
-    async def client_payload_done(self, sid, client_id, object_key):
+    async def client_payload_done(self, sid, client_id, s3_key=None):
         """ Upon receiving all the payload from a client, either via S3 or socket.io. """
-        if object_key is None:
+        if s3_key is None:
             assert self.client_payload[sid] is not None
 
             payload_size = 0
@@ -428,8 +455,7 @@ class Server:
                 payload_size = sys.getsizeof(
                     pickle.dumps(self.client_payload[sid]))
         else:
-            self.client_payload[sid] = self.s3_client.receive_from_s3(
-                object_key)
+            self.client_payload[sid] = self.s3_client.receive_from_s3(s3_key)
             payload_size = sys.getsizeof(pickle.dumps(
                 self.client_payload[sid]))
 
@@ -472,8 +498,7 @@ class Server:
                 if client_id in self.selected_clients:
                     self.selected_clients.remove(client_id)
 
-                    if len(self.updates) > 0 and len(self.updates) >= len(
-                            self.selected_clients):
+                    if len(self.updates) >= len(self.selected_clients):
                         logging.info(
                             "[Server #%d] All %d client reports received. Processing.",
                             os.getpid(), len(self.updates))

--- a/plato/servers/base.py
+++ b/plato/servers/base.py
@@ -129,7 +129,7 @@ class Server:
 
         if hasattr(Config().server, 'periodic_interval'):
             periodic_interval = Config().server.periodic_interval
-        else
+        else:
             periodic_interval = 5
 
         asyncio.get_event_loop().create_task(self.periodic(periodic_interval))

--- a/plato/servers/base.py
+++ b/plato/servers/base.py
@@ -347,7 +347,7 @@ class Server:
 
             # What is the minimum number of clients that must have reported before aggregation
             # takes place?
-            minimum_clients = 0
+            minimum_clients = 1
             if hasattr(Config().server, 'minimum_clients_aggregated'):
                 minimum_clients = Config().server.minimum_clients_aggregated
 
@@ -358,15 +358,18 @@ class Server:
                 staleness = Config().server.staleness
 
             for __, client_data in self.training_clients.items():
+                # The client is still working at an early round, early enough to stop the aggregation
+                # process as determined by 'staleness'
                 if client_data['round'] < self.current_round - staleness:
                     logging.info(
                         "[Server #%d] Client %s is still working at round %s, which is "
                         "beyond the staleness threshold %s compared to the current round %s. "
                         "Nothing to process.", os.getpid(), client_data['id'],
                         client_data['round'], staleness, self.current_round)
-                return
 
-            if len(self.updates) > minimum_clients:
+                    return
+
+            if len(self.updates) >= minimum_clients:
                 logging.info(
                     "[Server #%d] %d client reports received in asynchronous mode. Processing.",
                     os.getpid(), len(self.updates))

--- a/plato/utils/rlfl/simple_rl_server.py
+++ b/plato/utils/rlfl/simple_rl_server.py
@@ -282,9 +282,9 @@ class RLServer(fedavg.Server):
 
         await self.step()
 
-    async def client_payload_done(self, sid, client_id, object_key):
+    async def client_payload_done(self, sid, client_id, s3_key=None):
         """ Upon receiving all the payload from a client, either via S3 or socket.io. """
-        if object_key is None:
+        if s3_key is None:
             assert self.client_payload[sid] is not None
 
             payload_size = 0
@@ -295,8 +295,7 @@ class RLServer(fedavg.Server):
                 payload_size = sys.getsizeof(
                     pickle.dumps(self.client_payload[sid]))
         else:
-            self.client_payload[sid] = self.s3_client.receive_from_s3(
-                object_key)
+            self.client_payload[sid] = self.s3_client.receive_from_s3(s3_key)
             payload_size = sys.getsizeof(pickle.dumps(
                 self.client_payload[sid]))
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR adds basic support for bounded staleness in asynchronous mode in Plato.

## Description
<!--- Describe your changes in detail -->

The algorithm that is currently implemented can be described as follows:

Assuming that in a federated learning session, staleness is 2.

When a server sends out a model to a newly selected client, it will:

(1) Record the current communication round index for this client, indicating that this client is currently working in this communication round.

(2) Send out the current model.

When a server received a model update from a client it has previously selected, it will:

(1) "save" the model update for this reporting client;

(2) If the slowest client is at least working in round #(current communication round index - 2), aggregate all the model updates received so far, and then select a new client to replace this reporting client and send out the newly aggregated model to the new client;

(3) Otherwise, do nothing.

Two additional minor changes have been made:

- The way that the object key is passed around between clients and servers when S3 object storage is used has been refactored to be more readable.

- An additional configurable parameter, the minimum number of clients that should report before any aggregation takes place, has been added.

### Describe the motivation and context

Start with a simple bounded staleness implementation in the current Plato codebase, and test it extensively to make sure it works as expected.

### Why is this change required? What problem does it solve?

To support additional flexibility in asynchronous mode.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
First add the following code to `clients/simple.py` (in `train()`) in order to simulate a *sleepy* client:
```
    import asyncio

    async def train(self):
        """The machine learning training workload on a client."""
        logging.info("[Client #%d] Started training.", self.client_id)

        if self.client_id == 1:
            logging.info("[Client #1] Going to sleep for 20 seconds.")
            await asyncio.sleep(20)
            logging.info("[Client #1] Woke up.")
```

And then one can test the mechanism by running:

```shell
./run -c configs/MNIST/fedavg_async_lenet5.yml
```

<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) Fixes #
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
