### PR TITLE
Add implementation of Fedprox example

### DIFF
--- a/examples/fedprox/fedprox.py
+++ b/examples/fedprox/fedprox.py
@@ -1,0 +1,26 @@
+"""
+A federated learning training session using FedProx.
+
+Reference:
+Li, T., Sahu, A. K., Zaheer, M., Sanjabi, M., Talwalkar, A., & Smith, V. (2020).
+"Federated optimization in heterogeneous networks." Proceedings of Machine
+Learning and Systems, 2, 429-450.
+
+https://proceedings.mlsys.org/paper/2020/file/38af86134b65d0f10fe33d30dd76442e-Paper.pdf
+"""
+import fedprox_trainer
+
+from plato.servers import fedavg
+from plato.clients import simple
+
+
+def main():
+    """ A Plato federated learning training session using FedAsync. """
+    trainer = fedprox_trainer.Trainer()
+    client = simple.Client(trainer=trainer)
+    server = fedavg.Server()
+    server.run(client)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/fedprox/fedprox_MNIST_lenet5.yml
+++ b/examples/fedprox/fedprox_MNIST_lenet5.yml
@@ -1,0 +1,90 @@
+clients:
+    # Type
+    type: simple
+
+    # The total number of clients
+    total_clients: 10
+
+    # The number of clients selected in each round
+    per_round: 10
+
+    # Should the clients compute test accuracy locally?
+    do_test: false
+
+    # Whether simulate clients or not
+    simulation: true
+    speed_simulation: true
+
+    # The simulation distribution
+    simulation_distribution:
+        distribution: pareto
+        alpha: 1
+    max_sleep_time: 30
+    sleep_simulation: true
+    avg_training_time: 10
+
+    random_seed: 1
+
+    # FedProx hyperparameters
+    proximal_term_penalty_constant: 1
+
+server:
+    address: 127.0.0.1
+    port: 8000
+    synchronous: true
+
+    staleness_bound: 1000
+
+    checkpoint_dir: ./models/fedprox/mnist
+    model_dir: ./models/fedprox/mnist
+
+data:
+    # The training and testing dataset
+    datasource: MNIST
+
+    # Where the dataset is located
+    data_path: ./data
+
+    # Number of samples in each partition
+    partition_size: 600
+
+    # IID or non-IID?
+    sampler: noniid
+
+    # The concentration parameter for the Dirichlet distribution
+    concentration: 5
+
+    # The random seed for sampling data
+    random_seed: 1
+
+trainer:
+    # The type of the trainer
+    type: basic
+
+    # The maximum number of training rounds
+    rounds: 20
+
+    # Whether the training should use multiple GPUs if available
+    parallelized: false
+
+    # The maximum number of clients running concurrently 
+    max_concurrency: 10
+
+    # The target accuracy
+    target_accuracy: 0.98
+
+    # Number of epochs for local training in each communication round
+    epochs: 5
+    batch_size: 10
+    optimizer: SGD
+    learning_rate: 0.03
+    momentum: 0.9
+    weight_decay: 0.0
+
+    # The machine learning model
+    model_name: lenet5
+    num_classes: 47
+
+algorithm:
+    # Aggregation algorithm
+    type: fedavg

--- a/examples/fedprox/fedprox_MNIST_lenet5.yml
+++ b/examples/fedprox/fedprox_MNIST_lenet5.yml
@@ -3,7 +3,7 @@ clients:
     type: simple
 
     # The total number of clients
-    total_clients: 10
+    total_clients: 1000
 
     # The number of clients selected in each round
     per_round: 10
@@ -13,27 +13,18 @@ clients:
 
     # Whether simulate clients or not
     simulation: true
-    speed_simulation: true
-
-    # The simulation distribution
-    simulation_distribution:
-        distribution: pareto
-        alpha: 1
-    max_sleep_time: 30
-    sleep_simulation: true
-    avg_training_time: 10
 
     random_seed: 1
 
     # FedProx hyperparameters
     proximal_term_penalty_constant: 1
+    # FedProx parameters for experiment
+    straggler_percentage: 90
 
 server:
     address: 127.0.0.1
     port: 8000
     synchronous: true
-
-    staleness_bound: 1000
 
     checkpoint_dir: ./models/fedprox/mnist
     model_dir: ./models/fedprox/mnist
@@ -62,23 +53,23 @@ trainer:
     type: basic
 
     # The maximum number of training rounds
-    rounds: 20
+    rounds: 100
 
     # Whether the training should use multiple GPUs if available
     parallelized: false
 
-    # The maximum number of clients running concurrently 
+    # The maximum number of clients running concurrently
     max_concurrency: 10
 
     # The target accuracy
     target_accuracy: 0.98
 
     # Number of epochs for local training in each communication round
-    epochs: 5
+    epochs: 20
     batch_size: 10
     optimizer: SGD
     learning_rate: 0.03
-    momentum: 0.9
+    momentum: 0.0 # learning rate is fixed as in Appendix C.2
     weight_decay: 0.0
 
     # The machine learning model

