### PR TITLE
General cleanup of the configuration files

### DIFF
--- a/.github/workflows/configs/fedavg_yolov5.yml
+++ b/.github/workflows/configs/fedavg_yolov5.yml
@@ -18,12 +18,12 @@ server:
 data:
     # The training and testing dataset
     datasource: YOLO
-    data_params: packages/yolov5/yolov5/data/coco128.yaml
+    data_params: ./packages/yolov5/yolov5/data/coco128.yaml
 
     # Where the dataset is located
-    data_path: ./data/COCO
-    train_path: ./data/COCO/coco128/images/train2017/
-    test_path: ./data/COCO/coco128/images/train2017/
+    data_path: data/COCO
+    train_path: data/COCO/coco128/images/train2017/
+    test_path: data/COCO/coco128/images/train2017/
 
     # download command/URL (optional)
     download_urls:

--- a/.github/workflows/configs/mistnet_yolov5.yml
+++ b/.github/workflows/configs/mistnet_yolov5.yml
@@ -32,12 +32,12 @@ server:
 data:
     # The training and testing dataset
     datasource: YOLO
-    data_params: packages/yolov5/yolov5/data/coco128.yaml
+    data_params: ./packages/yolov5/yolov5/data/coco128.yaml
 
     # Where the dataset is located
-    data_path: ./data/COCO
-    train_path: ./data/COCO/coco128/images/train2017/
-    test_path: ./data/COCO/coco128/images/train2017/
+    data_path: data/COCO
+    train_path: data/COCO/coco128/images/train2017/
+    test_path: data/COCO/coco128/images/train2017/
 
     # download command/URL (optional)
     download_urls:

--- a/configs/CIFAR10/fedavg_resnet18.yml
+++ b/configs/CIFAR10/fedavg_resnet18.yml
@@ -19,9 +19,6 @@ data:
     # The training and testing dataset
     datasource: CIFAR10
 
-    # Where the dataset is located
-    data_path: ./data
-
     # Number of samples in each partition
     partition_size: 1000
 

--- a/configs/CIFAR10/fedavg_vgg16.yml
+++ b/configs/CIFAR10/fedavg_vgg16.yml
@@ -19,9 +19,6 @@ data:
     # The training and testing dataset
     datasource: CIFAR10
 
-    # Where the dataset is located
-    data_path: ./data
-
     # Number of samples in each partition
     partition_size: 50000
 

--- a/configs/CIFAR10/fedavg_wideresnet.yml
+++ b/configs/CIFAR10/fedavg_wideresnet.yml
@@ -19,9 +19,6 @@ data:
     # The training and testing dataset
     datasource: CIFAR10
 
-    # Where the dataset is located
-    data_path: ./data
-
     # Number of samples in each partition
     partition_size: 20000
 

--- a/configs/CIFAR10/mistnet_pretrain_resnet18.yml
+++ b/configs/CIFAR10/mistnet_pretrain_resnet18.yml
@@ -19,9 +19,6 @@ data:
     # The training and testing dataset
     datasource: CIFAR10
 
-    # Where the dataset is located
-    data_path: ./data
-
     # Number of samples in each partition
     partition_size: 20000
 

--- a/configs/CIFAR10/mistnet_resnet18.yml
+++ b/configs/CIFAR10/mistnet_resnet18.yml
@@ -19,9 +19,6 @@ data:
     # The training and testing dataset
     datasource: CIFAR10
 
-    # Where the dataset is located
-    data_path: ./data
-
     # Number of samples in each partition
     partition_size: 200
 

--- a/configs/CelebA/fedavg_resnet18.yml
+++ b/configs/CelebA/fedavg_resnet18.yml
@@ -28,9 +28,6 @@ data:
     # Number of identity in CelebA
     num_classes: 10178
 
-    # Where the dataset is located
-    data_path: ./data
-
     # Number of samples in each partition
     partition_size: 20000
 

--- a/configs/EMNIST/fedavg_async_lenet5.yml
+++ b/configs/EMNIST/fedavg_async_lenet5.yml
@@ -29,9 +29,6 @@ data:
     # The training and testing dataset
     datasource: EMNIST
 
-    # Where the dataset is located
-    data_path: ./data
-
     # Number of samples in each partition
     partition_size: 1128
 

--- a/configs/EMNIST/fedavg_lenet5.yml
+++ b/configs/EMNIST/fedavg_lenet5.yml
@@ -20,9 +20,6 @@ data:
     # The training and testing dataset
     datasource: EMNIST
 
