### PR TITLE
Added the facility to record local testing accuracies in .csv files

### DIFF
--- a/configs/EMNIST/fedavg_lenet5.yml
+++ b/configs/EMNIST/fedavg_lenet5.yml
@@ -9,7 +9,7 @@ clients:
     per_round: 5
 
     # Should the clients compute test accuracy locally?
-    do_test: false
+    do_test: true
 
     # Client simulation mode
     simulation: false

--- a/configs/EMNIST/fedavg_lenet5.yml
+++ b/configs/EMNIST/fedavg_lenet5.yml
@@ -9,7 +9,7 @@ clients:
     per_round: 5
 
     # Should the clients compute test accuracy locally?
-    do_test: true
+    do_test: false
 
     # Client simulation mode
     simulation: false

--- a/configs/MNIST/fedavg_async_lenet5.yml
+++ b/configs/MNIST/fedavg_async_lenet5.yml
@@ -3,13 +3,13 @@ clients:
     type: simple
 
     # The total number of clients
-    total_clients: 3
+    total_clients: 100
 
     # The number of clients selected in each round
-    per_round: 3
+    per_round: 20
 
     # Should the clients compute test accuracy locally?
-    do_test: true
+    do_test: false
 
     # Whether simulate clients or not
     simulation: true
@@ -53,7 +53,7 @@ trainer:
     type: basic
 
     # The maximum number of training rounds
-    rounds: 4
+    rounds: 2
 
     # Whether the training should use multiple GPUs if available
     parallelized: false

--- a/configs/MNIST/fedavg_async_lenet5.yml
+++ b/configs/MNIST/fedavg_async_lenet5.yml
@@ -3,10 +3,10 @@ clients:
     type: simple
 
     # The total number of clients
-    total_clients: 1
+    total_clients: 3
 
     # The number of clients selected in each round
-    per_round: 1
+    per_round: 3
 
     # Should the clients compute test accuracy locally?
     do_test: true

--- a/configs/MNIST/fedavg_async_lenet5.yml
+++ b/configs/MNIST/fedavg_async_lenet5.yml
@@ -9,7 +9,7 @@ clients:
     per_round: 20
 
     # Should the clients compute test accuracy locally?
-    do_test: false
+    do_test: true
 
     # Whether simulate clients or not
     simulation: true

--- a/configs/MNIST/fedavg_async_lenet5.yml
+++ b/configs/MNIST/fedavg_async_lenet5.yml
@@ -53,7 +53,7 @@ trainer:
     type: basic
 
     # The maximum number of training rounds
-    rounds: 3
+    rounds: 4
 
     # Whether the training should use multiple GPUs if available
     parallelized: false

--- a/configs/MNIST/fedavg_async_lenet5.yml
+++ b/configs/MNIST/fedavg_async_lenet5.yml
@@ -9,7 +9,7 @@ clients:
     per_round: 20
 
     # Should the clients compute test accuracy locally?
-    do_test: true
+    do_test: false
 
     # Whether simulate clients or not
     simulation: true

--- a/configs/MNIST/fedavg_async_lenet5.yml
+++ b/configs/MNIST/fedavg_async_lenet5.yml
@@ -3,13 +3,13 @@ clients:
     type: simple
 
     # The total number of clients
-    total_clients: 3
+    total_clients: 100
 
     # The number of clients selected in each round
-    per_round: 3
+    per_round: 20
 
     # Should the clients compute test accuracy locally?
-    do_test: true
+    do_test: false
 
     # Whether simulate clients or not
     simulation: true
@@ -53,7 +53,7 @@ trainer:
     type: basic
 
     # The maximum number of training rounds
-    rounds: 3
+    rounds: 2
 
     # Whether the training should use multiple GPUs if available
     parallelized: false

--- a/configs/MNIST/fedavg_async_lenet5.yml
+++ b/configs/MNIST/fedavg_async_lenet5.yml
@@ -3,13 +3,13 @@ clients:
     type: simple
 
     # The total number of clients
-    total_clients: 100
+    total_clients: 2
 
     # The number of clients selected in each round
-    per_round: 20
+    per_round: 2
 
     # Should the clients compute test accuracy locally?
-    do_test: false
+    do_test: true
 
     # Whether simulate clients or not
     simulation: true

--- a/configs/MNIST/fedavg_async_lenet5.yml
+++ b/configs/MNIST/fedavg_async_lenet5.yml
@@ -53,7 +53,7 @@ trainer:
     type: basic
 
     # The maximum number of training rounds
-    rounds: 2
+    rounds: 3
 
     # Whether the training should use multiple GPUs if available
     parallelized: false

--- a/configs/MNIST/fedavg_async_lenet5.yml
+++ b/configs/MNIST/fedavg_async_lenet5.yml
@@ -3,13 +3,13 @@ clients:
     type: simple
 
     # The total number of clients
-    total_clients: 2
+    total_clients: 100
 
     # The number of clients selected in each round
-    per_round: 2
+    per_round: 20
 
     # Should the clients compute test accuracy locally?
-    do_test: true
+    do_test: false
 
     # Whether simulate clients or not
     simulation: true

--- a/configs/MNIST/fedavg_async_lenet5.yml
+++ b/configs/MNIST/fedavg_async_lenet5.yml
@@ -3,13 +3,13 @@ clients:
     type: simple
 
     # The total number of clients
-    total_clients: 100
+    total_clients: 1
 
     # The number of clients selected in each round
-    per_round: 20
+    per_round: 1
 
     # Should the clients compute test accuracy locally?
-    do_test: false
+    do_test: true
 
     # Whether simulate clients or not
     simulation: true

--- a/configs/MNIST/fedavg_async_lenet5.yml
+++ b/configs/MNIST/fedavg_async_lenet5.yml
@@ -3,13 +3,13 @@ clients:
     type: simple
 
     # The total number of clients
-    total_clients: 100
+    total_clients: 3
 
     # The number of clients selected in each round
-    per_round: 20
+    per_round: 3
 
     # Should the clients compute test accuracy locally?
-    do_test: false
+    do_test: true
 
     # Whether simulate clients or not
     simulation: true
@@ -53,7 +53,7 @@ trainer:
     type: basic
 
     # The maximum number of training rounds
-    rounds: 2
+    rounds: 3
 
     # Whether the training should use multiple GPUs if available
     parallelized: false

