### PR TITLE
Changed to always run in the client simulation mode

### DIFF
--- a/.github/workflows/configs/fedavg_yolov5.yml
+++ b/.github/workflows/configs/fedavg_yolov5.yml
@@ -144,9 +144,6 @@ trainer:
     # The maximum number of training rounds
     rounds: 1
 
-    # Whether the training should use multiple GPUs if available
-    parallelized: false
-
     # The maximum number of clients running concurrently
     max_concurrency: 3
 

--- a/.github/workflows/configs/mistnet_yolov5.yml
+++ b/.github/workflows/configs/mistnet_yolov5.yml
@@ -155,9 +155,6 @@ trainer:
     # The maximum number of training rounds
     rounds: 1
 
-    # Whether the training should use multiple GPUs if available
-    parallelized: false
-
     # The maximum number of clients running concurrently
     max_concurrency: 1
 

--- a/README.md
+++ b/README.md
@@ -208,9 +208,7 @@ If runtime exceptions occur that prevent a federated learning session from runni
 
 ### Client simulation mode
 
-Plato supports a *client simulation mode*, in which the actual number of client processes launched equals the number of clients needed for concurrently active training (defined in `max_concurrency` in the `trainer` section of the configuration file), rather than the total number of clients. This supports a simulated federated learning environment, where the set of selected clients by the server will be simulated by the set of client processes actually running. For example, with a total of 10000 clients and 1000 clients selected, if only 5 clients can train concurrently in the federated learning session due to limits of CUDA memory, then the same number of clients will be launched as separate processes. Each client process may assume different client IDs in client simulation mode.
-
-To turn on the client simulation mode, add `simulation: true` to the `clients` section in the configuration file.
+Plato runs in a *client simulation mode*, where the actual number of client processes launched on one available device (of each edge server in cross-silo training) equals the number of clients needed for concurrently active training (defined in `max_concurrency` in the `trainer` section of the configuration file), rather than the total number of clients. This supports a simulated federated learning environment, where the set of selected clients by the server will be simulated by the set of client processes actually running. For example, with a total of 10000 clients and 1000 clients selected, if only 7 clients can train concurrently on one GPU in the federated learning session due to limits of CUDA memory, then the same number of clients will be launched on one GPU as separate processes. Each client process may assume different client IDs in client simulation mode.
 
 ### Server asynchronous mode
 

--- a/configs/CIFAR10/fedavg_resnet18.yml
+++ b/configs/CIFAR10/fedavg_resnet18.yml
@@ -3,16 +3,13 @@ clients:
     type: simple
 
     # The total number of clients
-    total_clients: 100
+    total_clients: 1000
 
     # The number of clients selected in each round
-    per_round: 20
+    per_round: 100
 
     # Should the clients compute test accuracy locally?
     do_test: false
-
-    # Client simulation mode
-    simulation: true
 
 server:
     address: 127.0.0.1
@@ -26,7 +23,7 @@ data:
     data_path: ./data
 
     # Number of samples in each partition
-    partition_size: 30000
+    partition_size: 1000
 
     # IID or non-IID?
     sampler: iid
@@ -36,20 +33,17 @@ trainer:
     type: basic
 
     # The maximum number of training rounds
-    rounds: 10
-
-    # Whether the training should use multiple GPUs if available
-    parallelized: true
+    rounds: 20
 
     # The maximum number of clients running concurrently
-    max_concurrency: 6
+    max_concurrency: 7
 
     # The target accuracy
     target_accuracy: 0.80
 
     # Number of epoches for local training in each communication round
-    epochs: 1
-    batch_size: 128
+    epochs: 5
+    batch_size: 10
     optimizer: SGD
     learning_rate: 0.1
     momentum: 0.9

--- a/configs/CIFAR10/fedavg_vgg16.yml
+++ b/configs/CIFAR10/fedavg_vgg16.yml
@@ -35,9 +35,6 @@ trainer:
     # The maximum number of training rounds
     rounds: 10000
 
-    # Whether the training should use multiple GPUs if available
-    parallelized: true
-
     # The maximum number of clients running concurrently
     max_concurrency: 2
 

--- a/configs/CIFAR10/fedavg_wideresnet.yml
+++ b/configs/CIFAR10/fedavg_wideresnet.yml
@@ -35,9 +35,6 @@ trainer:
     # The maximum number of training rounds
     rounds: 10000
 
-    # Whether the training should use multiple GPUs if available
-    parallelized: true
-
     # The maximum number of clients running concurrently
     max_concurrency: 2
 

--- a/configs/CIFAR10/mistnet_pretrain_resnet18.yml
+++ b/configs/CIFAR10/mistnet_pretrain_resnet18.yml
@@ -35,9 +35,6 @@ trainer:
     # The maximum number of training rounds
     rounds: 100
 
-    # Whether the training should use multiple GPUs if available
-    parallelized: false
-
     # The maximum number of clients running concurrently
     max_concurrency: 3
 

--- a/configs/CIFAR10/mistnet_resnet18.yml
+++ b/configs/CIFAR10/mistnet_resnet18.yml
@@ -35,9 +35,6 @@ trainer:
     # The maximum number of training rounds
     rounds: 1
 
-    # Whether the training should use multiple GPUs if available
-    parallelized: false
-
     # The maximum number of clients running concurrently
     max_concurrency: 3
 

--- a/configs/CINIC10/fedavg_vgg16.yml
+++ b/configs/CINIC10/fedavg_vgg16.yml
@@ -37,9 +37,6 @@ trainer:
     # The maximum number of training rounds
     rounds: 100
 
-    # Whether the training should use multiple GPUs if available
-    parallelized: true
-
     # The maximum number of clients running concurrently
     max_concurrency: 2
 

--- a/configs/CelebA/fedavg_resnet18.yml
+++ b/configs/CelebA/fedavg_resnet18.yml
@@ -24,7 +24,7 @@ data:
         # For ResNet, do not set <attr> to True since it does not match the expected output of ResNet
         attr: false
         identity: true
-    
+
     # Number of identity in CelebA
     num_classes: 10178
 
@@ -49,9 +49,6 @@ trainer:
 
     # The maximum number of training rounds
     rounds: 5
-
-    # Whether the training should use multiple GPUs if available
-    parallelized: true
 
     # The maximum number of clients running concurrently
     max_concurrency: 3

--- a/configs/EMNIST/fedavg_async_lenet5.yml
+++ b/configs/EMNIST/fedavg_async_lenet5.yml
@@ -11,8 +11,7 @@ clients:
     # Should the clients compute test accuracy locally?
     do_test: false
 
-    # Whether simulate clients or not
-    simulation: true
+    # Whether client heterogeneity should be simulated
     speed_simulation: true
 
     # The simulation distribution
@@ -51,9 +50,6 @@ trainer:
 
     # The maximum number of training rounds
     rounds: 50
-
-    # Whether the training should use multiple GPUs if available
-    parallelized: false
 
     # Whether to apply differential privacy
     # differential_privacy: true

--- a/configs/EMNIST/fedavg_lenet5.yml
+++ b/configs/EMNIST/fedavg_lenet5.yml
@@ -11,9 +11,6 @@ clients:
     # Should the clients compute test accuracy locally?
     do_test: false
 
-    # Client simulation mode
-    simulation: false
-
 server:
     address: 127.0.0.1
     port: 8000
@@ -41,9 +38,6 @@ trainer:
 
     # The maximum number of training rounds
     rounds: 50
-
-    # Whether the training should use multiple GPUs if available
-    parallelized: false
 
     # Whether to apply differential privacy
     # differential_privacy: true

--- a/configs/FashionMNIST/fedavg_lenet5.yml
+++ b/configs/FashionMNIST/fedavg_lenet5.yml
@@ -35,9 +35,6 @@ trainer:
     # The maximum number of training rounds
     rounds: 100
 
-    # Whether the training should use multiple GPUs if available
-    parallelized: true
-
     # The maximum number of clients running concurrently
     max_concurrency: 3
 