-    # Where the dataset is located
-    data_path: ./data
-
     # Number of samples in each partition
     partition_size: 1128
 

--- a/configs/FashionMNIST/fedavg_lenet5.yml
+++ b/configs/FashionMNIST/fedavg_lenet5.yml
@@ -19,9 +19,6 @@ data:
     # The training and testing dataset
     datasource: FashionMNIST
 
-    # Where the dataset is located
-    data_path: ./data
-
     # Number of samples in each partition
     partition_size: 20000
 

--- a/configs/Flickr30KEntities/flickr30Kentities.yml
+++ b/configs/Flickr30KEntities/flickr30Kentities.yml
@@ -19,12 +19,8 @@ data:
     # The training and testing dataset
     dataname: Flickr30KEntities
     datasource: Flickr30K
-
-    # Where the dataset is located
-    data_path: ./data
     download_file_id: 14qrLYzC0eazGzdkDkTxr534QQrZjLMaf
     num_workers: 4
-
 
 trainer:
     # The type of the trainer

--- a/configs/MNIST/fedavg_async_lenet5.yml
+++ b/configs/MNIST/fedavg_async_lenet5.yml
@@ -32,9 +32,6 @@ data:
     # The training and testing dataset
     datasource: MNIST
 
-    # Where the dataset is located
-    data_path: ./data
-
     # Number of samples in each partition
     partition_size: 600
 

--- a/configs/MNIST/fedavg_lenet5_noniid.yml
+++ b/configs/MNIST/fedavg_lenet5_noniid.yml
@@ -19,9 +19,6 @@ data:
     # The training and testing dataset
     datasource: MNIST
 
-    # Where the dataset is located
-    data_path: ./data
-
     # Number of samples in each partition
     partition_size: 20000
 

--- a/configs/MNIST/mnist_iid.yml
+++ b/configs/MNIST/mnist_iid.yml
@@ -1,9 +1,6 @@
 # The training and testing dataset
 datasource: MNIST
 
-# Where the dataset is located
-data_path: ./data
-
 # Number of samples in each partition
 partition_size: 20000
 

--- a/configs/PASCAL/fedavg_unet.yml
+++ b/configs/PASCAL/fedavg_unet.yml
@@ -19,9 +19,6 @@ data:
     # The training and testing dataset
     datasource: PASCAL_VOC
 
-    # Where the dataset is located
-    data_path: ./data
-
     # Number of samples in each partition
     partition_size: 2000
 

--- a/configs/ReferItGame/referitgame.yml
+++ b/configs/ReferItGame/referitgame.yml
@@ -21,13 +21,9 @@ data:
     datasource: COCO2017
 
     split_config: refcoco
-
-    # Where the dataset is located
-    data_path: ./data
     split_name: google # google, unc, umd
     download_splits_base_url: https://bvisionweb1.cs.unc.edu/licheng/referit/data/
     num_workers: 4
-
 
 trainer:
     # The type of the trainer

--- a/configs/YOLO/fedavg_yolov5.yml
+++ b/configs/YOLO/fedavg_yolov5.yml
@@ -18,12 +18,12 @@ server:
 data:
     # The training and testing dataset
     datasource: YOLO
-    data_params: packages/yolov5/yolov5/data/coco128.yaml
+    data_params: ./packages/yolov5/yolov5/data/coco128.yaml
 
     # Where the dataset is located
-    data_path: ./data/COCO
-    train_path: ./data/COCO/coco128/images/train2017/
-    test_path: ./data/COCO/coco128/images/train2017/
+    data_path: data/COCO
+    train_path: data/COCO/coco128/images/train2017/
+    test_path: data/COCO/coco128/images/train2017/
 
     # download command/URL (optional)
     download_urls:

--- a/configs/YOLO/mistnet_helmet.yml
+++ b/configs/YOLO/mistnet_helmet.yml
@@ -32,9 +32,9 @@ data:
     data_params: ./configs/YOLO/helmet_data.yaml
 
     # Where the dataset is located
-    data_path: ./data/helmet/
-    train_path: ./data/helmet/helmet/images/train/
-    test_path: ./data/helmet/helmet/images/val/
+    data_path: data/helmet/
+    train_path: data/helmet/helmet/images/train/
+    test_path: data/helmet/helmet/images/val/
 
     # download command/URL
     download_urls: ["https://iqua.ece.toronto.edu/~bli/helmet.zip"]