--- a/examples/fedprox/fedprox_MNIST_lenet5.yml
+++ b/examples/fedprox/fedprox_MNIST_lenet5.yml
@@ -20,7 +20,7 @@ clients:
     proximal_term_penalty_constant: 1
     # FedProx parameters for experiment
     straggler_simulation: true
-    straggler_percentage: 90
+    straggler_percentage: 50
 
 server:
     address: 127.0.0.1

--- a/examples/fedprox/fedprox_MNIST_lenet5.yml
+++ b/examples/fedprox/fedprox_MNIST_lenet5.yml
@@ -19,6 +19,7 @@ clients:
     # FedProx hyperparameters
     proximal_term_penalty_constant: 1
     # FedProx parameters for experiment
+    straggler_simulation: true
     straggler_percentage: 90
 
 server:

--- a/examples/fedprox/fedprox_trainer.py
+++ b/examples/fedprox/fedprox_trainer.py
@@ -45,15 +45,24 @@ class Trainer(basic.Trainer):
 
     def train_process(self, config, trainset, sampler, cut_layer=None):
         """The main training loop in FedProx framework. """
-        np.random.seed(self.client_id)
-        # Determine whether this selected client is a straggler
-        strag_prop = Config().clients.straggler_percentage / 100
-        is_straggler = np.random.choice([True, False],
-                                        p=[strag_prop, 1 - strag_prop])
-        if is_straggler:
-            # Choose the epoch uniformly as mentioned in Section 5.2 of the paper
-            global_epochs = Config().trainer.epochs
-            config['epochs'] = np.random.choice(np.arange(1, global_epochs))
+
+        # For FedProx, the server will accept partial solutions from straggling clients
+        # after waiting them for a certain amount of time. To re-create this scenario in
+        # an experiment, a proportion of the selected clients will train for a smaller
+        # number of epochs to simulate the stragglers that return with partial solutions,
+        # as mentioned in Section 5.2
+        if hasattr(Config().clients, 'straggler_simulation') and Config(
+        ).clients.straggler_simulation:
+            np.random.seed(self.client_id)
+            # Determine whether this selected client is a straggler
+            strag_prop = Config().clients.straggler_percentage / 100
+            is_straggler = np.random.choice([True, False],
+                                            p=[strag_prop, 1 - strag_prop])
+            if is_straggler:
+                # Choose the epoch uniformly as mentioned in Section 5.2 of the paper
+                global_epochs = Config().trainer.epochs
+                config['epochs'] = np.random.choice(np.arange(
+                    1, global_epochs))
 
         super(Trainer, self).train_process(config, trainset, sampler,
                                            cut_layer)

--- a/examples/fedprox/fedprox_trainer.py
+++ b/examples/fedprox/fedprox_trainer.py
@@ -1,0 +1,48 @@
+"""
+A federated learning training session using FedProx.
+
+Reference:
+Li, T., Sahu, A. K., Zaheer, M., Sanjabi, M., Talwalkar, A., & Smith, V. (2020).
+"Federated optimization in heterogeneous networks." Proceedings of Machine
+Learning and Systems, 2, 429-450.
+
+https://proceedings.mlsys.org/paper/2020/file/38af86134b65d0f10fe33d30dd76442e-Paper.pdf
+"""
+import torch
+
+from plato.config import Config
+from plato.trainers import basic
+
+
+class FedProxLocalObjective():
+    """ Representing the local objective of FedProx clients. """
+
+    def __init__(self, model):
+        self.model = model
+        self.init_global_weights = torch.tensor([], requires_grad=False)
+        for param in model.parameters():
+            self.init_global_weights = torch.cat(
+                (self.init_global_weights, torch.flatten(param)))
+
+    def compute_objective(self, outputs, labels):
+        """ Compute the objective the FedProx client wishes to minimize. """
+        cur_weights = torch.tensor([], requires_grad=False)
+        for param in self.model.parameters():
+            cur_weights = torch.cat((cur_weights, torch.flatten(param)))
+
+        mu = Config().clients.proximal_term_penalty_constant
+        prox_term = mu / 2 * torch.linalg.norm(
+            cur_weights - self.init_global_weights, ord=2)
+
+        local_function = torch.nn.CrossEntropyLoss()
+        h = local_function(outputs, labels) + prox_term
+        return h
+
+
+class Trainer(basic.Trainer):
+    """ The federated learning trainer for the FedProx client. """
+
+    def loss_criterion(self, model):
+        """ Return the loss criterion for FedProx clients. """
+        local_obj = FedProxLocalObjective(model)
+        return local_obj.compute_objective

--- a/examples/fedprox/fedprox_trainer.py
+++ b/examples/fedprox/fedprox_trainer.py
@@ -15,22 +15,24 @@ from plato.config import Config
 from plato.trainers import basic
 
 
