### PR TITLE
Supported launching the number of clients necessary for active training (specified as `max_concurrency` in the configuration file) in client simulation mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ If runtime exceptions occur that prevent a federated learning session from runni
 
 * Out of CUDA memory.
 
-  *Potential solutions:* Decrease the number of clients selected in each round (with the *client simulation mode* turned on); decrease the `max_concurrency` value in the `trainer` section in your configuration file; decrease the  `batch_size` used in the `trainer` section.
+  *Potential solutions:* Decrease the `max_concurrency` value in the `trainer` section in your configuration file.
  
 * The time that a client waits for the server to respond before disconnecting is too short. This could happen when training with large neural network models. If you get an `AssertionError` saying that there are not enough launched clients for the server to select, this could be the reason. But make sure you first check if it is due to the *out of CUDA memory* error.
 
@@ -208,7 +208,7 @@ If runtime exceptions occur that prevent a federated learning session from runni
 
 ### Client simulation mode
 
-Plato supports a *client simulation mode*, in which the actual number of client processes launched equals the number of clients to be selected by the server per round, rather than the total number of clients. This supports a simulated federated learning environment, where the set of selected clients by the server will be simulated by the set of client processes actually running. For example, with a total of 10000 clients, if the server only needs to select 100 of them to train their models in each round, only 100 client processes will be launched in client simulation mode, and a client process may assume a different client ID in each round.
+Plato supports a *client simulation mode*, in which the actual number of client processes launched equals the number of clients needed for concurrently active training (defined in `max_concurrency` in the `trainer` section of the configuration file), rather than the total number of clients. This supports a simulated federated learning environment, where the set of selected clients by the server will be simulated by the set of client processes actually running. For example, with a total of 10000 clients and 1000 clients selected, if only 5 clients can train concurrently in the federated learning session due to limits of CUDA memory, then the same number of clients will be launched as separate processes. Each client process may assume different client IDs in client simulation mode.
 
 To turn on the client simulation mode, add `simulation: true` to the `clients` section in the configuration file.
 

--- a/configs/CIFAR10/fedavg_resnet18.yml
+++ b/configs/CIFAR10/fedavg_resnet18.yml
@@ -3,27 +3,30 @@ clients:
     type: simple
 
     # The total number of clients
-    total_clients: 3
+    total_clients: 100 
 
     # The number of clients selected in each round
-    per_round: 2
+    per_round: 12 
 
     # Should the clients compute test accuracy locally?
     do_test: false
 
+    # Client simulation mode
+    simulation: true
+
 server:
     address: 127.0.0.1
-    port: 8000
+    port: 8020
 
 data:
     # The training and testing dataset
     datasource: CIFAR10
 
     # Where the dataset is located
-    data_path: ./data
+    data_path: /data/bli/data
 
     # Number of samples in each partition
-    partition_size: 20000
+    partition_size: 30000
 
     # IID or non-IID?
     sampler: iid
@@ -33,13 +36,13 @@ trainer:
     type: basic
 
     # The maximum number of training rounds
-    rounds: 10000
+    rounds: 10 
 
     # Whether the training should use multiple GPUs if available
     parallelized: true
 
     # The maximum number of clients running concurrently
-    max_concurrency: 2
+    max_concurrency: 6
 
     # The target accuracy
     target_accuracy: 0.80

--- a/configs/CIFAR10/fedavg_resnet18.yml
+++ b/configs/CIFAR10/fedavg_resnet18.yml
@@ -3,10 +3,10 @@ clients:
     type: simple
 
     # The total number of clients
-    total_clients: 100 
+    total_clients: 100
 
     # The number of clients selected in each round
-    per_round: 12 
+    per_round: 20
 
     # Should the clients compute test accuracy locally?
     do_test: false
@@ -23,7 +23,7 @@ data:
     datasource: CIFAR10
 
     # Where the dataset is located
-    data_path: /data/bli/data
+    data_path: ./data
 
     # Number of samples in each partition
     partition_size: 30000