--- a/configs/YOLO/mistnet_yolov5.yml
+++ b/configs/YOLO/mistnet_yolov5.yml
@@ -32,12 +32,12 @@ server:
 data:
     # The training and testing dataset
     datasource: YOLO
-    data_params: packages/yolov5/yolov5/data/coco128.yaml
+    data_params: ./packages/yolov5/yolov5/data/coco128.yaml
 
     # Where the dataset is located
-    data_path: ./data/COCO
-    train_path: ./data/COCO/coco128/images/train2017/
-    test_path: ./data/COCO/coco128/images/train2017/
+    data_path: data/COCO
+    train_path: data/COCO/coco128/images/train2017/
+    test_path: data/COCO/coco128/images/train2017/
 
     # download command/URL (optional)
     download_urls:

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -112,8 +112,10 @@ Attributes in **bold** must be included in a configuration file, while attribute
 
 | Attribute | Meaning | Valid Value | Note |
 |:---------:|:-------:|:-----------:|:----:|
-|**dataset**| The training and testing dataset|`MNIST`, `FashionMNIST`, `EMNIST`, `CIFAR10`, `CINIC10`, `YOLO`, `HuggingFace`, `PASCAL_VOC`, `TinyImageNet`, or `CelebA`||
+|**dataset**| The training and test datasets|`MNIST`, `FashionMNIST`, `EMNIST`, `CIFAR10`, `CINIC10`, `YOLO`, `HuggingFace`, `PASCAL_VOC`, `TinyImageNet`, or `CelebA`||
 |data_path|Where the dataset is located||default: `./data`, except for the `CINIC10` dataset, the default is `./data/CINIC-10`; for the `TinyImageNet` dataset, the default is `./data/tiny-imagenet-200`|
+|train_path|Where the training dataset is located||Need to be specified for datasets using `YOLO`|
+|test_path|Where the test dataset is located||Need to be specified for datasets using `YOLO`|
 |**sampler**|How to divide the entire dataset to the clients|`iid`||
 |||`iid_mindspore`||
 |||`noniid`|Could have *concentration* attribute to specify the concentration parameter in the Dirichlet distribution|

--- a/examples/adaptive_freezing/adaptive_freezing_CIFAR10_resnet18.yml
+++ b/examples/adaptive_freezing/adaptive_freezing_CIFAR10_resnet18.yml
@@ -18,9 +18,6 @@ data:
     # The training and testing dataset
     datasource: CIFAR10
 
-    # Where the dataset is located
-    data_path: ./data
-
     # Number of samples in each partition
     partition_size: 20000
 

--- a/examples/adaptive_freezing/adaptive_freezing_MNIST_lenet5.yml
+++ b/examples/adaptive_freezing/adaptive_freezing_MNIST_lenet5.yml
@@ -18,9 +18,6 @@ data:
     # The training and testing dataset
     datasource: MNIST
 
-    # Where the dataset is located
-    data_path: ./data
-
     # Number of samples in each partition
     partition_size: 20000
 

--- a/examples/adaptive_hgb/tests/sampler_config.yml
+++ b/examples/adaptive_hgb/tests/sampler_config.yml
@@ -21,9 +21,6 @@ data:
     # The training and testing dataset
     datasource: MNIST
 
-    # Where the dataset is located
-    data_path: ./data
-
     # Number of samples in each partition
     partition_size: 12000
 

--- a/examples/adaptive_sync/adaptive_sync_MNIST_lenet5.yml
+++ b/examples/adaptive_sync/adaptive_sync_MNIST_lenet5.yml
@@ -16,9 +16,6 @@ data:
     # The training and testing dataset
     datasource: MNIST
 
-    # Where the dataset is located
-    data_path: ./data
-
     # Number of samples in each partition
     partition_size: 20000
 

--- a/examples/afl/afl_FashionMNIST_lenet5.yml
+++ b/examples/afl/afl_FashionMNIST_lenet5.yml
@@ -47,9 +47,6 @@ data:
     # The training and testing dataset
     datasource: FashionMNIST
 
-    # Where the dataset is located
-    data_path: ./data
-
     # Number of samples in each partition
     partition_size: 200
 

--- a/examples/catalyst/fedavg_lenet5.yml
+++ b/examples/catalyst/fedavg_lenet5.yml
@@ -19,9 +19,6 @@ data:
     # The training and testing dataset
     datasource: MNIST
 
-    # Where the dataset is located
-    data_path: ./data
-
     # Number of samples in each partition
     partition_size: 20000
 