-class FedProxLocalObjective():
+def flatten_weights_from_model(model):
+    """ Return the weights of the given model as a 1-D tensor """
+    weights = torch.tensor([], requires_grad=False)
+    for param in model.parameters():
+        weights = torch.cat((weights, torch.flatten(param)))
+    return weights
+
+
+class FedProxLocalObjective:
     """ Representing the local objective of FedProx clients. """
 
     def __init__(self, model):
         self.model = model
-        self.init_global_weights = torch.tensor([], requires_grad=False)
-        for param in model.parameters():
-            self.init_global_weights = torch.cat(
-                (self.init_global_weights, torch.flatten(param)))
+        self.init_global_weights = flatten_weights_from_model(model)
 
     def compute_objective(self, outputs, labels):
         """ Compute the objective the FedProx client wishes to minimize. """
-        cur_weights = torch.tensor([], requires_grad=False)
-        for param in self.model.parameters():
-            cur_weights = torch.cat((cur_weights, torch.flatten(param)))
-
+        cur_weights = flatten_weights_from_model(self.model)
         mu = Config().clients.proximal_term_penalty_constant
         prox_term = mu / 2 * torch.linalg.norm(
             cur_weights - self.init_global_weights, ord=2)

--- a/plato/trainers/basic.py
+++ b/plato/trainers/basic.py
@@ -21,6 +21,7 @@ from plato.utils import optimizers
 
 class Trainer(base.Trainer):
     """A basic federated learning trainer, used by both the client and the server."""
+
     def __init__(self, model=None):
         """Initializing the trainer with the provided model.
 
@@ -110,8 +111,8 @@ class Trainer(base.Trainer):
 
     def simulate_sleep_time(self):
         """Simulate client's speed by putting it to sleep."""
-        if not (hasattr(Config().clients, 'sleep_simulation')
-                and Config().clients.sleep_simulation):
+        if hasattr(Config().clients,
+                   'sleep_simulation') and Config().clients.sleep_simulation:
             sleep_seconds = Config().client_sleep_times[self.client_id - 1]
 
             # Put this client to sleep

--- a/plato/trainers/basic.py
+++ b/plato/trainers/basic.py
@@ -111,8 +111,8 @@ class Trainer(base.Trainer):
 
     def simulate_sleep_time(self):
         """Simulate client's speed by putting it to sleep."""
-        if hasattr(Config().clients,
-                   'sleep_simulation') and Config().clients.sleep_simulation:
+        if not (hasattr(Config().clients, 'sleep_simulation')
+                and Config().clients.sleep_simulation):
             sleep_seconds = Config().client_sleep_times[self.client_id - 1]
 
             # Put this client to sleep


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Describe motivation and context -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This pull request tries to implement the FedProx framework proposed in this paper: https://proceedings.mlsys.org/paper/2020/file/38af86134b65d0f10fe33d30dd76442e-Paper.pdf

FedProx is a synchronous federated learning framework that is very similar to FedAvg except that FedProx adds a proximal term to the local objective that clients wish to minimize (i.e. the training loss function of the client). In other words, a FedProx client will train to minimize the following objective:

![Capture](https://user-images.githubusercontent.com/41752876/155824002-73160ff2-ad4c-4402-be1c-f68bb13b9083.PNG)

where <img src="https://render.githubusercontent.com/render/math?math=F_k(w)"> is the original loss function of clients in FedAvg, <img src="https://render.githubusercontent.com/render/math?math=w"> is the weight of the client model in the current training epoch, <img src="https://render.githubusercontent.com/render/math?math=w^t"> is the weight of the global model sent by the server to the client at the beginning of the training, and <img src="https://render.githubusercontent.com/render/math?math=\mu"> is a penalty constant of the proximal term, a hyperparameter of FedProx.

The major problem FedProx tries to solve is the impact of non-IID local training data across clients on the global model. With the proximal term added to the loss function, the training of local models at each client would be less affected by its potentially biased dataset.

Another important feature of FedProx is that for straggling clients, the server will collect partial models from them after waiting for a certain amount of time. However, the authors did not specifically describe their approach of implementation of collecting partial models. Instead, they simulate aggregation of partial models trained by stragglers by choosing a proportion of the selected clients and making them train for fewer epochs. This simulation can be reproduced by setting `straggler_simulation: true` in the configuration file under `clients`, but when `straggler_simulation: false`, the server would just wait for all selected clients to finish, as in FedAvg.

I think this feature of FedProx can be implemented if we enable the urgent request update functionality for the synchronous mode. But in that case, we need some sort of global time clock to determine when to request updates from stragglers. I do not know whether this is a good idea and I just want to ask whether it is a desirable functionality for the Plato framework.

Reference:
Li, T., Sahu, A. K., Zaheer, M., Sanjabi, M., Talwalkar, A., & Smith, V. (2020). "Federated optimization in heterogeneous networks." Proceedings of Machine Learning and Systems, 2, 429-450.

P.S. Also fixed a bug related to the sleep simulation of clients.


## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Run `python fedprox.py -c fedprox_MNIST_lenet5.yml` under directory `./examples/fedprox` without errors

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) Fixes #
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
