### PR TITLE
Fixed an issue in async FL

### DIFF
--- a/examples/cs_maml/cs_maml_server.py
+++ b/examples/cs_maml/cs_maml_server.py
@@ -141,7 +141,7 @@ class Server(fedavg_cs.Server):
         if self.do_personalization_test:
             client = client_info
         else:
-            client = client_info[1]
+            client = client_info[2]
             client_staleness = self.current_round - client['starting_round']
 
             self.updates.append(

--- a/examples/fl_maml/fl_maml_server.py
+++ b/examples/fl_maml/fl_maml_server.py
@@ -107,7 +107,7 @@ class Server(fedavg.Server):
         if self.do_personalization_test:
             client = client_info
         else:
-            client = client_info[1]
+            client = client_info[2]
             client_staleness = self.current_round - client['starting_round']
 
             self.updates.append(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR fixed an issue in async FL when two or more clients have the same finish time.

## Description
<!--- Describe your changes in detail -->
<!--- Describe motivation and context -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In previous implementation of async FL, if two or more clients have the same earliest finish time, it will give 
TypeError: '<' not supported between instances of 'dict' and 'dict'
when heappop the client with the earliest finish time.

This PR fixed this issue by adding a field of a random number between the finish time and the dict in client_info.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested with [configs/EMNIST//fedavg_async_lenet5.yml](https://github.com/TL-System/plato/blob/main/configs/EMNIST/fedavg_async_lenet5.yml)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) Fixes #
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