--- a/configs/HuggingFace/fedavg_shakespeare_bert.yml
+++ b/configs/HuggingFace/fedavg_shakespeare_bert.yml
@@ -11,8 +11,7 @@ clients:
     # Should the clients compute test accuracy locally?
     do_test: false
 
-    # Client simulation mode
-    simulation: false
+    # Whether client-server communication should be simulated with files
     comm_simulation: true
 
 server:
@@ -45,9 +44,6 @@ trainer:
 
     # The maximum number of training rounds
     rounds: 5
-
-    # Whether the training should use multiple GPUs if available
-    parallelized: false
 
     # Whether to apply differential privacy
     # differential_privacy: true

--- a/configs/HuggingFace/fedavg_shakespeare_distilgpt2.yml
+++ b/configs/HuggingFace/fedavg_shakespeare_distilgpt2.yml
@@ -11,8 +11,6 @@ clients:
     # Should the clients compute test accuracy locally?
     do_test: false
 
-    # Client simulation mode
-    simulation: false
     comm_simulation: true
 
 server:
@@ -45,9 +43,6 @@ trainer:
 
     # The maximum number of training rounds
     rounds: 5
-
-    # Whether the training should use multiple GPUs if available
-    parallelized: false
 
     # Whether to apply differential privacy
     # differential_privacy: true

--- a/configs/HuggingFace/fedavg_wikitext2_gpt2.yml
+++ b/configs/HuggingFace/fedavg_wikitext2_gpt2.yml
@@ -11,8 +11,7 @@ clients:
     # Should the clients compute test accuracy locally?
     do_test: false
 
-    # Client simulation mode
-    simulation: false
+    # Whether client-server communication should be simulated with files
     comm_simulation: true
 
 server:
@@ -46,9 +45,6 @@ trainer:
 
     # The maximum number of training rounds
     rounds: 5
-
-    # Whether the training should use multiple GPUs if available
-    parallelized: false
 
     # Whether to apply differential privacy
     # differential_privacy: true

--- a/configs/Kinetics/kinetics_mm.yml
+++ b/configs/Kinetics/kinetics_mm.yml
@@ -1,6 +1,4 @@
-
 # include basic settings for the models and the learning process
-
 
 # clients settings
 clients:
@@ -17,7 +15,6 @@ server:
 
 # dataset settings for the original dataset and the corresponding multimodal data processor
 data:
-
   datasource: kinetics700
   data_path: ./data/Kinetics
   download_url: https://storage.googleapis.com/deepmind-media/Datasets/kinetics700_2020.tar.gz
@@ -39,7 +36,7 @@ data:
   label_concentration: 0.1
 
   min_partition_size: 200
-  
+
   # The random seed for sampling data
   random_seed: 1
 
@@ -47,8 +44,7 @@ data:
     rgb: !include Pipeline/kinetics_csn_rgb.yml
     flow: !include Pipeline/kinetics_tsn_flow.yml
     audio: !include Pipeline/kinetics_audio_feature.yml
-    
-  
+
 # Train settings
 
 # optimizer
@@ -75,8 +71,7 @@ lr_configs: &lr_config
   warmup_by_epoch: True
   warmup_iters: 16
 
-total_epochs: &total_epochs
-  1000
+total_epochs: &total_epochs 1000
 
 log_config: &log_config
   interval: 20
@@ -94,13 +89,11 @@ trainer:
   optimizer_config: *optimizer_config
   learning_rate_config: *lr_config
   rounds: *total_epochs
-  parallelized: False
   max_accuracy: 3
   target_accuracy: 0.67
 
   log_config: *log_config
   checkpoint_config: *checkpoint_config
-
 
 model:
   model_name: rgb_flow_audio_model
@@ -111,14 +104,13 @@ evaluation:
   metrics:
     - top_k_accuracy
     - mean_class_accuracy
-  
+
 algorithm:
   type: fedavg
 
 # Aggregation algorithm
 # The number of local aggregation rounds on edge servers before sending
-# aggreagted weights to the central server 
-
+# aggreagted weights to the central server
 
 # runtime setting
 runner_setting:
@@ -129,6 +121,6 @@ runner_setting:
     load_from: null
     resume_from: null
     workflow:
-        - train
-        - 1
+      - train
+      - 1
     find_unused_parameters: True

--- a/configs/MNIST/fedavg_async_lenet5.yml
+++ b/configs/MNIST/fedavg_async_lenet5.yml
@@ -11,8 +11,7 @@ clients:
     # Should the clients compute test accuracy locally?
     do_test: false
 
-    # Whether simulate clients or not
-    simulation: true
+    # Whether client heterogeneity should be simulated
     speed_simulation: true
 
     # The simulation distribution
@@ -54,9 +53,6 @@ trainer:
 
     # The maximum number of training rounds
     rounds: 2
-
-    # Whether the training should use multiple GPUs if available
-    parallelized: false
 
     # Whether to apply differential privacy
     # differential_privacy: true

--- a/configs/MNIST/fedavg_cross_silo_lenet5.yml
+++ b/configs/MNIST/fedavg_cross_silo_lenet5.yml
@@ -11,9 +11,6 @@ clients:
     # Should the clients compute test accuracy locally?
     do_test: true
 
-    # Client simulation mode
-    simulation: true
-
 server:
     type: fedavg_cross_silo
     address: 127.0.0.1
@@ -38,9 +35,6 @@ trainer:
 
     # The maximum number of training rounds
     rounds: 3
-
-    # Whether the training should use multiple GPUs if available
-    parallelized: false
 
     # The maximum number of clients running concurrently
     max_concurrency: 1

--- a/configs/MNIST/fedavg_lenet5.yml
+++ b/configs/MNIST/fedavg_lenet5.yml
@@ -11,9 +11,6 @@ clients:
     # Should the clients compute test accuracy locally?
     do_test: false
 
-    # Client simulation mode
-    simulation: false
-
     # Processors for outbound data payloads
     outbound_processors:
         - model_pruning
@@ -31,9 +28,6 @@ trainer:
 
     # The maximum number of training rounds
     rounds: 5
-
-    # Whether the training should use multiple GPUs if available
-    parallelized: false
 
     # Whether to apply differential privacy
     # differential_privacy: true

--- a/configs/MNIST/fedavg_lenet5_mindspore.yml
+++ b/configs/MNIST/fedavg_lenet5_mindspore.yml
@@ -30,9 +30,6 @@ trainer:
     # The maximum number of training rounds in total
     rounds: 100
 
-    # Whether the training should use multiple GPUs if available
-    parallelized: false
-
     # The maximum number of clients running concurrently
     max_concurrency: 3
 

--- a/configs/MNIST/fedavg_lenet5_noniid.yml
+++ b/configs/MNIST/fedavg_lenet5_noniid.yml
@@ -41,9 +41,6 @@ trainer:
     # The maximum number of training rounds
     rounds: 5
 
-    # Whether the training should use multiple GPUs if available
-    parallelized: false
-
     # The maximum number of clients running concurrently
     max_concurrency: 3
 

--- a/configs/MNIST/fedavg_lenet5_tensorflow.yml
+++ b/configs/MNIST/fedavg_lenet5_tensorflow.yml
@@ -27,9 +27,6 @@ trainer:
     # The maximum number of training rounds
     rounds: 5
 
-    # Whether the training should use multiple GPUs if available
-    parallelized: false
-
     # The maximum number of clients running concurrently
     max_concurrency: 3
 

--- a/configs/MNIST/fedprox_lenet5.yml
+++ b/configs/MNIST/fedprox_lenet5.yml
@@ -24,9 +24,6 @@ trainer:
     # The maximum number of training rounds
     rounds: 100
 
-    # Whether the training should use multiple GPUs if available
-    parallelized: false
-
     # The maximum number of clients running concurrently
     max_concurrency: 3
 

--- a/configs/MNIST/mistnet_lenet5.yml
+++ b/configs/MNIST/mistnet_lenet5.yml
@@ -40,9 +40,6 @@ trainer:
     # The maximum number of training rounds
     rounds: 1
 
-    # Whether the training should use multiple GPUs if available
-    parallelized: false
-
     # The target accuracy
     target_accuracy: 0.95
 