@@ -36,7 +36,7 @@ trainer:
     type: basic
 
     # The maximum number of training rounds
-    rounds: 10 
+    rounds: 10
 
     # Whether the training should use multiple GPUs if available
     parallelized: true

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -17,7 +17,7 @@ Attributes in **bold** must be included in a configuration file, while attribute
 |**total_clients**|The total number of clients|A positive number||
 |**per_round**|The number of clients selected in each round| Any positive integer that is not larger than **total_clients**||
 |**do_test**|Should the clients compute test accuracy locally?| `true` or `false`|| 
-|simulation|Should we turn on the client simulation mode? When this is turned on, the number of client processes started is equal to the number of clients per round, rather than the total number of clients.|
+|simulation|Should we turn on the client simulation mode? When this is turned on, the number of client processes started is equal to `max_concurrency`, rather than the total number of clients.|
 |speed_simulation|Should we simulate client heterogeneity in training speed?|
 |simulation_distribution|Parameters for simulating client heterogeneity in training speed|`distribution`|`normal` for normal or `zipf` for Zipf|
 |||`s`|the parameter `s` in Zipf distribution|

--- a/docs/Running.md
+++ b/docs/Running.md
@@ -175,7 +175,7 @@ If runtime exceptions occur that prevent a federated learning session from runni
 
 * Out of CUDA memory.
 
-  *Potential solutions:* Decrease the number of clients selected in each round (with the *client simulation mode* turned on); decrease the `max_concurrency` value in the `trainer` section in your configuration file; decrease the  `batch_size` used in the `trainer` section.
+  *Potential solutions:* Decrease the `max_concurrency` value in the `trainer` section in your configuration file.
  
 * The time that a client waits for the server to respond before disconnecting is too short. This could happen when training with large neural network models. If you get an `AssertionError` saying that there are not enough launched clients for the server to select, this could be the reason. But make sure you first check if it is due to the *out of CUDA memory* error.
 

