### PR TITLE
Update feature.py to fix a TypeError bug of split learning example

### DIFF
--- a/plato/datasources/feature.py
+++ b/plato/datasources/feature.py
@@ -15,3 +15,9 @@ class DataSource(base.DataSource):
         self.feature_dataset = list(chain.from_iterable(features))
         self.trainset = self.feature_dataset
         self.testset = []
+
+    def __len__(self):
+        return len(self.trainset)
+
+    def __getitem__(self, item):
+        return self.trainset[item]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Describe motivation and context -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The class `DataSource` in file **plato/datasources/feature.py** does not implement method `__len__()` and `__getitem__()`, which causes the program to raise a TypeError when running the split learning example. The change fixes the bug by implementing these two methods.

This commit aims to resolve issue #140 

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
The change is tested by executing file **examples/split_learning/split_learning.py** and no errors were raised. The program successfully finished the training.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) Fixes #140 
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