--- a/configs/MNIST/mistnet_lenet5_mindspore.yml
+++ b/configs/MNIST/mistnet_lenet5_mindspore.yml
@@ -32,9 +32,6 @@ trainer:
     # The maximum number of training rounds in total
     rounds: 1
 
-    # Whether the training should use multiple GPUs if available
-    parallelized: false
-
     # The target accuracy
     target_accuracy: 0.96
 

--- a/configs/MNIST/mistnet_pretrain_lenet5.yml
+++ b/configs/MNIST/mistnet_pretrain_lenet5.yml
@@ -24,9 +24,6 @@ trainer:
     # The maximum number of training rounds
     rounds: 100
 
-    # Whether the training should use multiple GPUs if available
-    parallelized: false
-
     # The target accuracy
     target_accuracy: 0.90
 

--- a/configs/MNIST/mistnet_pretrain_lenet5_mindspore.yml
+++ b/configs/MNIST/mistnet_pretrain_lenet5_mindspore.yml
@@ -27,9 +27,6 @@ trainer:
     # The maximum number of training rounds
     rounds: 1
 
-    # Whether the training should use multiple GPUs if available
-    parallelized: false
-
     # The target accuracy
     target_accuracy: 0.90
 

--- a/configs/PASCAL/fedavg_unet.yml
+++ b/configs/PASCAL/fedavg_unet.yml
@@ -38,9 +38,6 @@ trainer:
     # The maximum number of training rounds
     rounds: 2
 
-    # Whether the training should use multiple GPUs if available
-    parallelized: false
-
     # The maximum number of clients running concurrently
     max_concurrency: 1
 

--- a/configs/TinyImageNet/fedavg_alexnet.yml
+++ b/configs/TinyImageNet/fedavg_alexnet.yml
@@ -11,9 +11,6 @@ clients:
     # Should the clients compute test accuracy locally?
     do_test: true
 
-    # Whether simulate clients or not
-    simulation: true
-
 server:
     address: 127.0.0.1
     port: 8000
@@ -37,9 +34,6 @@ trainer:
 
     # The maximum number of training rounds
     rounds: 100
-
-    # Whether the training should use multiple GPUs if available
-    parallelized: true
 
     # The maximum number of clients running concurrently
     max_concurrency: 2

--- a/configs/TinyImageNet/fedavg_googlenet.yml
+++ b/configs/TinyImageNet/fedavg_googlenet.yml
@@ -11,9 +11,6 @@ clients:
     # Should the clients compute test accuracy locally?
     do_test: true
 
-    # Whether simulate clients or not
-    simulation: true
-
 server:
     address: 127.0.0.1
     port: 8000
@@ -37,9 +34,6 @@ trainer:
 
     # The maximum number of training rounds
     rounds: 100
-
-    # Whether the training should use multiple GPUs if available
-    parallelized: true
 
     # The maximum number of clients running concurrently
     max_concurrency: 2

--- a/configs/TinyImageNet/fedavg_inceptionv3.yml
+++ b/configs/TinyImageNet/fedavg_inceptionv3.yml
@@ -11,9 +11,6 @@ clients:
     # Should the clients compute test accuracy locally?
     do_test: true
 
-    # Whether simulate clients or not
-    simulation: true
-
 server:
     address: 127.0.0.1
     port: 8000
@@ -37,9 +34,6 @@ trainer:
 
     # The maximum number of training rounds
     rounds: 100
-
-    # Whether the training should use multiple GPUs if available
-    parallelized: true
 
     # The maximum number of clients running concurrently
     max_concurrency: 2

--- a/configs/TinyImageNet/fedavg_shufflenet.yml
+++ b/configs/TinyImageNet/fedavg_shufflenet.yml
@@ -11,9 +11,6 @@ clients:
     # Should the clients compute test accuracy locally?
     do_test: true
 
-    # Whether simulate clients or not
-    simulation: true
-
 server:
     address: 127.0.0.1
     port: 8000
@@ -37,9 +34,6 @@ trainer:
 
     # The maximum number of training rounds
     rounds: 100
-
-    # Whether the training should use multiple GPUs if available
-    parallelized: true
 
     # The maximum number of clients running concurrently
     max_concurrency: 2

--- a/configs/TinyImageNet/fedavg_squeezenet.yml
+++ b/configs/TinyImageNet/fedavg_squeezenet.yml
@@ -11,9 +11,6 @@ clients:
     # Should the clients compute test accuracy locally?
     do_test: true
 
-    # Whether simulate clients or not
-    simulation: true
-
 server:
     address: 127.0.0.1
     port: 8000
@@ -37,9 +34,6 @@ trainer:
 
     # The maximum number of training rounds
     rounds: 100
-
-    # Whether the training should use multiple GPUs if available
-    parallelized: true
 
     # The maximum number of clients running concurrently
     max_concurrency: 2

--- a/configs/YOLO/fedavg_yolov5.yml
+++ b/configs/YOLO/fedavg_yolov5.yml
@@ -144,9 +144,6 @@ trainer:
     # The maximum number of training rounds
     rounds: 1
 
-    # Whether the training should use multiple GPUs if available
-    parallelized: false
-
     # The maximum number of clients running concurrently
     max_concurrency: 3
 

--- a/configs/YOLO/mistnet_helmet.yml
+++ b/configs/YOLO/mistnet_helmet.yml
@@ -66,9 +66,6 @@ trainer:
     # The maximum number of training rounds
     rounds: 1
 
-    # Whether the training should use multiple GPUs if available
-    parallelized: false
-
     # The maximum number of clients running concurrently
     max_concurrency: 3
 

--- a/configs/YOLO/mistnet_yolov5.yml
+++ b/configs/YOLO/mistnet_yolov5.yml
@@ -155,9 +155,6 @@ trainer:
     # The maximum number of training rounds
     rounds: 1
 
-    # Whether the training should use multiple GPUs if available
-    parallelized: false
-
     # The maximum number of clients running concurrently
     max_concurrency: 3
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -17,7 +17,6 @@ Attributes in **bold** must be included in a configuration file, while attribute
 |**total_clients**|The total number of clients|A positive number||
 |**per_round**|The number of clients selected in each round| Any positive integer that is not larger than **total_clients**||
 |**do_test**|Should the clients compute test accuracy locally?| `true` or `false`|if `true` and the configuration file has `results` section, a CSV file will log test accuracy of every selected client in each round| 
-|simulation|Should we turn on the client simulation mode? When this is turned on, the number of client processes started on one available device is equal to `max_concurrency` (or `max_concurrency` * `total_silos` in cross-silo training), rather than the total number of clients.|
 |speed_simulation|Should we simulate client heterogeneity in training speed?|
 |simulation_distribution|Parameters for simulating client heterogeneity in training speed|`distribution`|`normal` for normal or `zipf` for Zipf|
 |||`s`|the parameter `s` in Zipf distribution|

--- a/examples/adaptive_freezing/adaptive_freezing_CIFAR10_resnet18.yml
+++ b/examples/adaptive_freezing/adaptive_freezing_CIFAR10_resnet18.yml
@@ -16,7 +16,7 @@ server:
 
 data:
     # The training and testing dataset
-    datasource: CIFAR10 
+    datasource: CIFAR10
 
     # Where the dataset is located
     data_path: ./data
@@ -36,9 +36,6 @@ trainer:
 
     # The maximum number of clients running concurrently
     max_concurrency: 2
-
-    # Whether the training should use multiple GPUs if available
-    parallelized: false
 
     # The target accuracy
     target_accuracy: 0.80
@@ -64,4 +61,3 @@ algorithm:
     stability_threshold: 0.05
     tight_threshold: 0.8
     random_freezing: true
-

--- a/examples/adaptive_freezing/adaptive_freezing_MNIST_lenet5.yml
+++ b/examples/adaptive_freezing/adaptive_freezing_MNIST_lenet5.yml
@@ -34,9 +34,6 @@ trainer:
     # The maximum number of training rounds
     rounds: 20
 
