### PR TITLE
Recorded customized items more easily

### DIFF
--- a/plato/servers/fedavg.py
+++ b/plato/servers/fedavg.py
@@ -201,23 +201,7 @@ class Server(base.Server):
         # Record results into a .csv file
         new_row = []
         for item in self.recorded_items:
-            item_value = {
-                'round':
-                self.current_round,
-                'accuracy':
-                self.accuracy,
-                'elapsed_time':
-                self.wall_time - self.initial_wall_time,
-                'comm_time':
-                max([
-                    report.comm_time for (__, report, __, __) in self.updates
-                ]),
-                'round_time':
-                max([
-                    report.training_time + report.comm_time
-                    for (__, report, __, __) in self.updates
-                ]),
-            }[item]
+            item_value = self.get_record_items_values()[item]
             new_row.append(item_value)
 
         result_csv_file = f"{Config().params['result_path']}/{os.getpid()}.csv"
@@ -230,6 +214,24 @@ class Server(base.Server):
             for (client_id, report, __, __) in self.updates:
                 accuracy_row = [self.current_round, client_id, report.accuracy]
                 csv_processor.write_csv(accuracy_csv_file, accuracy_row)
+
+    def get_record_items_values(self):
+        """Get values will be recorded in result csv file."""
+        return {
+            'round':
+            self.current_round,
+            'accuracy':
+            self.accuracy,
+            'elapsed_time':
+            self.wall_time - self.initial_wall_time,
+            'comm_time':
+            max([report.comm_time for (__, report, __, __) in self.updates]),
+            'round_time':
+            max([
+                report.training_time + report.comm_time
+                for (__, report, __, __) in self.updates
+            ]),
+        }
 
     @staticmethod
     def accuracy_averaging(updates):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR made the recording of customized items easier.

## Description
<!--- Describe your changes in detail -->
<!--- Describe motivation and context -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To record customized items on a custom server more easily, this PR separated the original wrap_up_processing_reports() function. With this PR, if one wants to record additional items that are not in get_record_items_values() of /plato/server/fedavg.py, it is only needed to add them in its inherited get_record_items_values() function, instead of overriding the whole wrap_up_processing_reports() function.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested with ./run -c configs/MNIST/fedavg_lenet5.yml
and ./run -c configs/MNIST/fedavg_cross_silo_lenet5.yml

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) Fixes #
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