--- a/examples/customized/client.yml
+++ b/examples/customized/client.yml
@@ -19,9 +19,6 @@ data:
     # The training and testing dataset
     datasource: MNIST
 
-    # Where the dataset is located
-    data_path: ./data
-
     # Number of samples in each partition
     partition_size: 20000
 

--- a/examples/customized/server.yml
+++ b/examples/customized/server.yml
@@ -22,9 +22,6 @@ data:
     # The training and testing dataset
     datasource: MNIST
 
-    # Where the dataset is located
-    data_path: ./data
-
     # Number of samples in each partition
     partition_size: 20000
 

--- a/examples/dist_mistnet/mistnet_lenet5_server.yml
+++ b/examples/dist_mistnet/mistnet_lenet5_server.yml
@@ -24,9 +24,6 @@ data:
     # The training and testing dataset
     datasource: MNIST
 
-    # Where the dataset is located
-    data_path: ./data
-
     # Number of samples in each partition
     partition_size: 20000
 

--- a/examples/fedadp/fedadp_FashionMNIST_lenet5.yml
+++ b/examples/fedadp/fedadp_FashionMNIST_lenet5.yml
@@ -50,9 +50,6 @@ data:
     # The training and testing dataset
     datasource: FashionMNIST
 
-    # Where the dataset is located
-    data_path: ./data
-
     # Number of samples in each partition
     partition_size: 200
 

--- a/examples/fedasync/fedasync_CIFAR10_resnet18.yml
+++ b/examples/fedasync/fedasync_CIFAR10_resnet18.yml
@@ -41,9 +41,6 @@ data:
     # The training and testing dataset
     datasource: CIFAR10
 
-    # Where the dataset is located
-    data_path: ./data
-
     # Number of samples in each partition
     partition_size: 600
 