-    # Whether the training should use multiple GPUs if available
-    parallelized: false
-
     # The maximum number of clients running concurrently
     max_concurrency: 3
 

--- a/examples/adaptive_hgb/tests/sampler_config.yml
+++ b/examples/adaptive_hgb/tests/sampler_config.yml
@@ -11,9 +11,6 @@ clients:
     # Should the clients compute test accuracy locally?
     do_test: false
 
-    # Whether we should simulate clients
-    simulation: true
-
 server:
     address: 127.0.0.1
     port: 8000
@@ -44,16 +41,12 @@ data:
     label_concentration: 0.1
     client_quantity_concentration: 0.1
 
-
 trainer:
     # The type of the trainer
     type: basic
 
     # The maximum number of training rounds
     rounds: 10
-
-    # Whether the training should use multiple GPUs if available
-    parallelized: false
 
     # The maximum number of clients running concurrently
     max_concurrency: 5

--- a/examples/adaptive_sync/adaptive_sync_MNIST_lenet5.yml
+++ b/examples/adaptive_sync/adaptive_sync_MNIST_lenet5.yml
@@ -32,9 +32,6 @@ trainer:
     # The maximum number of training rounds
     rounds: 20
 
-    # Whether the training should use multiple GPUs if available
-    parallelized: false
-
     # The maximum number of clients running concurrently
     max_concurrency: 3
 

--- a/examples/afl/afl_FashionMNIST_lenet5.yml
+++ b/examples/afl/afl_FashionMNIST_lenet5.yml
@@ -8,9 +8,6 @@ clients:
     # Should the clients compute test accuracy locally?
     do_test: false
 
-    # Whether clients should be simulated with only a sufficient number of processes
-    simulation: true
-
     # Whether client heterogeneity should be simulated
     speed_simulation: true
 
@@ -19,13 +16,13 @@ clients:
         distribution: normal
         mean: 10
         sd: 3
-        
+
     # Should clients really go to sleep, or should we just simulate the sleep times?
     sleep_simulation: true
 
     # If we are simulating client training times, what is the average training time?
     avg_training_time: 20
-    
+
     random_seed: 1
 
 server:
@@ -74,9 +71,6 @@ data:
 trainer:
     # The maximum number of training rounds
     rounds: 100
-
-    # Whether the training should use multiple GPUs if available
-    parallelized: true
 
     # The maximum number of clients running concurrently
     max_concurrency: 4

--- a/examples/async/data_hetero/data_hetero_femnist_lenet5.yml
+++ b/examples/async/data_hetero/data_hetero_femnist_lenet5.yml
@@ -11,9 +11,6 @@ clients:
     # Should the clients compute test accuracy locally?
     do_test: false
 
-    # Whether simulate clients or not
-    simulation: true
-
 server:
     address: 127.0.0.1
     port: 8000
@@ -45,9 +42,6 @@ trainer:
 
     # The maximum number of training rounds
     rounds: 5
-
-    # Whether the training should use multiple GPUs if available
-    parallelized: true
 
     # The maximum number of clients running concurrently
     max_concurrency: 1

--- a/examples/attack_adaptive/attack-adaptive_MNIST_lenet5.yml
+++ b/examples/attack_adaptive/attack-adaptive_MNIST_lenet5.yml
@@ -38,9 +38,6 @@ trainer:
     # The maximum number of training rounds
     rounds: 5
 
-    # Whether the training should use multiple GPUs if available
-    parallelized: false
-
     # The maximum number of clients running concurrently
     max_concurrency: 1
 

--- a/examples/catalyst/fedavg_lenet5.yml
+++ b/examples/catalyst/fedavg_lenet5.yml
@@ -38,9 +38,6 @@ trainer:
     # The maximum number of training rounds
     rounds: 5
 
-    # Whether the training should use multiple GPUs if available
-    parallelized: false
-
     # The maximum number of clients running concurrently
     max_concurrency: 1
 

--- a/examples/cs_maml/cs_maml_MNIST_lenet5.yml
+++ b/examples/cs_maml/cs_maml_MNIST_lenet5.yml
@@ -8,9 +8,6 @@ clients:
     # Should the clients compute test accuracy locally?
     do_test: true
 
-    # Whether simulate clients or not
-    simulation: true
-
 server:
     type: fedavg_cross_silo
     address: 127.0.0.1
@@ -39,9 +36,6 @@ data:
 trainer:
     # The maximum number of training rounds
     rounds: 2
-
-    # Whether the training should use multiple GPUs if available
-    parallelized: false
 
     # The maximum number of clients running concurrently
     max_concurrency: 1

--- a/examples/customized/client.yml
+++ b/examples/customized/client.yml
@@ -38,9 +38,6 @@ trainer:
     # The maximum number of training rounds
     rounds: 5
 
-    # Whether the training should use multiple GPUs if available
-    parallelized: false
-
     # The maximum number of clients running concurrently
     max_concurrency: 1
 

--- a/examples/customized/server.yml
+++ b/examples/customized/server.yml
@@ -41,9 +41,6 @@ trainer:
     # The maximum number of training rounds
     rounds: 5
 
-    # Whether the training should use multiple GPUs if available
-    parallelized: false
-
     # The maximum number of clients running concurrently
     max_concurrency: 1
 

--- a/examples/dist_mistnet/mistnet_lenet5_client.yml
+++ b/examples/dist_mistnet/mistnet_lenet5_client.yml
@@ -40,9 +40,6 @@ trainer:
     # The maximum number of training rounds
     rounds: 1
 
-    # Whether the training should use multiple GPUs if available
-    parallelized: false
-
     # The target accuracy
     target_accuracy: 0.95
 

--- a/examples/dist_mistnet/mistnet_lenet5_server.yml
+++ b/examples/dist_mistnet/mistnet_lenet5_server.yml
@@ -43,9 +43,6 @@ trainer:
     # The maximum number of training rounds
     rounds: 1
 
-    # Whether the training should use multiple GPUs if available
-    parallelized: false
-
     # The target accuracy
     target_accuracy: 0.95
 

--- a/examples/fedadp/fedadp_FashionMNIST_lenet5.yml
+++ b/examples/fedadp/fedadp_FashionMNIST_lenet5.yml
@@ -11,9 +11,6 @@ clients:
     # Should the clients compute test accuracy locally?
     do_test: false
 
-    # Whether clients should be simulated with only a sufficient number of processes
-    simulation: true
-
     # Whether client heterogeneity should be simulated
     speed_simulation: true
 
@@ -22,13 +19,13 @@ clients:
         distribution: normal
         mean: 10
         sd: 3
-        
+
     # Should clients really go to sleep, or should we just simulate the sleep times?
     sleep_simulation: true
 
     # If we are simulating client training times, what is the average training time?
     avg_training_time: 20
-    
+
     random_seed: 1
 
 server:
@@ -80,9 +77,6 @@ trainer:
 
     # The maximum number of training rounds
     rounds: 100
-
-    # Whether the training should use multiple GPUs if available
-    parallelized: true
 
     # The maximum number of clients running concurrently
     max_concurrency: 4

--- a/examples/fedasync/fedasync_CIFAR10_resnet18.yml
+++ b/examples/fedasync/fedasync_CIFAR10_resnet18.yml
@@ -11,8 +11,7 @@ clients:
     # Should the clients compute test accuracy locally?
     do_test: false
 
-    # Whether simulate clients or not
-    simulation: true
+    # Whether client heterogeneity should be simulated
     speed_simulation: true
 
     # The simulation distribution
@@ -47,7 +46,7 @@ data:
 
     # Number of samples in each partition
     partition_size: 600
-    
+
     # IID or non-IID?
     sampler: noniid
 
@@ -61,10 +60,7 @@ trainer:
     # The maximum number of training rounds
     rounds: 100
 
-    # Whether the training should use multiple GPUs if available
-    parallelized: false
-
-    # The maximum number of clients running concurrently 
+    # The maximum number of clients running concurrently
     max_concurrency: 5
 
     # The target accuracy
@@ -91,4 +87,3 @@ results:
 
     # Plot results (x_axis-y_axis)
     plot: round-accuracy, elapsed_time-accuracy