--- a/examples/adaptive_hgb/adaptive_hgb_trainer.py
+++ b/examples/adaptive_hgb/adaptive_hgb_trainer.py
@@ -359,7 +359,6 @@ class Trainer(basic.Trainer):
         Returns:
             Whether training was successfully completed.
         """
-        self.start_training()
 
         if mp.get_start_method(allow_none=True) != 'spawn':
             mp.set_start_method('spawn', force=True)

--- a/plato/config.py
+++ b/plato/config.py
@@ -6,7 +6,6 @@ import argparse
 import json
 import logging
 import os
-import sqlite3
 from collections import OrderedDict, namedtuple
 from typing import Any, IO
 
@@ -18,6 +17,7 @@ from plato.utils.available_gpu import available_gpu
 
 class Loader(yaml.SafeLoader):
     """ YAML Loader with `!include` constructor. """
+
     def __init__(self, stream: IO) -> None:
         """Initialise Loader."""
 
@@ -186,13 +186,6 @@ class Config:
 
             if 'model' in config:
                 Config.model = Config.namedtuple_from_dict(config['model'])
-
-            if hasattr(Config().trainer, 'max_concurrency'):
-                # Using a temporary SQLite database to limit the maximum number of concurrent
-                # trainers
-                Config.sql_connection = sqlite3.connect(
-                    f"{Config.params['result_dir']}/running_trainers.sqlitedb")
-                Config().cursor = Config.sql_connection.cursor()
 
         return cls._instance
 

--- a/plato/servers/base.py
+++ b/plato/servers/base.py
@@ -126,6 +126,11 @@ class Server:
 
         Server.client_simulation_mode = False
 
+        # With specifying max_concurrency, clients train batch by batach
+        # This parameter is the number of selected clients that has trained
+        if hasattr(Config().trainer, 'max_concurrency'):
+            self.trained_clients_num = 0
+
     def __repr__(self):
         return f'Server #{os.getpid()}'
 
@@ -263,7 +268,9 @@ class Server:
                          client_id)
 
         if (self.current_round == 0 or self.resumed_session) and len(
-                self.clients) >= self.clients_per_round:
+                self.clients) >= Config().trainer.max_concurrency if hasattr(
+                    Config().trainer,
+                    'max_concurrency') else self.clients_per_round:
             logging.info("[%s] Starting training.", self)
             self.resumed_session = False
             await self.select_clients()
@@ -279,8 +286,13 @@ class Server:
 
         if Server.client_simulation_mode:
             # In the client simulation mode, we only need to launch a limited
-            # number of client objects (same as the number of clients per round)
-            client_processes = Config().clients.per_round
+            # number of client objects
+            # If max_concurency is specified, the limite number is the same as max_concurrency
+            if hasattr(Config().trainer, 'max_concurrency'):
+                client_processes = Config().trainer.max_concurrency
+            # Otherwise, the limited number is the same as the number of clients per round
+            else:
+                client_processes = Config().clients.per_round
         else:
             client_processes = Config().clients.total_clients
 
@@ -316,86 +328,112 @@ class Server:
             logging.info("Closing the connection to client #%d.", client_id)
             await self.sio.emit('disconnect', room=client['sid'])
 
-    async def select_clients(self):
+    async def select_clients(self, for_next_batch=False):
         """ Select a subset of the clients and send messages to them to start training. """
-        self.updates = []
-        self.current_round += 1
+        if not for_next_batch:
+            self.updates = []
+            self.current_round += 1
 
-        logging.info("\n[%s] Starting round %s/%s.", self, self.current_round,
-                     Config().trainer.rounds)
+            logging.info("\n[%s] Starting round %s/%s.", self,
+                         self.current_round,
+                         Config().trainer.rounds)
 
-        if Server.client_simulation_mode:
-            # In the client simulation mode, the client pool for client selection contains
-            # all the virtual clients to be simulated
-            self.clients_pool = list(range(1, 1 + self.total_clients))
-            if Config().is_central_server():
-                self.clients_pool = list(
-                    range(Config().clients.per_round + 1,
-                          Config().clients.per_round + 1 + self.total_clients))
+            if Server.client_simulation_mode:
+                # In the client simulation mode, the client pool for client selection contains
+                # all the virtual clients to be simulated
+                self.clients_pool = list(range(1, 1 + self.total_clients))
 
-        else:
-            # If no clients are simulated, the client pool for client selection consists of
-            # the current set of clients that have contacted the server
-            self.clients_pool = list(self.clients)
+                if Config().is_central_server():
+                    launched_client_num = Config(
+                    ).trainer.max_concurrency if hasattr(
+                        Config().trainer,
+                        'max_concurrency') else Config().clients.per_round
+                    # In cross-silo FL, the central server selects from the pool of edge servers
+                    self.clients_pool = list(
+                        range(launched_client_num + 1,
+                              launched_client_num + 1 + self.total_clients))
+            else:
+                # If no clients are simulated, the client pool for client selection consists of
+                # the current set of clients that have contacted the server
+                self.clients_pool = list(self.clients)
 
-        # In asychronous FL, avoid selecting new clients to replace those that are still
-        # training at this time
+            # In asychronous FL, avoid selecting new clients to replace those that are still
+            # training at this time
 
-        # When simulating the wall clock time, if len(self.reported_clients) is 0, the
-        # server has aggregated all reporting clients already
-        if self.asynchronous_mode and self.selected_clients is not None and len(
-                self.reported_clients) > 0 and len(
-                    self.reported_clients) < self.clients_per_round:
-            # If self.selected_clients is None, it implies that it is the first iteration;
-            # If len(self.reported_clients) == self.clients_per_round, it implies that
-            # all selected clients have already reported.
+            # When simulating the wall clock time, if len(self.reported_clients) is 0, the
+            # server has aggregated all reporting clients already
+            if self.asynchronous_mode and self.selected_clients is not None and len(
+                    self.reported_clients) > 0 and len(
+                        self.reported_clients) < self.clients_per_round:
+                # If self.selected_clients is None, it implies that it is the first iteration;
+                # If len(self.reported_clients) == self.clients_per_round, it implies that
+                # all selected clients have already reported.
 
-            # Except for these two cases, we need to exclude the clients who are still
-            # training.
-            training_client_ids = [
-                self.training_clients[client_id]['id']
-                for client_id in list(self.training_clients.keys())
-            ]
+                # Except for these two cases, we need to exclude the clients who are still
+                # training.
+                training_client_ids = [
+                    self.training_clients[client_id]['id']
+                    for client_id in list(self.training_clients.keys())
+                ]
 
-            # If the server is simulating the wall clock time, some of the clients who
-            # reported may not have been aggregated; they should be excluded from the next
-            # round of client selection
-            reporting_client_ids = [
-                client[1]['client_id'] for client in self.reported_clients
-            ]
+                # If the server is simulating the wall clock time, some of the clients who
+                # reported may not have been aggregated; they should be excluded from the next
+                # round of client selection
+                reporting_client_ids = [
+                    client[1]['client_id'] for client in self.reported_clients
+                ]
 
-            selectable_clients = [
-                client for client in self.clients_pool
-                if client not in training_client_ids
-                and client not in reporting_client_ids
-            ]
+                selectable_clients = [
+                    client for client in self.clients_pool
+                    if client not in training_client_ids
+                    and client not in reporting_client_ids
+                ]
 
-            if self.simulate_wall_time:
-                self.selected_clients = self.choose_clients(
-                    selectable_clients, len(self.current_processed_clients))
+                if self.simulate_wall_time:
+                    self.selected_clients = self.choose_clients(
+                        selectable_clients,
+                        len(self.current_processed_clients))
+                else:
+                    self.selected_clients = self.choose_clients(
+                        selectable_clients, len(self.reported_clients))
             else:
                 self.selected_clients = self.choose_clients(
-                    selectable_clients, len(self.reported_clients))
-        else:
-            self.selected_clients = self.choose_clients(
-                self.clients_pool, self.clients_per_round)
+                    self.clients_pool, self.clients_per_round)
 
-        self.current_reported_clients = {}
-        self.current_processed_clients = {}
+            self.current_reported_clients = {}
+            self.current_processed_clients = {}
 
-        # There is no need to clear the list of reporting clients if we are
-        # simulating the wall clock time on the server. This is because
-        # when wall clock time is simulated, the server needs to wait for
-        # all the clients to report before selecting a subset of clients for
-        # replacement, and all remaining reporting clients will be processed
-        # in the next round
-        if not self.simulate_wall_time:
-            self.reported_clients = []
+            # There is no need to clear the list of reporting clients if we are
+            # simulating the wall clock time on the server. This is because
+            # when wall clock time is simulated, the server needs to wait for
+            # all the clients to report before selecting a subset of clients for
+            # replacement, and all remaining reporting clients will be processed
+            # in the next round
+            if not self.simulate_wall_time:
+                self.reported_clients = []
 
         if len(self.selected_clients) > 0:
             self.selected_sids = []
 
-            for i, selected_client_id in enumerate(self.selected_clients):
+            # With specifying max_concurrency, selected clients run batch by batach
+            # The number of clients in each batch is equal to max_concurrency
+            if hasattr(Config().trainer, 'max_concurrency'):
+                selected_clients = self.selected_clients[
+                    self.trained_clients_num:min(
+                        self.trained_clients_num + Config().trainer.
+                        max_concurrency, len(self.selected_clients))]
+                self.trained_clients_num = min(
+                    self.trained_clients_num +
+                    Config().trainer.max_concurrency,
+                    len(self.selected_clients))
+
+                # Prepare for the next round after selecting the last batch of this round
+                if self.trained_clients_num == len(self.selected_clients):
+                    self.trained_clients_num = 0
+            else:
+                selected_clients = self.selected_clients
+
+            for i, selected_client_id in enumerate(selected_clients):
                 self.selected_client_id = selected_client_id
 
                 if self.client_simulation_mode:
@@ -822,6 +860,13 @@ class Server:
 
             logging.info("[%s] Advancing the wall clock time to %.2f.", self,
                          self.wall_time)
+
+        if hasattr(Config().trainer, 'max_concurrency'):
+            # Clients in the current batch finish training
+            # The server will select the next batch of clients to train
+            if len(self.updates) >= self.trained_clients_num and len(
+                    self.updates) < self.clients_per_round:
+                await self.select_clients(for_next_batch=True)
 
         # If all updates have been received from selected clients, the aggregation process
         # proceeds regardless of synchronous or asynchronous modes. This guarantees that

--- a/plato/servers/base.py
+++ b/plato/servers/base.py
@@ -126,8 +126,9 @@ class Server:
 
         Server.client_simulation_mode = False
 
-        # With specifying max_concurrency, clients train batch by batach
-        # This parameter is the number of selected clients that has trained
+        # With specifying max_concurrency, selected clients run batch by batach
+        # The number of clients in a batch is the same as the max_concurrency
+        # This parameter is the number of selected clients that has run in the current round
         if hasattr(Config().trainer, 'max_concurrency'):
             self.trained_clients_num = 0
 
@@ -418,8 +419,9 @@ class Server:
         if len(self.selected_clients) > 0:
             self.selected_sids = []
 
-            # With specifying max_concurrency, selected clients run batch by batach
-            # The number of clients in each batch is equal to max_concurrency
+            # With specifying max_concurrency, run selected clients batch by batach
+            # The number of clients in each batch is equal to
+            # (or maybe smaller than for the last batch) max_concurrency
             if hasattr(Config().trainer, 'max_concurrency'):
                 selected_clients = self.selected_clients[
                     self.trained_clients_num:min(

--- a/plato/servers/base.py
+++ b/plato/servers/base.py
@@ -283,9 +283,8 @@ class Server:
         starting_id = 1
 
         if Server.client_simulation_mode:
-            # In the client simulation mode, we only need to launch a limited
-            # number of client objects
-            # If max_concurency is specified, the limite number is the same as max_concurrency
+            # In the client simulation mode, we only need to launch the number of clients
+            # necessary for concurrent training, which is `max_concurrency` in `trainer`
             if hasattr(Config().trainer, 'max_concurrency'):
                 client_processes = Config().trainer.max_concurrency
             # Otherwise, the limited number is the same as the number of clients per round

--- a/plato/servers/base.py
+++ b/plato/servers/base.py
@@ -192,11 +192,6 @@ class Server:
             edge_client=None,
             trainer=None):
         """ Start a run loop for the server. """
-        # Remove the running trainers table from previous runs.
-        if not Config().is_edge_server() and hasattr(Config().trainer,
-                                                     'max_concurrency'):
-            with Config().sql_connection:
-                Config().cursor.execute("DROP TABLE IF EXISTS trainers")
 
         self.client = client
         self.configure()

--- a/plato/servers/fedavg.py
+++ b/plato/servers/fedavg.py
@@ -121,8 +121,8 @@ class Server(base.Server):
         if self.algorithm is None:
             self.algorithm = algorithms_registry.get(self.trainer)
 
-    async def select_clients(self):
-        await super().select_clients()
+    async def select_clients(self, for_next_batch=False):
+        await super().select_clients(for_next_batch=for_next_batch)
 
     def extract_client_updates(self, updates):
         """Extract the model weight updates from client updates."""

--- a/plato/servers/fedavg_cs.py
+++ b/plato/servers/fedavg_cs.py
@@ -127,8 +127,8 @@ class Server(fedavg.Server):
                                                  Config().data.testset_size)
                     self.testset_sampler = SubsetRandomSampler(test_samples)
 
-    async def select_clients(self):
-        if Config().is_edge_server():
+    async def select_clients(self, for_next_batch=False):
+        if Config().is_edge_server() and not for_next_batch:
             if self.current_round == 0:
                 # Wait until this edge server is selected by the central server
                 # to avoid the edge server selects clients and clients begin training
@@ -136,7 +136,7 @@ class Server(fedavg.Server):
                 await self.new_global_round_begins.wait()
                 self.new_global_round_begins.clear()
 
-        await super().select_clients()
+        await super().select_clients(for_next_batch=for_next_batch)
 
     async def customize_server_response(self, server_response):
         """Wrap up generating the server response with any additional information."""

--- a/plato/trainers/basic.py
+++ b/plato/trainers/basic.py
@@ -287,7 +287,6 @@ class Trainer(base.Trainer):
         self.training_start_time = time.time()
 
         if 'max_concurrency' in config:
-            self.start_training()
             tic = time.perf_counter()
 
             if mp.get_start_method(allow_none=True) != 'spawn':
@@ -305,10 +304,6 @@ class Trainer(base.Trainer):
             try:
                 self.load_model(filename)
             except OSError as error:  # the model file is not found, training failed
-                if 'max_concurrency' in config:
-                    self.run_sql_statement(
-                        "DELETE FROM trainers WHERE run_id = (?)",
-                        (self.client_id, ))
                 raise ValueError(
                     f"Training on client {self.client_id} failed.") from error
 
@@ -397,8 +392,6 @@ class Trainer(base.Trainer):
         config['run_id'] = Config().params['run_id']
 
         if hasattr(Config().trainer, 'max_concurrency'):
-            self.start_training()
-
             if mp.get_start_method(allow_none=True) != 'spawn':
                 mp.set_start_method('spawn', force=True)
 

--- a/plato/trainers/mindspore/basic.py
+++ b/plato/trainers/mindspore/basic.py
@@ -114,7 +114,6 @@ class Trainer(base.Trainer):
         Arguments:
         trainset: The training dataset.
         """