--- a/configs/MNIST/fedavg_lenet5.yml
+++ b/configs/MNIST/fedavg_lenet5.yml
@@ -9,7 +9,7 @@ clients:
     per_round: 2
 
     # Should the clients compute test accuracy locally?
-    do_test: false
+    do_test: true
 
     # Client simulation mode
     simulation: false

--- a/configs/MNIST/fedavg_lenet5.yml
+++ b/configs/MNIST/fedavg_lenet5.yml
@@ -3,10 +3,10 @@ clients:
     type: simple
 
     # The total number of clients
-    total_clients: 1
+    total_clients: 10
 
     # The number of clients selected in each round
-    per_round: 1
+    per_round: 2
 
     # Should the clients compute test accuracy locally?
     do_test: true

--- a/configs/MNIST/fedavg_lenet5.yml
+++ b/configs/MNIST/fedavg_lenet5.yml
@@ -9,7 +9,7 @@ clients:
     per_round: 2
 
     # Should the clients compute test accuracy locally?
-    do_test: true
+    do_test: false
 
     # Client simulation mode
     simulation: false

--- a/configs/MNIST/fedavg_lenet5.yml
+++ b/configs/MNIST/fedavg_lenet5.yml
@@ -3,10 +3,10 @@ clients:
     type: simple
 
     # The total number of clients
-    total_clients: 10
+    total_clients: 1
 
     # The number of clients selected in each round
-    per_round: 2
+    per_round: 1
 
     # Should the clients compute test accuracy locally?
     do_test: true

--- a/examples/adaptive_hgb/adaptive_hgb_server.py
+++ b/examples/adaptive_hgb/adaptive_hgb_server.py
@@ -10,16 +10,17 @@ from plato.servers import fedavg
 
 class Server(fedavg.Server):
     """Federated server for adaptive gradient blending."""
+
     async def federated_averaging(self, updates):
         """Aggregate weight updates from the clients using federated averaging."""
         weights_received = self.extract_client_updates(updates)
 
         # Extract the total number of samples
         self.total_samples = sum(
-            [report.num_samples for (report, __, __) in updates])
+            [report.num_samples for (__, report, __, __) in updates])
 
         clients_delta_ogs = [(report.delta_O, report.delta_G)
-                             for (report, __, __) in updates]
+                             for (__, report, __, __) in updates]
 
         clients_optimal_weights = self.get_optimal_gradient_blend_weights_OG(
             delta_OGs=clients_delta_ogs)
@@ -31,7 +32,7 @@ class Server(fedavg.Server):
         }
 
         for i, update in enumerate(weights_received):
-            report, __, __ = updates[i]
+            __, report, __, __ = updates[i]
 
             for name, delta in update.items():
                 # Use weighted average by the number of samples

--- a/examples/afl/afl_server.py
+++ b/examples/afl/afl_server.py
@@ -20,6 +20,7 @@ from plato.servers import fedavg
 
 class Server(fedavg.Server):
     """A federated learning server using the AFL algorithm."""
+
     def __init__(self, model=None, algorithm=None, trainer=None):
         super().__init__(model, algorithm, trainer)
 
@@ -34,7 +35,7 @@ class Server(fedavg.Server):
 
         # Update the local valuations from the updates
         for i, update in enumerate(weights_received):
-            report, __, __ = updates[i]
+            __, report, __, __ = updates[i]
             client_id = self.selected_clients[i]
             self.local_values[client_id]["valuation"] = report.valuation
 

--- a/examples/cs_maml/cs_maml_server.py
+++ b/examples/cs_maml/cs_maml_server.py
@@ -14,6 +14,7 @@ from plato.servers import fedavg_cs
 
 class Server(fedavg_cs.Server):
     """Cross-silo federated learning server using federated averaging."""
+
     def __init__(self, model=None, algorithm=None, trainer=None):
         super().__init__(model=model, algorithm=algorithm, trainer=trainer)
 
@@ -116,10 +117,10 @@ class Server(fedavg_cs.Server):
         if not self.do_personalization_test:
             self.round_time = max([
                 report.training_time + report.comm_time
-                for (report, __, __) in self.updates
+                for (__, report, __, __) in self.updates
             ])
             self.comm_time = max(
-                [report.comm_time for (report, __, __) in self.updates])
+                [report.comm_time for (__, report, __, __) in self.updates])
 
     async def process_client_info(self, client_id, sid):
         """ Process the received metadata information from a reporting client. """

--- a/examples/fedadp/fedadp_server.py
+++ b/examples/fedadp/fedadp_server.py
@@ -18,6 +18,7 @@ from plato.servers import fedavg
 
 class Server(fedavg.Server):
     """A federated learning server using the FedAdp algorithm."""
+
     def __init__(self):
         super().__init__()
 
@@ -31,7 +32,7 @@ class Server(fedavg.Server):
         # Extract weights udpates from the client updates
         weights_received = self.extract_client_updates(updates)
 
-        num_samples = [report.num_samples for (report, __, __) in updates]
+        num_samples = [report.num_samples for (__, report, __, __) in updates]
         total_samples = sum(num_samples)
 
         self.global_grads = {

--- a/examples/fednova/fednova_server.py
+++ b/examples/fednova/fednova_server.py
@@ -14,6 +14,7 @@ from plato.servers import fedavg
 
 class Server(fedavg.Server):
     """A federated learning server using the FedNova algorithm. """
+
     async def federated_averaging(self, updates):
         """Aggregate weight updates from the clients using FedNova."""
         # Extracting weights from the updates
@@ -21,10 +22,10 @@ class Server(fedavg.Server):
 
         # Extracting the total number of samples
         self.total_samples = sum(
-            [report.num_samples for (report, __, __) in updates])
+            [report.num_samples for (__, report, __, __) in updates])
 
         # Extracting the number of local epoches, tau_i, from the updates