-

--- a/examples/fedasync/fedasync_MNIST_lenet5.yml
+++ b/examples/fedasync/fedasync_MNIST_lenet5.yml
@@ -11,9 +11,10 @@ clients:
     # Should the clients compute test accuracy locally?
     do_test: false
 
-    # Whether simulate clients or not
-    simulation: true
+    # Whether client heterogeneity should be simulated
     speed_simulation: true
+
+    # Whether client-server communication should be simulated with files
     comm_simulation: true
 
     # The simulation distribution
@@ -70,10 +71,7 @@ trainer:
     # The maximum number of training rounds
     rounds: 80
 
-    # Whether the training should use multiple GPUs if available
-    parallelized: false
-
-    # The maximum number of clients running concurrently 
+    # The maximum number of clients running concurrently
     max_concurrency: 10
 
     # The target accuracy

--- a/examples/fedatt/fedatt_FashionMNIST_lenet5.yml
+++ b/examples/fedatt/fedatt_FashionMNIST_lenet5.yml
@@ -11,9 +11,6 @@ clients:
     # Should the clients compute test accuracy locally?
     do_test: false
 
-    # Whether clients should be simulated with only a sufficient number of processes
-    simulation: true
-
     # Whether client heterogeneity should be simulated
     speed_simulation: true
 
@@ -80,9 +77,6 @@ trainer:
 
     # The maximum number of training rounds
     rounds: 100
-
-    # Whether the training should use multiple GPUs if available
-    parallelized: true
 
     # The maximum number of clients running concurrently
     max_concurrency: 4

--- a/examples/fednova/fednova_MNIST_lenet5.yml
+++ b/examples/fednova/fednova_MNIST_lenet5.yml
@@ -32,9 +32,6 @@ trainer:
     # The maximum number of training rounds
     rounds: 100
 
-    # Whether the training should use multiple GPUs if available
-    parallelized: false
-
     # The maximum number of clients running concurrently
     max_concurrency: 3
 

--- a/examples/fedprox/fedprox_MNIST_lenet5.yml
+++ b/examples/fedprox/fedprox_MNIST_lenet5.yml
@@ -11,9 +11,6 @@ clients:
     # Should the clients compute test accuracy locally?
     do_test: false
 
-    # Whether simulate clients or not
-    simulation: true
-
     random_seed: 1
 
     # FedProx hyperparameters
@@ -55,9 +52,6 @@ trainer:
 
     # The maximum number of training rounds
     rounds: 100
-
-    # Whether the training should use multiple GPUs if available
-    parallelized: false
 
     # The maximum number of clients running concurrently
     max_concurrency: 10

--- a/examples/fedsarah/fedsarah_MNIST_lenet5.yml
+++ b/examples/fedsarah/fedsarah_MNIST_lenet5.yml
@@ -29,9 +29,6 @@ trainer:
     # The maximum number of training rounds
     rounds: 100
 
-    # Whether the training should use multiple GPUs if available
-    parallelized: false
-
     # The maximum number of clients running concurrently
     max_concurrency: 3
 

--- a/examples/fedunlearning_baseline/fedun_MNIST_lenet5.yml
+++ b/examples/fedunlearning_baseline/fedun_MNIST_lenet5.yml
@@ -43,9 +43,6 @@ trainer:
     # The maximum number of training rounds
     rounds: 200
 
-    # Whether the training should use multiple GPUs if available
-    parallelized: true
-
     # The maximum number of clients running concurrently
     max_concurrency: 2
 

--- a/examples/fei/fei_CIFAR10_resnet18.yml
+++ b/examples/fei/fei_CIFAR10_resnet18.yml
@@ -8,9 +8,6 @@ clients:
     # Should the clients compute test accuracy locally?
     do_test: false
 
-    # Whether clients should be simulated with only a sufficient number of processes
-    simulation: true
-
     # Whether client heterogeneity should be simulated
     speed_simulation: true
 
@@ -20,7 +17,7 @@ clients:
         distribution: uniform
         low: 0
         high: 20
-    
+
     # Should clients really go to sleep, or should we just simulate the sleep times?
     sleep_simulation: true
 
@@ -72,9 +69,6 @@ data:
 trainer:
     # The maximum number of training rounds
     rounds: 200
-
-    # Whether the training should use multiple GPUs if available
-    parallelized: true
 
     # The maximum number of clients running concurrently
     max_concurrency: 4

--- a/examples/fei/fei_FashionMNIST_lenet5.yml
+++ b/examples/fei/fei_FashionMNIST_lenet5.yml
@@ -8,9 +8,6 @@ clients:
     # Should the clients compute test accuracy locally?
     do_test: false
 
-    # Whether clients should be simulated with only a sufficient number of processes
-    simulation: true
-
     # Whether client heterogeneity should be simulated
     speed_simulation: true
 
@@ -26,7 +23,7 @@ clients:
 
     # If we are simulating client training times, what is the average training time?
     avg_training_time: 20
-    
+
     random_seed: 1
 
 server:
@@ -75,9 +72,6 @@ data:
 trainer:
     # The maximum number of training rounds
     rounds: 100
-
-    # Whether the training should use multiple GPUs if available
-    parallelized: true
 
     # The maximum number of clients running concurrently
     max_concurrency: 4

--- a/examples/fl_maml/fl_maml_MNIST_lenet5.yml
+++ b/examples/fl_maml/fl_maml_MNIST_lenet5.yml
@@ -8,9 +8,6 @@ clients:
     # Should the clients compute test accuracy locally?
     do_test: true
 
-    # Whether simulate clients or not
-    simulation: true
-
 server:
     address: 127.0.0.1
     port: 8000
@@ -37,9 +34,6 @@ data:
 trainer:
     # The maximum number of training rounds
     rounds: 2
-
-    # Whether the training should use multiple GPUs if available
-    parallelized: false
 
     # The maximum number of clients running concurrently
     max_concurrency: 1

--- a/examples/mistnetplus/mistnet_lenet5_client.yml
+++ b/examples/mistnetplus/mistnet_lenet5_client.yml
@@ -40,9 +40,6 @@ trainer:
     # The maximum number of training rounds
     rounds: 5
 
-    # Whether the training should use multiple GPUs if available
-    parallelized: false
-
     # The maximum number of clients running concurrently
     max_concurrency: 3
 

--- a/examples/mistnetplus/mistnet_lenet5_server.yml
+++ b/examples/mistnetplus/mistnet_lenet5_server.yml
@@ -43,9 +43,6 @@ trainer:
     # The maximum number of training rounds
     rounds: 5
 
-    # Whether the training should use multiple GPUs if available
-    parallelized: false
-
     # The maximum number of clients running concurrently
     max_concurrency: 3
 

--- a/examples/nnrt/mistnet_yolov5.yml
+++ b/examples/nnrt/mistnet_yolov5.yml
@@ -149,9 +149,6 @@ trainer:
     # The maximum number of training rounds
     rounds: 1
 
-    # Whether the training should use multiple GPUs if available
-    parallelized: false
-
     # The maximum number of clients running concurrently
     max_concurrency: 3
 

--- a/examples/port/port_cifar10.yml
+++ b/examples/port/port_cifar10.yml
@@ -11,9 +11,6 @@ clients:
     # Should the clients compute test accuracy locally?
     do_test: false
 
-    # Whether clients should be simulated with only a sufficient number of processes 
-    simulation: true
-
     # Whether client-server communication should be simulated with files
     comm_simulation: true
 
@@ -83,7 +80,7 @@ data:
     # The concentration parameter for the Dirichlet distribution
     concentration: 5
 
-    # The size of the testset on the server 
+    # The size of the testset on the server
     testset_size: 10000
 
     # The random seed for sampling data
@@ -95,9 +92,6 @@ trainer:
 
     # The maximum number of training rounds
     rounds: 80
-
-    # Whether the training should use multiple GPUs if available
-    parallelized: false
 
     # The maximum number of clients running concurrently
     max_concurrency: 5