-        self.start_training()
         tic = time.perf_counter()
 
         self.mindspore_model.train(
@@ -135,7 +134,6 @@ class Trainer(base.Trainer):
         Arguments:
         testset: The test dataset.
         """
-        self.start_training()
 
         # Deactivate the cut layer so that testing uses all the layers
         self.mindspore_model._network.cut_layer = None

--- a/plato/trainers/tensorflow/basic.py
+++ b/plato/trainers/tensorflow/basic.py
@@ -17,7 +17,6 @@ class Trainer(base.Trainer):
     """A basic federated learning trainer for TensorFlow, used by both
     the client and the server.
     """
-
     def __init__(self, model=None):
         """Initializing the trainer with the provided model.
 
@@ -143,7 +142,6 @@ class Trainer(base.Trainer):
         config['run_id'] = Config().params['run_id']
         if hasattr(Config().trainer, 'max_concurrency'):
             # reserved for mp.Process
-            self.start_training()
             tic = time.perf_counter()
             self.train_process(config, trainset, sampler, cut_layer)
             toc = time.perf_counter()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

With this PR, Plato is able to launch only the number of clients necessary for active training in client simulation mode.

## Description
<!--- Describe your changes in detail -->

Previously, in client simulation mode, Plato launches all the clients to be simulated for one communication round. 

With this PR, only the clients necessary for active training are launched in Plato's client simulation mode. This is specified as `max_concurrency` in the simulation mode. For example, with ResNet-18, only around 70GB of memory is needed if `max_concurrency` is 7, regardless of the number of clients selected per round.

<!--- Describe motivation and context -->

The memory requirement of the previous design increases as the number of clients selected in one communication round increases, and is therefore not scalable to a large number of clients selected per round. For example, 160 GB of physical memory is needed to simulate a scenario where 100 clients are selected per round out of 500, and ResNet-18 is used as the model.

<!--- Why is this change required? What problem does it solve? -->

This PR improves scalability in terms of memory usage for a federated learning session. `max_concurrency` is bounded by the amount of CUDA memory available on a GPU, so it cannot be a large number.

<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->

Tested on a GPU server using an NVIDIA RTX A4500 GPU with 20 GB of CUDA memory, and with ResNet-18:

```
./run -c configs/CIFAR10/fedavg_resnet18.yml
```

<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) Fixes #
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
