### PR TITLE
Add new config file for FedAsync example to reproduce the experiment in the original paper

### DIFF
--- a/examples/cs_maml/cs_maml_trainer.py
+++ b/examples/cs_maml/cs_maml_trainer.py
@@ -4,7 +4,6 @@ The training and testing loops for PyTorch.
 import copy
 import logging
 import os
-import random
 
 import numpy as np
 import torch

--- a/examples/fedasync/fedasync_CIFAR10_resnet18.yml
+++ b/examples/fedasync/fedasync_CIFAR10_resnet18.yml
@@ -17,8 +17,10 @@ clients:
 
     # The simulation distribution
     simulation_distribution:
-        distribution: pareto
-        alpha: 1.5
+        # staleness is simulated from uniform distribution as mentioned in Section 5.2
+        distribution: uniform
+        low: 0
+        high: 20
 
 server:
     address: 127.0.0.1
@@ -27,8 +29,8 @@ server:
     simulate_wall_time: false
 
     # Parameter for FedAsync
-    minimum_clients_aggregated: 1
     staleness_bound: 4
+    minimum_clients_aggregated: 1
     mixing_hyperparameter: 0.9
     adaptive_mixing: true
     staleness_weighting_function:

--- a/examples/fedasync/fedasync_CIFAR10_resnet18.yml
+++ b/examples/fedasync/fedasync_CIFAR10_resnet18.yml
@@ -27,17 +27,18 @@ server:
     simulate_wall_time: false
 
     # Parameter for FedAsync
-    staleness_bound: 1000 # FedAsync doesn't have any staleness bound
     minimum_clients_aggregated: 1
+    staleness_bound: 4
     mixing_hyperparameter: 0.9
     adaptive_mixing: true
     staleness_weighting_function:
-        type: Polynomial
-        a: 2
+        type: Hinge
+        a: 10
+        b: 4
 
 data:
     # The training and testing dataset
-    datasource: MNIST
+    datasource: CIFAR10
 
     # Where the dataset is located
     data_path: ./data
@@ -69,14 +70,14 @@ trainer:
 
     # Number of epoches for local training in each communication round
     epochs: 5
-    batch_size: 32
+    batch_size: 50
     optimizer: SGD
-    learning_rate: 0.01
+    learning_rate: 0.1
     momentum: 0.9
-    weight_decay: 0.0
+    weight_decay: 0.005
 
     # The machine learning model
-    model_name: lenet5
+    model_name: resnet_18
 
 algorithm:
     # Aggregation algorithm

--- a/examples/fedasync/fedasync_MNIST_lenet5.yml
+++ b/examples/fedasync/fedasync_MNIST_lenet5.yml
@@ -1,4 +1,7 @@
 clients:
+    # Type
+    type: simple
+
     # The total number of clients
     total_clients: 100
 
@@ -14,8 +17,8 @@ clients:
 
     # The simulation distribution
     simulation_distribution:
-        distribution: zipf
-        s: 1.5
+        distribution: pareto
+        alpha: 1.5
 
 server:
     address: 127.0.0.1

--- a/examples/fedasync/fedasync_server.py
+++ b/examples/fedasync/fedasync_server.py
@@ -70,7 +70,7 @@ class Server(fedavg.Server):
         updated_weights = OrderedDict()
         for name, weight in baseline_weights.items():
             updated_weights[name] = weight * (
-                    1 - self.mixing_hyperparam
+                1 - self.mixing_hyperparam
             ) + weights_received[0][name] * self.mixing_hyperparam
 
         self.algorithm.load_weights(updated_weights)
@@ -109,8 +109,7 @@ class Server(fedavg.Server):
             else:
                 logging.warning(
                     "FedAsync: Unknown staleness weighting function type. "
-                    "Type needs to be constant, polynomial, or hinge."
-                )
+                    "Type needs to be constant, polynomial, or hinge.")
         else:
             return Server.constant_function()
 
@@ -122,7 +121,7 @@ class Server(fedavg.Server):
     @staticmethod
     def polynomial_function(staleness, a) -> float:
         """ Polynomial staleness function as proposed in Sec. 5.2, Evaluation Setup. """
-        return (staleness + 1) ** -a
+        return (staleness + 1)**-a
 
     @staticmethod
     def hinge_function(staleness, a, b) -> float:

--- a/examples/fednova/fednova_client.py
+++ b/examples/fednova/fednova_client.py
@@ -40,7 +40,7 @@ class Client(simple.Client):
 
     def configure(self):
         super().configure()
-        random.seed(3000 + self.client_id)
+        np.random.seed(3000 + self.client_id)
 
     async def train(self):
         """ FedNova clients use different number of local epochs. """

--- a/examples/fl_maml/fl_maml_trainer.py
+++ b/examples/fl_maml/fl_maml_trainer.py
@@ -4,7 +4,6 @@ The training and testing loops for PyTorch.
 import copy
 import logging
 import os
-import random
 
 import numpy as np
 import torch

--- a/plato/config.py
+++ b/plato/config.py
@@ -208,6 +208,8 @@ class Config:
                                                size=total_clients)
             if dist.distribution.lower() == "pareto":
                 sleep_times = np.random.pareto(dist.alpha, size=total_clients)
+            if dist.distribution.lower() == "uniform":
+                sleep_times = np.random.uniform(dist.low, dist.high, size=total_clients)
         else:
             # By default, use Zipf distribution with a parameter of 1.5
             sleep_times = np.random.pareto(1.0, size=total_clients)

--- a/plato/config.py
+++ b/plato/config.py
@@ -211,7 +211,9 @@ class Config:
             if dist.distribution.lower() == "zipf":
                 sleep_times = np.random.zipf(dist.s, size=total_clients)
             if dist.distribution.lower() == "uniform":
-                sleep_times = np.random.uniform(dist.low, dist.high, size=total_clients)
+                sleep_times = np.random.uniform(dist.low,
+                                                dist.high,
+                                                size=total_clients)
         else:
             # By default, use Pareto distribution with a parameter of 1.0
             sleep_times = np.random.pareto(1.0, size=total_clients)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add new YML file for FedAsync example to reproduce the CIFAR10 experiment in the original paper
## Description
<!--- Describe your changes in detail -->
<!--- Describe motivation and context -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Add new file `fedasync_CIFAR10_resnet18.yml` under `examples/fedasync` that tries to reproduce the experiment with CIFAR10 dataset in the original FedAsync paper.

Also update `fedasync_server.py` to support the use of different staleness weighting functions mentioned in the paper when updating the mixing hyperparameter

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Execute the following command with no error:
`python run.py --config=examples/fedasync/fedasync_CIFAR10_resnet18.yml`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) Fixes #
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Additional Context
1. The original paper uses its own custom convolutional neural network to run the experiments, which I'm not so sure how to reproduce in the Plato framework, so I just use the existing ResNet18 model.
2. The original paper also simulates the staleness of clients directly from a uniform distribution, so they can control the max staleness of clients, which I think is not possible to be entirely reproduced in the Plato framework. Thus, I just simulate the client's sleep time from a uniform distribution and set the `staleness_bound` correspondingly, which is not a 100% reproduction but similar to the design of the original paper