--- a/examples/rhythm/rhythm_MNIST_lenet5.yml
+++ b/examples/rhythm/rhythm_MNIST_lenet5.yml
@@ -35,9 +35,6 @@ trainer:
     # The maximum number of training rounds
     rounds: 100
 
-    # Whether the training should use multiple GPUs if available
-    parallelized: false
-
     # The maximum number of clients running concurrently
     max_concurrency: 3
 

--- a/examples/scaffold/scaffold_MNIST_lenet5.yml
+++ b/examples/scaffold/scaffold_MNIST_lenet5.yml
@@ -29,9 +29,6 @@ trainer:
     # The maximum number of training rounds
     rounds: 100
 
-    # Whether the training should use multiple GPUs if available
-    parallelized: false
-
     # The maximum number of clients running concurrently
     max_concurrency: 3
 

--- a/examples/split_learning/split_learning_MNIST_lenet5.yml
+++ b/examples/split_learning/split_learning_MNIST_lenet5.yml
@@ -40,9 +40,6 @@ trainer:
     # The maximum number of training rounds
     rounds: 6
 
-    # Whether the training should use multiple GPUs if available
-    parallelized: false
-
     # The maximum number of clients running concurrently
     max_concurrency: 3
 

--- a/examples/sub_fedavg/subfedavg_MNIST_lenet5.yml
+++ b/examples/sub_fedavg/subfedavg_MNIST_lenet5.yml
@@ -11,8 +11,7 @@ clients:
     # Should the clients compute test accuracy locally?
     do_test: false
 
-    # Whether simulate clients or not
-    simulation: true
+    # Whether client-server communication should be simulated with files
     comm_simulation: true
 
     pruning_amount: 0.4
@@ -56,9 +55,6 @@ trainer:
 
     # The maximum number of training rounds
     rounds: 2
-
-    # Whether the training should use multiple GPUs if available
-    parallelized: false
 
     # The maximum number of clients running concurrently
     max_concurrency: 2

--- a/examples/tempo/tempo_MNIST_lenet5.yml
+++ b/examples/tempo/tempo_MNIST_lenet5.yml
@@ -8,9 +8,7 @@ clients:
     per_round: 20
 
     # Should the clients compute test accuracy locally?
-    do_test: true
-
-    simulation: true
+    do_test: false
 
 server:
     type: fedavg_cross_silo
@@ -37,10 +35,7 @@ trainer:
     type: basic
 
     # The maximum number of training rounds
-    rounds: 200
-
-    # Whether the training should use multiple GPUs if available
-    parallelized: false
+    rounds: 30
 
     # The maximum number of clients running concurrently
     max_concurrency: 1
@@ -72,4 +67,3 @@ algorithm:
     # The number of local aggregation rounds on edge servers before sending
     # aggregated weights to the central server
     local_rounds: 4
-

--- a/examples/tempo/tempo_edge.py
+++ b/examples/tempo/tempo_edge.py
@@ -9,17 +9,14 @@ from plato.clients import edge
 
 class Client(edge.Client):
     """A federated learning edge client of Tempo."""
+
     def process_server_response(self, server_response):
         """Additional client-specific processing on the server response."""
         super().process_server_response(server_response)
 
         if 'local_epoch_num' in server_response:
             local_epoch_list = server_response['local_epoch_num']
-            if hasattr(Config().clients,
-                       'simulation') and Config().clients.simulation:
-                index = self.client_id - Config().clients.per_round - 1
-            else:
-                index = self.client_id - Config().clients.total_clients - 1
+            index = self.client_id - Config().clients.total_clients - 1
 
             local_epoch_num = local_epoch_list[index]
             # Update the number of local epochs

