### PR TITLE
Update Report class in examples to adapt the change in simple.Report

### DIFF
--- a/examples/axiothea/axiothea_client.py
+++ b/examples/axiothea/axiothea_client.py
@@ -29,4 +29,4 @@ class Client(simple.Client):
         report, weights = await super().train()
 
         return Report(report.num_samples, report.accuracy,
-                      report.training_time, report.data_loading_time), weights
+                      report.training_time, report.update_response), weights

--- a/examples/fedsarah/fedsarah_client.py
+++ b/examples/fedsarah/fedsarah_client.py
@@ -48,7 +48,7 @@ class Client(simple.Client):
         fn = f"new_client_control_variates_{self.client_id}.pth"
         os.remove(fn)
         return Report(report.num_samples, report.accuracy,
-                      report.training_time, report.data_loading_time,
+                      report.training_time, report.update_response,
                       2), [weights, self.client_control_variates]
 
     def load_payload(self, server_payload):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Change the attribute of class `Report` used by examples correctly to adapt the change in `simple.Report`

## Description
<!--- Describe your changes in detail -->
<!--- Describe motivation and context -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The dataclass `simple.Report` in `clients/simple.py` has been updated to include only one attribute `update_response`, but this change has not been propagated to examples that use this class. They are still using `report.data_loading_time`.

The fix updates the attribute used by example `fedsarah` and `axiothea` correctly.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Run `examples/fedsarah/fedsarah.py` without error.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) Fixes #
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
