### PR TITLE
Fix an issue with the naming of directory to store result .csv files

### DIFF
--- a/examples/afl/afl_client.py
+++ b/examples/afl/afl_client.py
@@ -35,7 +35,7 @@ class Client(simple.Client):
         valuation = self.calc_valuation(report.num_samples, loss)
 
         return Report(report.num_samples, report.accuracy, report.training_time,
-                      report.data_loading_time, valuation), weights
+                      report.update_response, valuation), weights
 
     def get_loss(self):
         """ Retrieve the loss value from the training process. """

--- a/examples/fedasync/fedasync.py
+++ b/examples/fedasync/fedasync.py
@@ -3,8 +3,8 @@ A federated learning training session using FedAsync.
 
 Reference:
 
-Xie, C., Koyejo, S., & Gupta, I. (2019). "Asynchronous federated optimization." 
-arXiv preprint arXiv:1903.03934.
+Xie, C., Koyejo, S., Gupta, I. (2019). "Asynchronous federated optimization,"
+in Proc. 12th Annual Workshop on Optimization for Machine Learning (OPT 2020).
 
 https://opt-ml.org/papers/2020/paper_28.pdf
 """

--- a/plato/config.py
+++ b/plato/config.py
@@ -112,7 +112,11 @@ class Config:
                 else:
                     datasource = Config.data.datasource
                     model = Config.trainer.model_name
-                    server_type = Config.algorithm.type
+                    server_type = "custom"
+                    if hasattr(Config().server, "type"):
+                        server_type = Config.server.type
+                    elif hasattr(Config().algorithm, "type"):
+                        server_type = Config.algorithm.type
                     Config.result_dir = f'./results/{datasource}/{model}/{server_type}/'
 
             if 'model' in config:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
An AttributeError could be raised if the user wants to save results by adding the `results` section in the configuration .yml file but does not provide `results_dir` and `type` for `algorithm`
## Description
<!--- Describe your changes in detail -->
<!--- Describe motivation and context -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently, if the user adds a `results` section in the .yml config file but does not give a`results_dir` attribute, the program will create a default result directory of `./results/{datasource}/{model}/{server_type}/`, where `server_type` is assigned to be the `type` of `algorithm`. However, if the user wishes to implement their own algorithm, they might not provide a type to the algorithm in the config file, and that would give an AttributeError since the program could not find the `type` attribute of the algorithm.

The fix simply sets `server_type` to a default value and re-assigns the variable to `type` of algorithm or server, depending on which is provided in the config file.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
1. Add the following content at the end of `examples/adaptive_sync/adaptive_sync_MNIST_lenet5.yml` and `examples/adaptive_freezing/adaptive_freezing_MNIST_lenet5.yml`:
```
results:
    # Write the following parameter(s) into a CSV
    types: round, elapsed_time, accuracy

    # Plot results (x_axis-y_axis)
    plot: round-accuracy, elapsed_time-accuracy
```

2. Run  `examples/adaptive_sync/adaptive_sync.py` and `examples/adaptive_freezing/adaptive_freezing.py`

3. Without the fix, the above executions will give an AttributeError saying that `AttributeError: 'Config' object has no attribute 'type'`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) Fixes #
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