-        local_epochs = [report.epochs for (report, __, __) in updates]
+        local_epochs = [report.epochs for (__, report, __, __) in updates]
 
         # Performing weighted averaging
         avg_update = {
@@ -34,13 +35,13 @@ class Server(fedavg.Server):
 
         tau_eff = 0
         for i, update in enumerate(weights_received):
-            report, __, __ = updates[i]
+            __, report, __, __ = updates[i]
             num_samples = report.num_samples
             tau_eff_ = local_epochs[i] * num_samples / self.total_samples
             tau_eff += tau_eff_
 
         for i, update in enumerate(weights_received):
-            report, __, __ = updates[i]
+            __, report, __, __ = updates[i]
             num_samples = report.num_samples
 
             for name, delta in update.items():

--- a/examples/fedsaw/fedsaw_server.py
+++ b/examples/fedsaw/fedsaw_server.py
@@ -18,6 +18,7 @@ from plato.servers import fedavg_cs
 
 class Server(fedavg_cs.Server):
     """Cross-silo federated learning server using FedSaw."""
+
     def __init__(self, model=None, algorithm=None, trainer=None):
         super().__init__(model=model, algorithm=algorithm, trainer=trainer)
 
@@ -122,8 +123,9 @@ class Server(fedavg_cs.Server):
         record_items_values['pruning_amount'] = Config().clients.pruning_amount
 
         if Config().is_central_server():
-            edge_comm_overhead = sum(
-                [report.comm_overhead for (report, __, __) in self.updates])
+            edge_comm_overhead = sum([
+                report.comm_overhead for (__, report, __, __) in self.updates
+            ])
             record_items_values[
                 'comm_overhead'] = edge_comm_overhead + self.comm_overhead
         else:

--- a/examples/fei/fei_server.py
+++ b/examples/fei/fei_server.py
@@ -10,6 +10,7 @@ from plato.utils.reinforcement_learning import rl_server
 
 class RLServer(rl_server.RLServer):
     """ A federated learning server with RL Agent. """
+
     def __init__(self, agent, model=None, algorithm=None, trainer=None):
         super().__init__(agent, model, algorithm, trainer)
         self.local_correlations = [0] * Config().clients.per_round
@@ -21,15 +22,17 @@ class RLServer(rl_server.RLServer):
     def prep_state(self):
         """ Wrap up the state update to RL Agent. """
         # Store client ids
-        client_ids = [report.client_id for (report, __, __) in self.updates]
+        client_ids = [
+            report.client_id for (__, report, __, __) in self.updates
+        ]
 
         state = [0] * 4
         state[0] = self.normalize_state(
-            [report.num_samples for (report, __, __) in self.updates])
+            [report.num_samples for (__, report, __, __) in self.updates])
         state[1] = self.normalize_state(
-            [report.training_time for (report, __, __) in self.updates])
+            [report.training_time for (__, report, __, __) in self.updates])
         state[2] = self.normalize_state(
-            [report.valuation for (report, __, __) in self.updates])
+            [report.valuation for (__, report, __, __) in self.updates])
         state[3] = self.normalize_state(self.corr)
         state = np.transpose(np.round(np.array(state), 4))
 

--- a/examples/fl_maml/fl_maml_server.py
+++ b/examples/fl_maml/fl_maml_server.py
@@ -10,6 +10,7 @@ from plato.utils import csv_processor
 
 class Server(fedavg.Server):
     """A federated learning server for personalized FL."""
+
     def __init__(self, model=None, algorithm=None, trainer=None):
         super().__init__(model=model, algorithm=algorithm, trainer=trainer)
         self.do_personalization_test = False
@@ -87,10 +88,10 @@ class Server(fedavg.Server):
         else:
             self.round_time = max([
                 report.training_time + report.comm_time
-                for (report, __, __) in self.updates
+                for (__, report, __, __) in self.updates
             ])
             self.comm_time = max(
-                [report.comm_time for (report, __, __) in self.updates])
+                [report.comm_time for (__, report, __, __) in self.updates])
 
     async def process_client_info(self, client_id, sid):
         """ Process the received metadata information from a reporting client. """

--- a/examples/port/port_server.py
+++ b/examples/port/port_server.py
@@ -57,13 +57,13 @@ class Server(fedavg.Server):
 
         # Extract the total number of samples
         self.total_samples = sum(
-            [report.num_samples for (report, __, __) in updates])
+            [report.num_samples for (__, report, __, __) in updates])
 
         # Constructing the aggregation weights to be used
         aggregation_weights = []
 
         for i, update in enumerate(weights_received):
-            report, __, staleness = updates[i]
+            __, report, __, staleness = updates[i]
             num_samples = report.num_samples
 
             similarity = await self.cosine_similarity(update, staleness)
@@ -99,7 +99,7 @@ class Server(fedavg.Server):
         }
 
         for i, update in enumerate(weights_received):
-            report, __, staleness = updates[i]
+            __, report, __, staleness = updates[i]
             num_samples = report.num_samples
 
             for name, delta in update.items():

--- a/examples/sub_fedavg_cs/subcs_server.py
+++ b/examples/sub_fedavg_cs/subcs_server.py
@@ -14,6 +14,7 @@ from plato.servers import fedavg_cs
 
 class Server(fedavg_cs.Server):
     """Cross-silo federated learning server using Sub-FedAvg(Un)."""
+
     def __init__(self, model=None, algorithm=None, trainer=None):
         super().__init__(model=model, algorithm=algorithm, trainer=trainer)
 
@@ -29,8 +30,9 @@ class Server(fedavg_cs.Server):
         record_items_values['pruning_amount'] = Config().clients.pruning_amount
 
         if Config().is_central_server():
-            edge_comm_overhead = sum(
-                [report.comm_overhead for (report, __, __) in self.updates])
+            edge_comm_overhead = sum([
+                report.comm_overhead for (__, report, __, __) in self.updates
+            ])
             record_items_values[
                 'comm_overhead'] = edge_comm_overhead + self.comm_overhead
         else:

--- a/plato/servers/base.py
+++ b/plato/servers/base.py
@@ -755,8 +755,8 @@ class Server:
                     os.getpid(), client['client_id'])
 
                 client_staleness = self.current_round - client['starting_round']
-                self.updates.append(
-                    (client['report'], client['payload'], client_staleness))
+                self.updates.append((client['client_id'], client['report'],
+                                     client['payload'], client_staleness))
 
             # Step 3: Processing stale clients that exceed a staleness threshold
 