--- a/examples/tempo/tempo_server.py
+++ b/examples/tempo/tempo_server.py
@@ -90,11 +90,7 @@ class Server(fedavg_cs.Server):
         """
         weights_diff_list = []
         for i in range(Config().algorithm.total_silos):
-            if hasattr(Config().clients,
-                       'simulation') and Config().clients.simulation:
-                client_id = i + 1 + Config().clients.per_round
-            else:
-                client_id = i + 1 + Config().clients.total_clients
+            client_id = i + 1 + Config().clients.total_clients
             (report, weights) = [(report, payload)
                                  for (__, report, payload, __) in self.updates
                                  if int(report.client_id) == client_id][0]

--- a/plato/clients/base.py
+++ b/plato/clients/base.py
@@ -151,10 +151,8 @@ class Client:
         self.process_server_response(response)
 
         # Update (virtual) client id for client, trainer and algorithm
-        if hasattr(Config().clients,
-                   'simulation') and Config().clients.simulation:
-            self.client_id = response['id']
-            self.configure()
+        self.client_id = response['id']
+        self.configure()
 
         logging.info("[Client #%d] Selected by the server.", self.client_id)
 

--- a/plato/config.py
+++ b/plato/config.py
@@ -171,16 +171,17 @@ class Config:
                 server_type = Config.server.type
             elif hasattr(Config().algorithm, "type"):
                 server_type = Config.algorithm.type
-            Config.params[
-                'result_dir'] = f'./results/{datasource}_{model}_{server_type}'
 
             if 'results' in config:
                 Config.results = Config.namedtuple_from_dict(config['results'])
 
                 if hasattr(Config.results, 'result_dir'):
                     Config.params['result_dir'] = Config.results.result_dir
+                else:
+                    Config.params[
+                        'result_dir'] = f'./results/{datasource}_{model}_{server_type}'
 
-            os.makedirs(Config.params['result_dir'], exist_ok=True)
+                os.makedirs(Config.params['result_dir'], exist_ok=True)
 
             if 'model' in config:
                 Config.model = Config.namedtuple_from_dict(config['model'])

--- a/plato/samplers/orthogonal.py
+++ b/plato/samplers/orthogonal.py
@@ -13,6 +13,7 @@ from plato.samplers import base
 class Sampler(base.Sampler):
     """Create a data sampler for each client to use a divided partition of the dataset.
     A client only has data of certain classes."""
+
     def __init__(self, datasource, client_id, testing):
         super().__init__()
 
@@ -28,11 +29,7 @@ class Sampler(base.Sampler):
             target_list = datasource.targets()
         class_list = datasource.classes()
 
-        if hasattr(Config().clients,
-                   'simulation') and Config().clients.simulation:
-            max_client_id = int(Config().clients.per_round)
-        else:
-            max_client_id = int(Config().clients.total_clients)
+        max_client_id = int(Config().clients.total_clients)
 
         if client_id > max_client_id:
             # This client is an edge server

--- a/plato/servers/fedavg_cs.py
+++ b/plato/servers/fedavg_cs.py
@@ -50,35 +50,31 @@ class Server(fedavg.Server):
                                         Config().algorithm.total_silos)
             ][edge_server_id - 1]
 
-            if hasattr(Config().clients,
-                       'simulation') and Config().clients.simulation:
-                if hasattr(Config().trainer, 'max_concurrency'):
-                    launched_total_clients = min(
-                        Config().trainer.max_concurrency *
-                        max(1,
-                            Config().gpu_count()) *
-                        Config().algorithm.total_silos,
-                        Config().clients.per_round)
-                else:
-                    launched_total_clients = Config().clients.per_round
+            if hasattr(Config().trainer, 'max_concurrency'):
+                launched_total_clients = min(
+                    Config().trainer.max_concurrency *
+                    max(1,
+                        Config().gpu_count()) * Config().algorithm.total_silos,
+                    Config().clients.per_round)
+            else:
+                launched_total_clients = Config().clients.per_round
 
-                edges_launched_clients = [
-                    len(i)
-                    for i in np.array_split(np.arange(launched_total_clients),
-                                            Config().algorithm.total_silos)
-                ]
-                starting_client_id = sum(
-                    edges_launched_clients[:edge_server_id - 1])
-                launched_clients = edges_launched_clients[edge_server_id - 1]
-                self.launched_clients = list(
-                    range(starting_client_id + 1,
-                          starting_client_id + 1 + launched_clients))
+            edges_launched_clients = [
+                len(i)
+                for i in np.array_split(np.arange(launched_total_clients),
+                                        Config().algorithm.total_silos)
+            ]
+            starting_client_id = sum(edges_launched_clients[:edge_server_id -
+                                                            1])
+            launched_clients = edges_launched_clients[edge_server_id - 1]
+            self.launched_clients = list(
+                range(starting_client_id + 1,
+                      starting_client_id + 1 + launched_clients))
 
-                starting_client_id = sum(edges_total_clients[:edge_server_id -
-                                                             1])
-                self.clients_pool = list(
-                    range(starting_client_id + 1,
-                          starting_client_id + 1 + self.total_clients))
+            starting_client_id = sum(edges_total_clients[:edge_server_id - 1])
+            self.clients_pool = list(
+                range(starting_client_id + 1,
+                      starting_client_id + 1 + self.total_clients))
 
             logging.info(
                 "[Edge server #%d (#%d)] Started training on %d clients with %d per round.",
@@ -143,10 +139,6 @@ class Server(fedavg.Server):
                 result_csv_file = f'{result_dir}/edge_{os.getpid()}.csv'
                 csv_processor.initialize_csv(result_csv_file,
                                              self.recorded_items, result_dir)
-
-            self.client_simulation_mode = hasattr(
-                Config().clients, 'simulation') and Config().clients.simulation
-
         else:
             super().configure()
             if hasattr(Config().server, 'do_test') and Config().server.do_test:

--- a/tests/TestsConfig/coco.yml
+++ b/tests/TestsConfig/coco.yml
@@ -87,7 +87,6 @@ trainer:
   optimizer_config: *optimizer_config
   learning_rate_config: *lr_config
   rounds: *total_epochs
-  parallelized: False
   max_accuracy: 3
   target_accuracy: 0.67
 

--- a/tests/TestsConfig/distribution_noniid_sampler.yml
+++ b/tests/TestsConfig/distribution_noniid_sampler.yml
@@ -1,6 +1,4 @@
-
 # include basic settings for the models and the learning process
-
 
 # clients settings
 clients:
@@ -19,7 +17,7 @@ server:
 data:
   datasource: CIFAR10
   data_path: ./data
-  
+
   downloader:
     num_workers: 4
     failed_save_file: failed_record.txt
@@ -37,7 +35,7 @@ data:
   label_concentration: 0.1
 
   min_partition_size: 200
-  
+
   # The random seed for sampling data
   random_seed: 1
 
@@ -45,8 +43,7 @@ data:
     rgb: !include Pipeline/kinetics_csn_rgb.yml
     flow: !include Pipeline/kinetics_tsn_flow.yml
     audio: !include Pipeline/kinetics_audio_feature.yml
-    
-  
+
 # Train settings
 
 # optimizer
@@ -73,8 +70,7 @@ lr_configs: &lr_config
   warmup_by_epoch: True
   warmup_iters: 16
 
-total_epochs: &total_epochs
-  1000
+total_epochs: &total_epochs 1000
 
 log_config: &log_config
   interval: 20
@@ -92,13 +88,11 @@ trainer:
   optimizer_config: *optimizer_config
   learning_rate_config: *lr_config
   rounds: *total_epochs
-  parallelized: False
   max_accuracy: 3
   target_accuracy: 0.67
 
   log_config: *log_config
   checkpoint_config: *checkpoint_config
-
 
 model:
   model_name: rgb_flow_audio_model
@@ -109,14 +103,13 @@ evaluation:
   metrics:
     - top_k_accuracy
     - mean_class_accuracy
-  
+
 algorithm:
   type: fedavg
 
 # Aggregation algorithm
 # The number of local aggregation rounds on edge servers before sending
-# aggreagted weights to the central server 
-
+# aggreagted weights to the central server
 
 # runtime setting
 runner_setting:
@@ -127,6 +120,6 @@ runner_setting:
     load_from: null
     resume_from: null
     workflow:
-        - train
-        - 1
+      - train
+      - 1
     find_unused_parameters: True

--- a/tests/TestsConfig/flickr30k_entities.yml
+++ b/tests/TestsConfig/flickr30k_entities.yml
@@ -84,7 +84,6 @@ trainer:
   optimizer_config: *optimizer_config
   learning_rate_config: *lr_config
   rounds: *total_epochs
-  parallelized: False
   max_accuracy: 3
   target_accuracy: 0.67
 

--- a/tests/TestsConfig/gym.yml
+++ b/tests/TestsConfig/gym.yml
@@ -1,6 +1,4 @@
-
 # include basic settings for the models and the learning process
-
 
 # clients settings
 clients:
@@ -33,7 +31,7 @@ data:
   label_concentration: 0.1
 
   min_partition_size: 200
-  
+
   # The random seed for sampling data
   random_seed: 1
 
@@ -41,8 +39,7 @@ data:
     rgb: !include Pipeline/gym_csn_rgb.yml
     flow: !include Pipeline/gym_tsn_flow.yml
     audio_feature: !include Pipeline/gym_audio_feature.yml
-    
-  
+
 # Train settings
 
 # optimizer
@@ -69,8 +66,7 @@ lr_configs: &lr_config
   warmup_by_epoch: True
   warmup_iters: 16
 
-total_epochs: &total_epochs
-  1000
+total_epochs: &total_epochs 1000
 
 log_config: &log_config
   interval: 20
@@ -88,13 +84,11 @@ trainer:
   optimizer_config: *optimizer_config
   learning_rate_config: *lr_config
   rounds: *total_epochs
-  parallelized: False
   max_accuracy: 3
   target_accuracy: 0.67
 
   log_config: *log_config
   checkpoint_config: *checkpoint_config
-
 
 model:
   model_name: rgb_flow_audio_model
@@ -105,14 +99,13 @@ evaluation:
   metrics:
     - top_k_accuracy
     - mean_class_accuracy
-  
+
 algorithm:
   type: fedavg
 
 # Aggregation algorithm
 # The number of local aggregation rounds on edge servers before sending
-# aggreagted weights to the central server 
-
+# aggreagted weights to the central server
 
 # runtime setting
 runner_setting:
@@ -123,6 +116,6 @@ runner_setting:
     load_from: null
     resume_from: null
     workflow:
-        - train
-        - 1
+      - train
+      - 1
     find_unused_parameters: True

--- a/tests/TestsConfig/kinetics.yml
+++ b/tests/TestsConfig/kinetics.yml
@@ -1,6 +1,4 @@
-
 # include basic settings for the models and the learning process
-
 
 # clients settings
 clients:
@@ -37,7 +35,7 @@ data:
   label_concentration: 0.1
 
   min_partition_size: 200
-  
+
   # The random seed for sampling data
   random_seed: 1
 
@@ -45,8 +43,7 @@ data:
     rgb: !include Pipeline/kinetics_csn_rgb.yml
     flow: !include Pipeline/kinetics_tsn_flow.yml
     audio_feature: !include Pipeline/kinetics_audio_feature.yml
-    
-  
+
 # Train settings
 
 # optimizer
@@ -73,8 +70,7 @@ lr_configs: &lr_config
   warmup_by_epoch: True
   warmup_iters: 16
 
-total_epochs: &total_epochs
-  1000
+total_epochs: &total_epochs 1000
 
 log_config: &log_config
   interval: 20
@@ -92,13 +88,11 @@ trainer:
   optimizer_config: *optimizer_config
   learning_rate_config: *lr_config
   rounds: *total_epochs
-  parallelized: False
   max_accuracy: 3
   target_accuracy: 0.67
 
   log_config: *log_config
   checkpoint_config: *checkpoint_config
-
 
 model:
   model_name: rgb_flow_audio_model
@@ -109,14 +103,13 @@ evaluation:
   metrics:
     - top_k_accuracy
     - mean_class_accuracy
-  
+
 algorithm:
   type: fedavg
 
 # Aggregation algorithm
 # The number of local aggregation rounds on edge servers before sending
-# aggreagted weights to the central server 
-
+# aggreagted weights to the central server
 
 # runtime setting
 runner_setting:
@@ -127,6 +120,6 @@ runner_setting:
     load_from: null
     resume_from: null
     workflow:
-        - train
-        - 1
+      - train
+      - 1
     find_unused_parameters: True

--- a/tests/TestsConfig/label_quantity_noniid_sampler.yml
+++ b/tests/TestsConfig/label_quantity_noniid_sampler.yml
@@ -1,6 +1,4 @@
-
 # include basic settings for the models and the learning process
-
 
 # clients settings
 clients:
@@ -34,10 +32,9 @@ data:
   modality_sampler: modality_iid
 
   per_client_classes_size: 6
-  
 
   min_partition_size: 200
-  
+
   # The random seed for sampling data
   random_seed: 1
 
@@ -45,8 +42,7 @@ data:
     rgb: !include Pipeline/kinetics_csn_rgb.yml
     flow: !include Pipeline/kinetics_tsn_flow.yml
     audio: !include Pipeline/kinetics_audio_feature.yml
-    
-  
+
 # Train settings
 
 # optimizer
@@ -73,8 +69,7 @@ lr_configs: &lr_config
   warmup_by_epoch: True
   warmup_iters: 16
 
-total_epochs: &total_epochs
-  1000
+total_epochs: &total_epochs 1000
 
 log_config: &log_config
   interval: 20
@@ -92,13 +87,11 @@ trainer:
   optimizer_config: *optimizer_config
   learning_rate_config: *lr_config
   rounds: *total_epochs
-  parallelized: False
   max_accuracy: 3
   target_accuracy: 0.67
 
   log_config: *log_config
   checkpoint_config: *checkpoint_config
-
 
 model:
   model_name: rgb_flow_audio_model
@@ -109,14 +102,13 @@ evaluation:
   metrics:
     - top_k_accuracy
     - mean_class_accuracy
-  
+
 algorithm:
   type: fedavg
 
 # Aggregation algorithm
 # The number of local aggregation rounds on edge servers before sending
-# aggreagted weights to the central server 
-
+# aggreagted weights to the central server
 
 # runtime setting
 runner_setting:
@@ -127,6 +119,6 @@ runner_setting:
     load_from: null
     resume_from: null
     workflow:
-        - train
-        - 1
+      - train
+      - 1
     find_unused_parameters: True

--- a/tests/TestsConfig/mixed_label_quantity_noniid_sampler.yml
+++ b/tests/TestsConfig/mixed_label_quantity_noniid_sampler.yml
@@ -1,6 +1,4 @@
-
 # include basic settings for the models and the learning process
-
 
 # clients settings
 clients:
@@ -19,7 +17,7 @@ server:
 data:
   datasource: CIFAR10
   data_path: ./data
-  
+
   downloader:
     num_workers: 4
     failed_save_file: failed_record.txt
@@ -42,7 +40,7 @@ data:
   keep_anchor_classes_size: 1
 
   min_partition_size: 200
-  
+
   # The random seed for sampling data
   random_seed: 1
 
@@ -50,8 +48,7 @@ data:
     rgb: !include Pipeline/kinetics_csn_rgb.yml
     flow: !include Pipeline/kinetics_tsn_flow.yml
     audio: !include Pipeline/kinetics_audio_feature.yml
-    
-  
+
 # Train settings
 
 # optimizer
@@ -78,8 +75,7 @@ lr_configs: &lr_config
   warmup_by_epoch: True
   warmup_iters: 16
 
-total_epochs: &total_epochs
-  1000
+total_epochs: &total_epochs 1000
 
 log_config: &log_config
   interval: 20
@@ -97,13 +93,11 @@ trainer:
   optimizer_config: *optimizer_config
   learning_rate_config: *lr_config
   rounds: *total_epochs
-  parallelized: False
   max_accuracy: 3
   target_accuracy: 0.67
 
   log_config: *log_config
   checkpoint_config: *checkpoint_config
-
 
 model:
   model_name: rgb_flow_audio_model
@@ -114,14 +108,13 @@ evaluation:
   metrics:
     - top_k_accuracy
     - mean_class_accuracy
-  
+
 algorithm:
   type: fedavg
 
 # Aggregation algorithm
 # The number of local aggregation rounds on edge servers before sending
-# aggreagted weights to the central server 
-
+# aggreagted weights to the central server
 
 # runtime setting
 runner_setting:
@@ -132,6 +125,6 @@ runner_setting:
     load_from: null
     resume_from: null
     workflow:
-        - train
-        - 1
+      - train
+      - 1
     find_unused_parameters: True

--- a/tests/TestsConfig/referitgame.yml
+++ b/tests/TestsConfig/referitgame.yml
@@ -89,7 +89,6 @@ trainer:
   optimizer_config: *optimizer_config
   learning_rate_config: *lr_config
   rounds: *total_epochs
-  parallelized: False
   max_accuracy: 3
   target_accuracy: 0.67
 

--- a/tests/TestsConfig/sample_quantity_noniid_sampler.yml
+++ b/tests/TestsConfig/sample_quantity_noniid_sampler.yml
@@ -1,6 +1,4 @@
-
 # include basic settings for the models and the learning process
-
 
 # clients settings
 clients:
@@ -19,7 +17,7 @@ server:
 data:
   datasource: CIFAR10
   data_path: ./data
-  
+
   downloader:
     num_workers: 4
     failed_save_file: failed_record.txt
@@ -36,7 +34,7 @@ data:
   client_quantity_concentration: 0.1
 
   min_partition_size: 100
-  
+
   # The random seed for sampling data
   random_seed: 1
 
@@ -44,8 +42,7 @@ data:
     rgb: !include Pipeline/kinetics_csn_rgb.yml
     flow: !include Pipeline/kinetics_tsn_flow.yml
     audio: !include Pipeline/kinetics_audio_feature.yml
-    
-  
+
 # Train settings
 
 # optimizer
@@ -72,8 +69,7 @@ lr_configs: &lr_config
   warmup_by_epoch: True
   warmup_iters: 16
 
-total_epochs: &total_epochs
-  1000
+total_epochs: &total_epochs 1000
 
 log_config: &log_config
   interval: 20
@@ -91,13 +87,11 @@ trainer:
   optimizer_config: *optimizer_config
   learning_rate_config: *lr_config
   rounds: *total_epochs
-  parallelized: False
   max_accuracy: 3
   target_accuracy: 0.67
 
   log_config: *log_config
   checkpoint_config: *checkpoint_config
-
 
 model:
   model_name: rgb_flow_audio_model
@@ -108,14 +102,13 @@ evaluation:
   metrics:
     - top_k_accuracy
     - mean_class_accuracy
-  
+
 algorithm:
   type: fedavg
 
 # Aggregation algorithm
 # The number of local aggregation rounds on edge servers before sending
-# aggreagted weights to the central server 
-
+# aggreagted weights to the central server
 
 # runtime setting
 runner_setting:
@@ -126,6 +119,6 @@ runner_setting:
     load_from: null
     resume_from: null
     workflow:
-        - train
-        - 1
+      - train
+      - 1
     find_unused_parameters: True

--- a/tests/config.yml
+++ b/tests/config.yml
@@ -38,9 +38,6 @@ trainer:
     # The maximum number of training rounds
     rounds: 5
 
-    # Whether the training should use multiple GPUs if available
-    parallelized: false
-
     # The maximum number of clients running concurrently
     max_concurrency: 4
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR changes Plato to always run in the client simulation mode.

## Description
<!--- Describe your changes in detail -->
<!--- Describe motivation and context -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR changes Plato to always run in the client simulation mode, where the number of client launched on each available device is equal to `max_concurrency` in `trainer` in the configuration file.
As `max_concurrency` is set based on the resource limitation of device. For example, a GPU of 20 GB CUDA memory can maximally support 7 clients training the ResNet-18 model concurrently, and thus `max_concurrency` should be set as 7 when using this GPU. Since at most 7 client processes can run at the same time, launching more than 7 client processes will just make more processes idle. Therefore, client simulation mode should be always turned on, instead of being an option as the previous implementation.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested with ./run -c configs/MNIST/fedavg_lenet5.yml 
and ./run -c configs/MNIST/fedavg_cross_silo_lenet5.yml

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) Fixes #
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