--- a/examples/fedprox/fedprox_trainer.py
+++ b/examples/fedprox/fedprox_trainer.py
@@ -9,7 +9,6 @@ Learning and Systems, 2, 429-450.
 https://proceedings.mlsys.org/paper/2020/file/38af86134b65d0f10fe33d30dd76442e-Paper.pdf
 """
 import torch
-import numpy as np
 
 from plato.config import Config
 from plato.trainers import basic
@@ -32,15 +31,16 @@ class FedProxLocalObjective:
 
     def compute_objective(self, outputs, labels):
         """ Compute the objective the FedProx client wishes to minimize. """
-        cur_weights = flatten_weights_from_model(self.model)
-        mu = Config().clients.proximal_term_penalty_constant if hasattr(
+        current_weights = flatten_weights_from_model(self.model)
+        parameter_mu = Config(
+        ).clients.proximal_term_penalty_constant if hasattr(
             Config().clients, "proximal_term_penalty_constant") else 1
-        prox_term = mu / 2 * torch.linalg.norm(
-            cur_weights - self.init_global_weights, ord=2)
+        proximal_term = parameter_mu / 2 * torch.linalg.norm(
+            current_weights - self.init_global_weights, ord=2)
 
         local_function = torch.nn.CrossEntropyLoss()
-        h = local_function(outputs, labels) + prox_term
-        return h
+        function_h = local_function(outputs, labels) + proximal_term
+        return function_h
 
 
 class Trainer(basic.Trainer):

--- a/examples/fedsarah/fedsarah_MNIST_lenet5.yml
+++ b/examples/fedsarah/fedsarah_MNIST_lenet5.yml
@@ -16,9 +16,6 @@ data:
     # The training and testing dataset
     datasource: MNIST
 
-    # Where the dataset is located
-    data_path: ./data
-
     # Number of samples in each partition
     partition_size: 20000
 

--- a/examples/fei/fei_CIFAR10_resnet18.yml
+++ b/examples/fei/fei_CIFAR10_resnet18.yml
@@ -48,9 +48,6 @@ data:
     # The training and testing dataset
     datasource: CIFAR10
 
-    # Where the dataset is located
-    data_path: ./data
-
     # Number of samples in each partition
     partition_size: 5000
 

--- a/examples/fei/fei_FashionMNIST_lenet5.yml
+++ b/examples/fei/fei_FashionMNIST_lenet5.yml
@@ -48,9 +48,6 @@ data:
     # The training and testing dataset
     datasource: FashionMNIST
 
-    # Where the dataset is located
-    data_path: ./data
-
     # Number of samples in each partition
     partition_size: 200
 

--- a/examples/mistnetplus/mistnet_lenet5_server.yml
+++ b/examples/mistnetplus/mistnet_lenet5_server.yml
@@ -24,9 +24,6 @@ data:
     # The training and testing dataset
     datasource: MNIST
 
-    # Where the dataset is located
-    data_path: ./data
-
     # Number of samples in each partition
     partition_size: 20000
 

--- a/examples/scaffold/scaffold_MNIST_lenet5.yml
+++ b/examples/scaffold/scaffold_MNIST_lenet5.yml
@@ -16,9 +16,6 @@ data:
     # The training and testing dataset
     datasource: MNIST
 
-    # Where the dataset is located
-    data_path: ./data
-
     # Number of samples in each partition
     partition_size: 20000
 

--- a/examples/split_learning/split_learning_MNIST_lenet5.yml
+++ b/examples/split_learning/split_learning_MNIST_lenet5.yml
@@ -21,9 +21,6 @@ data:
     # The training and testing dataset
     datasource: MNIST
 
-    # Where the dataset is located
-    data_path: ./data
-
     # Number of samples in each partition
     partition_size: 20000
 

--- a/plato/datasources/yolo.py
+++ b/plato/datasources/yolo.py
@@ -80,9 +80,12 @@ class DataSource(base.DataSource):
     def get_train_set(self):
         single_class = (Config().data.num_classes == 1)
 
+        train_path = os.path.join(Config.params['base_path'],
+                                  Config().data.train_path)
+
         if self.train_set is None:
             self.train_set = LoadImagesAndLabels(
-                Config().data.train_path,
+                train_path,
                 self.image_size,
                 Config().trainer.batch_size,
                 augment=False,  # augment images
@@ -100,9 +103,12 @@ class DataSource(base.DataSource):
     def get_test_set(self):
         single_class = (Config().data.num_classes == 1)
 
+        test_path = os.path.join(Config.params['base_path'],
+                                 Config().data.test_path)
+
         if self.test_set is None:
             self.test_set = LoadImagesAndLabels(
-                Config().data.test_path,
+                test_path,
                 self.image_size,
                 Config().trainer.batch_size,
                 augment=False,  # augment images

--- a/tests/TestsConfig/coco.yml
+++ b/tests/TestsConfig/coco.yml
@@ -17,7 +17,6 @@ server:
 data:
   dataname: COCO2017
   datasource: COCO
-  data_path: ./data
 
   download_train_url: http://images.cocodataset.org/zips/train2017.zip
   download_test_url: http://images.cocodataset.org/zips/test2017.zip

--- a/tests/TestsConfig/distribution_noniid_sampler.yml
+++ b/tests/TestsConfig/distribution_noniid_sampler.yml
@@ -16,7 +16,6 @@ server:
 # dataset settings for the original dataset and the corresponding multimodal data processor
 data:
   datasource: CIFAR10
-  data_path: ./data
 
   downloader:
     num_workers: 4

--- a/tests/TestsConfig/label_quantity_noniid_sampler.yml
+++ b/tests/TestsConfig/label_quantity_noniid_sampler.yml
@@ -16,7 +16,6 @@ server:
 # dataset settings for the original dataset and the corresponding multimodal data processor
 data:
   datasource: CIFAR10
-  data_path: ./data
 
   downloader:
     num_workers: 4

--- a/tests/TestsConfig/mixed_label_quantity_noniid_sampler.yml
+++ b/tests/TestsConfig/mixed_label_quantity_noniid_sampler.yml
@@ -16,7 +16,6 @@ server:
 # dataset settings for the original dataset and the corresponding multimodal data processor
 data:
   datasource: CIFAR10
-  data_path: ./data
 
   downloader:
     num_workers: 4

--- a/tests/TestsConfig/sample_quantity_noniid_sampler.yml
+++ b/tests/TestsConfig/sample_quantity_noniid_sampler.yml
@@ -16,7 +16,6 @@ server:
 # dataset settings for the original dataset and the corresponding multimodal data processor
 data:
   datasource: CIFAR10
-  data_path: ./data
 
   downloader:
     num_workers: 4

--- a/tests/config.yml
+++ b/tests/config.yml
@@ -19,9 +19,6 @@ data:
     # The training and testing dataset
     datasource: MNIST
 
-    # Where the dataset is located
-    data_path: ./data
-
     # Number of samples in each partition
     partition_size: 2000
 


### PR DESCRIPTION
This PR included some general cleanup of the configuration files across the board. For example, the `data_path` has been removed from all the configuration files that just used the default `data`.