@@ -791,8 +791,8 @@ class Server:
                         client_staleness = self.current_round - client[
                             'starting_round']
                         self.updates.append(
-                            (client['report'], client['payload'],
-                             client_staleness))
+                            (client['client_id'], client['report'],
+                             client['payload'], client_staleness))
 
             self.reported_clients = possibly_stale_clients
             logging.info("[Server #%s] Aggregating %s clients in total.",
@@ -810,8 +810,8 @@ class Server:
             client = client_info[1]
             client_staleness = self.current_round - client['starting_round']
 
-            self.updates.append(
-                (client['report'], client['payload'], client_staleness))
+            self.updates.append((client['client_id'], client['report'],
+                                 client['payload'], client_staleness))
 
         if not self.simulate_wall_time:
             # In both synchronous and asynchronous modes, if we are not simulating the wall clock

--- a/plato/servers/fedavg.py
+++ b/plato/servers/fedavg.py
@@ -112,15 +112,11 @@ class Server(base.Server):
 
         #Initializes a test accuracy csv file if test accuracies are computed locally
         if (Config().clients.do_test):    
-            round_num = []
-            round_num.append("")
-            for i in range(Config().trainer.rounds):
-                round_num.append("Round " + str(i + 1))
-            client_rows = []
-            client_rows.append("")
+            client_headers = []
+            client_headers.append("")
             for i in range(Config().clients.per_round):
-                client_rows.append("Client " + str(i + 1))
-            csv_processor.initialize_accuracy_csv(test_accuracy_csv_file, round_num, client_rows, Config().params['result_dir'])
+                client_headers.append("Client " + str(i + 1))
+            csv_processor.initialize_csv(test_accuracy_csv_file, client_headers, Config().params['result_dir'])
 
 
     def load_trainer(self):
@@ -227,11 +223,16 @@ class Server(base.Server):
 
             """If the test accuracies are computed locally, it is written into the new csv file"""    
             if (Config().clients.do_test): 
-                new_test_accuracy_column = []
+                new_test_accuracy_row = []
+                new_test_accuracy_row.append(f"Round {self.current_round}")
                 for (report, __, __) in self.updates:
-                    new_test_accuracy_column.append(report.accuracy)
+                    new_test_accuracy_row.append(report.accuracy)
                 test_accuracy_csv_file = f"{Config().params['result_dir']}/{os.getpid()}_Client_Test_Accuracy.csv"    
-                csv_processor.write_csv_column(test_accuracy_csv_file, new_test_accuracy_column)   
+                csv_processor.write_csv(test_accuracy_csv_file, new_test_accuracy_row)   
+
+                """If training has reached the last round, the csv file is transposed for readability"""
+                if (self.current_round == Config().trainer.rounds):
+                    csv_processor.transpose_csv(test_accuracy_csv_file)
 
             result_csv_file = f"{Config().params['result_dir']}/{os.getpid()}.csv"
             csv_processor.write_csv(result_csv_file, new_row)

--- a/plato/servers/fedavg.py
+++ b/plato/servers/fedavg.py
@@ -225,8 +225,6 @@ class Server(base.Server):
             if Config().clients.do_test:
                 # Updates the log for client test accuracies
                 accuracy_csv_file = f"{Config().params['result_dir']}/{os.getpid()}_accuracy.csv"
-
-                self.selected_clients.sort()
                 index = 0
                 for (report, __, __) in self.updates:
                     accuracy_row = [

--- a/plato/servers/fedavg.py
+++ b/plato/servers/fedavg.py
@@ -176,7 +176,7 @@ class Server(base.Server):
         await self.aggregate_weights(self.updates)
 
         # Testing the global model accuracy
-        if Config().clients.do_test:
+        if hasattr(Config().server, 'do_test') and not Config().server.do_test:
             # Compute the average accuracy from client reports
             self.accuracy = self.accuracy_averaging(self.updates)
             logging.info('[%s] Average client accuracy: %.2f%%.', self,

--- a/plato/servers/fedavg.py
+++ b/plato/servers/fedavg.py
@@ -109,13 +109,13 @@ class Server(base.Server):
             csv_processor.initialize_csv(result_csv_file, self.recorded_items,
                                          Config().params['result_dir'])
 
-        # Initializes a test accuracy csv file if test accuracies are computed locally
-        if Config().clients.do_test and hasattr(Config(), 'results'):
-            test_accuracy_csv_file = f"{Config().params['result_dir']}/{os.getpid()}_test_accuracy.csv"
-            test_accuracy_headers = ["round", "client_id", "test_accuracy"]
-            csv_processor.initialize_csv(test_accuracy_csv_file,
-                                         test_accuracy_headers,
-                                         Config().params['result_dir'])
+            # Initialize the test accuracy csv file if clients compute locally
+            if Config().clients.do_test:
+                test_accuracy_csv_file = f"{Config().params['result_dir']}/{os.getpid()}_test_accuracy.csv"
+                test_accuracy_headers = ["round", "client_id", "test_accuracy"]
+                csv_processor.initialize_csv(test_accuracy_csv_file,
+                                             test_accuracy_headers,
+                                             Config().params['result_dir'])
 
     def load_trainer(self):
         """Setting up the global model to be trained via federated learning."""

--- a/plato/servers/fedavg.py
+++ b/plato/servers/fedavg.py
@@ -110,7 +110,7 @@ class Server(base.Server):
             for item in self.recorded_items:
                 headers.append(item)
             for i in range(self.clients_per_round):
-                headers.append("Client " + str(i + 1))
+                headers.append("Client " + str(i + 1) + ' Accuracy')
             csv_processor.initialize_csv(result_csv_file, headers,
                                          Config().params['result_dir'])
 
@@ -216,7 +216,7 @@ class Server(base.Server):
                 }[item]
                 new_row.append(item_value)
             for (report, __, __) in self.updates:
-                new_row.append(report)
+                new_row.append(report.accuracy)
                  
             result_csv_file = f"{Config().params['result_dir']}/{os.getpid()}.csv"
             csv_processor.write_csv(result_csv_file, new_row)

--- a/plato/servers/fedavg.py
+++ b/plato/servers/fedavg.py
@@ -190,7 +190,8 @@ class Server(base.Server):
         """ Wrap up processing the reports with any additional work. """
         if hasattr(Config(), 'results'):
             new_row = []
-
+            for (report, __, __) in self.updates:
+                new_row.append(report.accuracy)
             for item in self.recorded_items:
                 item_value = {
                     'round':

--- a/plato/servers/fedavg.py
+++ b/plato/servers/fedavg.py
@@ -18,6 +18,7 @@ from plato.utils import csv_processor
 
 class Server(base.Server):
     """Federated learning server using federated averaging."""
+
     def __init__(self, model=None, algorithm=None, trainer=None):
         super().__init__()
 
@@ -46,7 +47,6 @@ class Server(base.Server):
             self.recorded_items = [
                 x.strip() for x in recorded_items.split(',')
             ]
-
 
     def configure(self):
         """
@@ -110,11 +110,12 @@ class Server(base.Server):
                                          Config().params['result_dir'])
 
         # Initializes a test accuracy csv file if test accuracies are computed locally
-        if (Config().clients.do_test and hasattr(Config(), 'results')):    
+        if Config().clients.do_test and hasattr(Config(), 'results'):
             test_accuracy_csv_file = f"{Config().params['result_dir']}/{os.getpid()}_test_accuracy.csv"
             test_accuracy_headers = ["round", "client_id", "test_accuracy"]
-            csv_processor.initialize_csv(test_accuracy_csv_file, test_accuracy_headers, Config().params['result_dir'])
-
+            csv_processor.initialize_csv(test_accuracy_csv_file,
+                                         test_accuracy_headers,
+                                         Config().params['result_dir'])
 
     def load_trainer(self):
         """Setting up the global model to be trained via federated learning."""
@@ -197,7 +198,7 @@ class Server(base.Server):
     async def wrap_up_processing_reports(self):
         """ Wrap up processing the reports with any additional work. """
         if hasattr(Config(), 'results'):
-            new_row = []           
+            new_row = []
             for item in self.recorded_items:
                 item_value = {
                     'round':
@@ -217,18 +218,22 @@ class Server(base.Server):
                     ]),
                 }[item]
                 new_row.append(item_value)
- 
+
             # Updates test accuracy csv file
-            if (Config().clients.do_test):  
-                test_accuracy_csv_file = f"{Config().params['result_dir']}/{os.getpid()}_test_accuracy.csv" 
+            if Config().clients.do_test:
+                test_accuracy_csv_file = f"{Config().params['result_dir']}/{os.getpid()}_test_accuracy.csv"
                 client_id = 1
                 for (report, __, __) in self.updates:
-                    test_accuracy_row = [self.current_round, client_id, report.accuracy]
-                    csv_processor.write_csv(test_accuracy_csv_file, test_accuracy_row) 
-                    client_id = client_id + 1     
+                    test_accuracy_row = [
+                        self.current_round, client_id, report.accuracy
+                    ]
+                    csv_processor.write_csv(test_accuracy_csv_file,
+                                            test_accuracy_row)
+                    client_id = client_id + 1
 
             result_csv_file = f"{Config().params['result_dir']}/{os.getpid()}.csv"
             csv_processor.write_csv(result_csv_file, new_row)
+
     @staticmethod
     def accuracy_averaging(updates):
         """Compute the average accuracy across clients."""

--- a/plato/servers/fedavg.py
+++ b/plato/servers/fedavg.py
@@ -225,7 +225,7 @@ class Server(base.Server):
                 client_id = 1
                 for (report, __, __) in self.updates:
                     test_accuracy_row = [
-                        self.current_round, client_id, report.accuracy
+                        self.current_round, client_id, report
                     ]
                     csv_processor.write_csv(test_accuracy_csv_file,
                                             test_accuracy_row)

--- a/plato/servers/fedavg.py
+++ b/plato/servers/fedavg.py
@@ -109,10 +109,10 @@ class Server(base.Server):
             csv_processor.initialize_csv(result_csv_file, self.recorded_items,
                                          Config().params['result_dir'])
 
-        #Initializes a test accuracy csv file if test accuracies are computed locally
-        if (Config().clients.do_test):    
-            test_accuracy_csv_file = f"{Config().params['result_dir']}/{os.getpid()}_Client_Test_Accuracy.csv"
-            test_accuracy_headers = ["Round", "Client ID", "Test Accuracy"]
+        # Initializes a test accuracy csv file if test accuracies are computed locally
+        if (Config().clients.do_test and hasattr(Config(), 'results')):    
+            test_accuracy_csv_file = f"{Config().params['result_dir']}/{os.getpid()}_test_accuracy.csv"
+            test_accuracy_headers = ["round", "client_id", "test_accuracy"]
             csv_processor.initialize_csv(test_accuracy_csv_file, test_accuracy_headers, Config().params['result_dir'])
 
 
@@ -217,10 +217,10 @@ class Server(base.Server):
                     ]),
                 }[item]
                 new_row.append(item_value)
-
-            """If the test accuracies are computed locally, it is written into the new csv file"""    
-            if (Config().clients.do_test): 
-                test_accuracy_csv_file = f"{Config().params['result_dir']}/{os.getpid()}_Client_Test_Accuracy.csv" 
+ 
+            # Updates test accuracy csv file
+            if (Config().clients.do_test and hasattr(Config(), 'results')):  
+                test_accuracy_csv_file = f"{Config().params['result_dir']}/{os.getpid()}_test_accuracy.csv" 
                 client_id = 1
                 for (report, __, __) in self.updates:
                     test_accuracy_row = [self.current_round, client_id, report.accuracy]

--- a/plato/servers/fedavg.py
+++ b/plato/servers/fedavg.py
@@ -238,13 +238,14 @@ class Server(base.Server):
                 # Updates the log for client test accuracies
                 accuracy_csv_file = f"{Config().params['result_dir']}/{os.getpid()}_accuracy.csv"
 
-                client_id = 1
+                self.selected_clients.sort()
+                index = 0
                 for (report, __, __) in self.updates:
                     accuracy_row = [
-                        self.current_round, client_id, report.accuracy
+                        self.current_round, self.selected_clients[index], report.accuracy
                     ]
+                    index = index + 1
                     csv_processor.write_csv(accuracy_csv_file, accuracy_row)
-                    client_id = client_id + 1
 
     @staticmethod
     def accuracy_averaging(updates):

--- a/plato/servers/fedavg.py
+++ b/plato/servers/fedavg.py
@@ -169,6 +169,7 @@ class Server(base.Server):
         # Testing the global model accuracy
         if Config().clients.do_test:
             # Compute the average accuracy from client reports
+            base = 4
             self.accuracy = self.accuracy_averaging(self.updates)
             logging.info('[%s] Average client accuracy: %.2f%%.', self,
                          100 * self.accuracy)

--- a/plato/servers/fedavg.py
+++ b/plato/servers/fedavg.py
@@ -219,7 +219,7 @@ class Server(base.Server):
                 new_row.append(item_value)
  
             # Updates test accuracy csv file
-            if (Config().clients.do_test and hasattr(Config(), 'results')):  
+            if (Config().clients.do_test):  
                 test_accuracy_csv_file = f"{Config().params['result_dir']}/{os.getpid()}_test_accuracy.csv" 
                 client_id = 1
                 for (report, __, __) in self.updates:

--- a/plato/servers/fedavg.py
+++ b/plato/servers/fedavg.py
@@ -81,7 +81,8 @@ class Server(base.Server):
         self.outbound_processor, self.inbound_processor = processor_registry.get(
             "Server", server_id=os.getpid(), trainer=self.trainer)
 
-        if not Config().clients.do_test:
+        if not Config().clients.do_test or (hasattr(Config().server, 'do_test')
+                                            and Config().server.do_test):
             self.datasource = datasources_registry.get(client_id=0)
             self.testset = self.datasource.get_test_set()
 
@@ -176,15 +177,16 @@ class Server(base.Server):
         await self.aggregate_weights(self.updates)
 
         # Testing the global model accuracy
-        if hasattr(Config().server, 'do_test') and not Config().server.do_test:
+        if not Config().clients.do_test or (hasattr(Config().server, 'do_test')
+                                            and Config().server.do_test):
+            # Testing the updated model directly at the server
+            self.accuracy = await self.trainer.server_test(
+                self.testset, self.testset_sampler)
+        else:
             # Compute the average accuracy from client reports
             self.accuracy = self.accuracy_averaging(self.updates)
             logging.info('[%s] Average client accuracy: %.2f%%.', self,
                          100 * self.accuracy)
-        else:
-            # Testing the updated model directly at the server
-            self.accuracy = await self.trainer.server_test(
-                self.testset, self.testset_sampler)
 
         if hasattr(Config().trainer, 'target_perplexity'):
             logging.info('[%s] Global model perplexity: %.2f\n', self,

--- a/plato/servers/fedavg.py
+++ b/plato/servers/fedavg.py
@@ -219,18 +219,6 @@ class Server(base.Server):
                 }[item]
                 new_row.append(item_value)
 
-            # Updates test accuracy csv file
-            if Config().clients.do_test:
-                test_accuracy_csv_file = f"{Config().params['result_dir']}/{os.getpid()}_test_accuracy.csv"
-                client_id = 1
-                for (report, __, __) in self.updates:
-                    test_accuracy_row = [
-                        self.current_round, client_id, report
-                    ]
-                    csv_processor.write_csv(test_accuracy_csv_file,
-                                            test_accuracy_row)
-                    client_id = client_id + 1
-
             result_csv_file = f"{Config().params['result_dir']}/{os.getpid()}.csv"
             csv_processor.write_csv(result_csv_file, new_row)
 
@@ -242,7 +230,8 @@ class Server(base.Server):
                 index = 0
                 for (report, __, __) in self.updates:
                     accuracy_row = [
-                        self.current_round, self.selected_clients[index], report.accuracy
+                        self.current_round, self.selected_clients[index],
+                        report.accuracy
                     ]
                     index = index + 1
                     csv_processor.write_csv(accuracy_csv_file, accuracy_row)

--- a/plato/servers/fedavg.py
+++ b/plato/servers/fedavg.py
@@ -103,17 +103,17 @@ class Server(base.Server):
                 self.testset_sampler = torch.utils.data.SubsetRandomSampler(
                     test_samples, generator=gen)
 
-        # Initialize the csv files which will record results
+        # Initialize the csv file which will record results
         if hasattr(Config(), 'results'):
             result_csv_file = f"{Config().params['result_dir']}/{os.getpid()}.csv"
-            test_accuracy_csv_file = f"{Config().params['result_dir']}/{os.getpid()}_Client_Test_Accuracy.csv"
             csv_processor.initialize_csv(result_csv_file, self.recorded_items,
                                          Config().params['result_dir'])
 
         #Initializes a test accuracy csv file if test accuracies are computed locally
         if (Config().clients.do_test):    
-            client_headers = ["Round", "Client ID", "Test Accuracy"]
-            csv_processor.initialize_csv(test_accuracy_csv_file, client_headers, Config().params['result_dir'])
+            test_accuracy_csv_file = f"{Config().params['result_dir']}/{os.getpid()}_Client_Test_Accuracy.csv"
+            test_accuracy_headers = ["Round", "Client ID", "Test Accuracy"]
+            csv_processor.initialize_csv(test_accuracy_csv_file, test_accuracy_headers, Config().params['result_dir'])
 
 
     def load_trainer(self):
@@ -226,7 +226,7 @@ class Server(base.Server):
                     test_accuracy_row = [self.current_round, client_id, report.accuracy]
                     csv_processor.write_csv(test_accuracy_csv_file, test_accuracy_row) 
                     client_id = client_id + 1     
-                    
+
             result_csv_file = f"{Config().params['result_dir']}/{os.getpid()}.csv"
             csv_processor.write_csv(result_csv_file, new_row)
     @staticmethod

--- a/plato/servers/fedavg.py
+++ b/plato/servers/fedavg.py
@@ -169,7 +169,6 @@ class Server(base.Server):
         # Testing the global model accuracy
         if Config().clients.do_test:
             # Compute the average accuracy from client reports
-            base = 4
             self.accuracy = self.accuracy_averaging(self.updates)
             logging.info('[%s] Average client accuracy: %.2f%%.', self,
                          100 * self.accuracy)

--- a/plato/servers/fedavg.py
+++ b/plato/servers/fedavg.py
@@ -112,10 +112,7 @@ class Server(base.Server):
 
         #Initializes a test accuracy csv file if test accuracies are computed locally
         if (Config().clients.do_test):    
-            client_headers = []
-            client_headers.append("")
-            for i in range(Config().clients.per_round):
-                client_headers.append("Client " + str(i + 1))
+            client_headers = ["Round", "Client ID", "Test Accuracy"]
             csv_processor.initialize_csv(test_accuracy_csv_file, client_headers, Config().params['result_dir'])
 
 
@@ -223,17 +220,13 @@ class Server(base.Server):
 
             """If the test accuracies are computed locally, it is written into the new csv file"""    
             if (Config().clients.do_test): 
-                new_test_accuracy_row = []
-                new_test_accuracy_row.append(f"Round {self.current_round}")
+                test_accuracy_csv_file = f"{Config().params['result_dir']}/{os.getpid()}_Client_Test_Accuracy.csv" 
+                client_id = 1
                 for (report, __, __) in self.updates:
-                    new_test_accuracy_row.append(report.accuracy)
-                test_accuracy_csv_file = f"{Config().params['result_dir']}/{os.getpid()}_Client_Test_Accuracy.csv"    
-                csv_processor.write_csv(test_accuracy_csv_file, new_test_accuracy_row)   
-
-                """If training has reached the last round, the csv file is transposed for readability"""
-                if (self.current_round == Config().trainer.rounds):
-                    csv_processor.transpose_csv(test_accuracy_csv_file)
-
+                    test_accuracy_row = [self.current_round, client_id, report.accuracy]
+                    csv_processor.write_csv(test_accuracy_csv_file, test_accuracy_row) 
+                    client_id = client_id + 1     
+                    
             result_csv_file = f"{Config().params['result_dir']}/{os.getpid()}.csv"
             csv_processor.write_csv(result_csv_file, new_row)
     @staticmethod

--- a/plato/servers/fedavg_cs.py
+++ b/plato/servers/fedavg_cs.py
@@ -18,6 +18,7 @@ from plato.utils import csv_processor
 
 class Server(fedavg.Server):
     """Cross-silo federated learning server using federated averaging."""
+
     def __init__(self, model=None, algorithm=None, trainer=None):
         super().__init__(model=model, algorithm=algorithm, trainer=trainer)
 
@@ -199,11 +200,11 @@ class Server(fedavg.Server):
         """Compute the average accuracy across clients."""
         # Get total number of samples
         total_samples = sum(
-            [report.num_samples for (report, __, __) in self.updates])
+            [report.num_samples for (__, report, __, __) in self.updates])
 
         # Perform weighted averaging
         accuracy = 0
-        for (report, __, __) in self.updates:
+        for (__, report, __, __) in self.updates:
             accuracy += report.average_accuracy * (report.num_samples /
                                                    total_samples)
 
@@ -255,11 +256,11 @@ class Server(fedavg.Server):
             'elapsed_time':
             self.wall_time - self.initial_wall_time,
             'comm_time':
-            max([report.comm_time for (report, __, __) in self.updates]),
+            max([report.comm_time for (__, report, __, __) in self.updates]),
             'round_time':
             max([
                 report.training_time + report.comm_time
-                for (report, __, __) in self.updates
+                for (__, report, __, __) in self.updates
             ]),
         }
 

--- a/plato/utils/csv_processor.py
+++ b/plato/utils/csv_processor.py
@@ -14,7 +14,11 @@ def initialize_csv(result_csv_file: str, recorded_items: List,
     if not os.path.exists(result_dir):
         os.makedirs(result_dir)
 
-    with open(result_csv_file, 'w', encoding='utf-8',) as result_file:
+    with open(
+            result_csv_file,
+            'w',
+            encoding='utf-8',
+    ) as result_file:
         result_writer = csv.writer(result_file)
         first_row = recorded_items
         result_writer.writerow(first_row)
@@ -22,6 +26,10 @@ def initialize_csv(result_csv_file: str, recorded_items: List,
 
 def write_csv(result_csv_file: str, new_row: List) -> None:
     """ Write the results of current round. """
-    with open(result_csv_file, 'a', encoding='utf-8',) as result_file:
+    with open(
+            result_csv_file,
+            'a',
+            encoding='utf-8',
+    ) as result_file:
         result_writer = csv.writer(result_file)
         result_writer.writerow(new_row)

--- a/plato/utils/csv_processor.py
+++ b/plato/utils/csv_processor.py
@@ -20,39 +20,13 @@ def initialize_csv(result_csv_file: str, recorded_items: List,
         first_row = recorded_items
         result_writer.writerow(first_row)
 
-def initialize_accuracy_csv(result_csv_file: str, num_rounds: List, num_clients: List,
-                   result_dir: str) -> None:
-    """Creates csv file for the test accuracy"""
-    if not os.path.exists(result_dir):
-        os.makedirs(result_dir)
-
-    with open(result_csv_file, 'w', encoding='utf-8',
-              newline='') as result_file:
-
-        result_writer = csv.writer(result_file)
-        first_row = num_rounds
-        result_writer.writerow(first_row)
-
-        for i in range(len(num_clients) - 1):
-            result_writer.writerow([num_clients[i + 1]])
-
-
 def write_csv(result_csv_file: str, new_row: List) -> None:
     """ Write the results of current round. """
-    with open(result_csv_file, 'a', encoding='utf-8') as result_file:
+    with open(result_csv_file, 'a', encoding='utf-8', newline = '') as result_file:
         result_writer = csv.writer(result_file)
         result_writer.writerow(new_row)
 
-def write_csv_column(result_csv_file: str, new_column: List) -> None:
-    """ Writes the test accuracies of current round. """
-    with open(result_csv_file, 'r', encoding='utf-8') as result_file:
-        csv_reader = csv.reader(result_file)
-        data = list(csv_reader)
-        for i in range(1, len(data)):
-            data[i].append(new_column[i - 1])
-
-
-    with open(result_csv_file, 'w', encoding='utf-8', newline = '') as result_file:
-        result_writer = csv.writer(result_file)
-        for i in range(len(data)):
-            result_writer.writerow(data[i])
+def transpose_csv(result_csv_file: str) -> None:
+    """ Transposes the csv """
+    transpose = zip(*csv.reader(open(result_csv_file, "r")))
+    csv.writer(open(result_csv_file, "w", newline = '')).writerows(transpose)

--- a/plato/utils/csv_processor.py
+++ b/plato/utils/csv_processor.py
@@ -25,8 +25,3 @@ def write_csv(result_csv_file: str, new_row: List) -> None:
     with open(result_csv_file, 'a', encoding='utf-8', newline = '') as result_file:
         result_writer = csv.writer(result_file)
         result_writer.writerow(new_row)
-
-def transpose_csv(result_csv_file: str) -> None:
-    """ Transposes the csv """
-    transpose = zip(*csv.reader(open(result_csv_file, "r")))
-    csv.writer(open(result_csv_file, "w", newline = '')).writerows(transpose)

--- a/plato/utils/csv_processor.py
+++ b/plato/utils/csv_processor.py
@@ -20,8 +20,10 @@ def initialize_csv(result_csv_file: str, recorded_items: List,
         first_row = recorded_items
         result_writer.writerow(first_row)
 
+
 def write_csv(result_csv_file: str, new_row: List) -> None:
     """ Write the results of current round. """
-    with open(result_csv_file, 'a', encoding='utf-8', newline = '') as result_file:
+    with open(result_csv_file, 'a', encoding='utf-8',
+              newline='') as result_file:
         result_writer = csv.writer(result_file)
         result_writer.writerow(new_row)

--- a/plato/utils/csv_processor.py
+++ b/plato/utils/csv_processor.py
@@ -14,22 +14,14 @@ def initialize_csv(result_csv_file: str, recorded_items: List,
     if not os.path.exists(result_dir):
         os.makedirs(result_dir)
 
-    with open(
-            result_csv_file,
-            'w',
-            encoding='utf-8',
-    ) as result_file:
+    with open(result_csv_file, 'w', encoding='utf-8') as result_file:
         result_writer = csv.writer(result_file)
-        first_row = recorded_items
-        result_writer.writerow(first_row)
+        header_row = recorded_items
+        result_writer.writerow(header_row)
 
 
 def write_csv(result_csv_file: str, new_row: List) -> None:
     """ Write the results of current round. """
-    with open(
-            result_csv_file,
-            'a',
-            encoding='utf-8',
-    ) as result_file:
+    with open(result_csv_file, 'a', encoding='utf-8') as result_file:
         result_writer = csv.writer(result_file)
         result_writer.writerow(new_row)

--- a/plato/utils/csv_processor.py
+++ b/plato/utils/csv_processor.py
@@ -48,12 +48,11 @@ def write_csv_column(result_csv_file: str, new_column: List) -> None:
     with open(result_csv_file, 'r', encoding='utf-8') as result_file:
         csv_reader = csv.reader(result_file)
         data = list(csv_reader)
-        data = [x for x in data if x != []]
         for i in range(1, len(data)):
             data[i].append(new_column[i - 1])
 
 
-    with open(result_csv_file, 'w', encoding='utf-8') as result_file:
+    with open(result_csv_file, 'w', encoding='utf-8', newline = '') as result_file:
         result_writer = csv.writer(result_file)
         for i in range(len(data)):
             result_writer.writerow(data[i])

--- a/plato/utils/csv_processor.py
+++ b/plato/utils/csv_processor.py
@@ -20,9 +20,40 @@ def initialize_csv(result_csv_file: str, recorded_items: List,
         first_row = recorded_items
         result_writer.writerow(first_row)
 
+def initialize_accuracy_csv(result_csv_file: str, num_rounds: List, num_clients: List,
+                   result_dir: str) -> None:
+    """Creates csv file for the test accuracy"""
+    if not os.path.exists(result_dir):
+        os.makedirs(result_dir)
+
+    with open(result_csv_file, 'w', encoding='utf-8',
+              newline='') as result_file:
+
+        result_writer = csv.writer(result_file)
+        first_row = num_rounds
+        result_writer.writerow(first_row)
+
+        for i in range(len(num_clients) - 1):
+            result_writer.writerow([num_clients[i + 1]])
+
 
 def write_csv(result_csv_file: str, new_row: List) -> None:
     """ Write the results of current round. """
     with open(result_csv_file, 'a', encoding='utf-8') as result_file:
         result_writer = csv.writer(result_file)
         result_writer.writerow(new_row)
+
+def write_csv_column(result_csv_file: str, new_column: List) -> None:
+    """ Writes the test accuracies of current round. """
+    with open(result_csv_file, 'r', encoding='utf-8') as result_file:
+        csv_reader = csv.reader(result_file)
+        data = list(csv_reader)
+        data = [x for x in data if x != []]
+        for i in range(1, len(data)):
+            data[i].append(new_column[i - 1])
+
+
+    with open(result_csv_file, 'w', encoding='utf-8') as result_file:
+        result_writer = csv.writer(result_file)
+        for i in range(len(data)):
+            result_writer.writerow(data[i])

--- a/plato/utils/csv_processor.py
+++ b/plato/utils/csv_processor.py
@@ -14,8 +14,7 @@ def initialize_csv(result_csv_file: str, recorded_items: List,
     if not os.path.exists(result_dir):
         os.makedirs(result_dir)
 
-    with open(result_csv_file, 'w', encoding='utf-8',
-              newline='') as result_file:
+    with open(result_csv_file, 'w', encoding='utf-8',) as result_file:
         result_writer = csv.writer(result_file)
         first_row = recorded_items
         result_writer.writerow(first_row)
@@ -23,7 +22,6 @@ def initialize_csv(result_csv_file: str, recorded_items: List,
 
 def write_csv(result_csv_file: str, new_row: List) -> None:
     """ Write the results of current round. """
-    with open(result_csv_file, 'a', encoding='utf-8',
-              newline='') as result_file:
+    with open(result_csv_file, 'a', encoding='utf-8',) as result_file:
         result_writer = csv.writer(result_file)
         result_writer.writerow(new_row)

--- a/plato/utils/reinforcement_learning/rl_server.py
+++ b/plato/utils/reinforcement_learning/rl_server.py
@@ -17,6 +17,7 @@ from plato.trainers import registry as trainers_registry
 
 class RLServer(fedavg.Server):
     """ A federated learning server with an RL Agent. """
+
     def __init__(self, agent, model=None, algorithm=None, trainer=None):
         super().__init__(model=model, algorithm=algorithm, trainer=trainer)
         self.agent = agent
@@ -40,7 +41,7 @@ class RLServer(fedavg.Server):
         self.update_state()
 
         # Extract the total number of samples
-        num_samples = [report.num_samples for (report, __, __) in updates]
+        num_samples = [report.num_samples for (__, report, __, __) in updates]
         self.total_samples = sum(num_samples)
 
         # Perform weighted averaging


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When running a job, if the configuration file has the attribute "do_test" set to true and if there also exists a "results" attribute, then the test accuracies of each client will be computed locally and stored in a csv file with the round number, client ID and test accuracy as headers.
<!--- Describe motivation and context -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
Tested on local machine using the "fedavg_async_lenet5" configuration file  with 1-3 clients. Each with 1-3 rounds after setting "do_test" to True and another time to False
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) Fixes #
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
