### PR TITLE
Correct the customized model in trainer as an object

### DIFF
--- a/examples/basic/basic.py
+++ b/examples/basic/basic.py
@@ -18,6 +18,7 @@ class DataSource(base.DataSource):
     """
     A custom datasource with custom training and validation datasets.
     """
+
     def __init__(self):
         super().__init__()
 
@@ -33,6 +34,7 @@ class DataSource(base.DataSource):
 
 class Trainer(basic.Trainer):
     """ A custom trainer with custom training and testing loops. """
+
     def train_model(self, config, trainset, sampler, cut_layer=None):  # pylint: disable=unused-argument
         """A custom training loop. """
         optimizer = torch.optim.Adam(self.model.parameters(), lr=1e-3)
@@ -80,12 +82,13 @@ class Trainer(basic.Trainer):
         return accuracy
 
 
-class Model(nn.Module):
+class Model():
     """ A custom model. """
-    def __init__(self):
-        super().__init__()
 
-        self.body = nn.Sequential(
+    @staticmethod
+    def get_model():
+        """Obtaining an instance of this model."""
+        return nn.Sequential(
             nn.Linear(28 * 28, 128),
             nn.ReLU(),
             nn.Linear(128, 128),
@@ -93,21 +96,13 @@ class Model(nn.Module):
             nn.Linear(128, 10),
         )
 
-    def forward(self, x):
-        return self.body(x)
-
-    @staticmethod
-    def get_model(*args):
-        """Obtaining an instance of this model."""
-        return Model()
-
 
 def main():
     """
        A Plato federated learning training session using a custom model,
        datasource, and trainer.
     """
-    datasource = DataSource()
+    datasource = DataSource
     model = Model
     trainer = Trainer
 

--- a/examples/basic/basic.py
+++ b/examples/basic/basic.py
@@ -18,7 +18,6 @@ class DataSource(base.DataSource):
     """
     A custom datasource with custom training and validation datasets.
     """
-
     def __init__(self):
         super().__init__()
 
@@ -34,7 +33,6 @@ class DataSource(base.DataSource):
 
 class Trainer(basic.Trainer):
     """ A custom trainer with custom training and testing loops. """
-
     def train_model(self, config, trainset, sampler, cut_layer=None):  # pylint: disable=unused-argument
         """A custom training loop. """
         optimizer = torch.optim.Adam(self.model.parameters(), lr=1e-3)
@@ -82,20 +80,35 @@ class Trainer(basic.Trainer):
         return accuracy
 
 
+class Model(nn.Module):
+    """ A custom model. """
+    def __init__(self):
+        super().__init__()
+
+        self.body = nn.Sequential(
+            nn.Linear(28 * 28, 128),
+            nn.ReLU(),
+            nn.Linear(128, 128),
+            nn.ReLU(),
+            nn.Linear(128, 10),
+        )
+
+    def forward(self, x):
+        return self.body(x)
+
+    @staticmethod
+    def get_model(*args):
+        """Obtaining an instance of this model."""
+        return Model()
+
+
 def main():
     """
        A Plato federated learning training session using a custom model,
        datasource, and trainer.
     """
-    model = nn.Sequential(
-        nn.Linear(28 * 28, 128),
-        nn.ReLU(),
-        nn.Linear(128, 128),
-        nn.ReLU(),
-        nn.Linear(128, 10),
-    )
-
     datasource = DataSource()
+    model = Model
     trainer = Trainer
 
     client = simple.Client(model=model, datasource=datasource, trainer=trainer)

--- a/examples/fedunlearning_baseline/fedunlearning_client.py
+++ b/examples/fedunlearning_baseline/fedunlearning_client.py
@@ -46,11 +46,6 @@ class Client(simple.Client):
                 self,
                 Config().clients.deleted_data_ratio * 100)
 
-            if not hasattr(Config().data,
-                           'reload_data') or Config().data.reload_data:
-                logging.info("[%s] Loading the dataset.", self)
-                self.load_data()
-
             self.sampler = unlearning_iid.Sampler(self.datasource,
                                                   self.client_id, False)
 

--- a/plato/clients/simple.py
+++ b/plato/clients/simple.py
@@ -35,7 +35,8 @@ class Client(base.Client):
         self.custom_model = model
         self.model = None
 
-        self.datasource = datasource
+        self.custom_datasource = datasource
+        self.datasource = None
 
         self.custom_algorithm = algorithm
         self.algorithm = None
@@ -82,10 +83,18 @@ class Client(base.Client):
         """Generating data and loading them onto this client."""
         logging.info("[%s] Loading its data source...", self)
 
-        if self.datasource is None or (hasattr(Config().data, 'reload_data')
-                                       and Config().data.reload_data):
+        if self.datasource is None and self.custom_datasource is None or (
+                hasattr(Config().data, 'reload_data')
+                and Config().data.reload_data):
+            # The only case where Config().data.reload_data is set to true is
+            # when clients with different client IDs need to load from different datasets,
+            # such as in the pre-partitioned Federated EMNIST dataset. We do not support
+            # reloading data from a custom datasource at this time.
             self.datasource = datasources_registry.get(
                 client_id=self.client_id)
+        elif self.datasource is None and self.custom_datasource is not None:
+            self.datasource = self.custom_datasource()
+            self.custom_datasource = None
 
         logging.info("[%s] Dataset size: %s", self,
                      self.datasource.num_train_examples())

--- a/plato/trainers/basic.py
+++ b/plato/trainers/basic.py
@@ -33,9 +33,9 @@ class Trainer(base.Trainer):
         self.model_state_dict = None
 
         if model is None:
-            model = models_registry.get()
-
-        self.model = model
+            self.model = models_registry.get()
+        else:
+            self.model = model.get_model()
 
     def zeros(self, shape):
         """Returns a PyTorch zero tensor with the given shape."""

--- a/plato/trainers/mindspore/basic.py
+++ b/plato/trainers/mindspore/basic.py
@@ -42,6 +42,8 @@ class Trainer(base.Trainer):
 
         if model is None:
             self.model = models_registry.get()
+        else:
+            self.model = model.get_model()
 
         # Initializing the loss criterion
         loss_criterion = SoftmaxCrossEntropyWithLogits(sparse=True,

--- a/plato/trainers/tensorflow/basic.py
+++ b/plato/trainers/tensorflow/basic.py
@@ -30,7 +30,7 @@ class Trainer(base.Trainer):
         if model is None:
             self.model = models_registry.get()
         else:
-            self.model = model
+            self.model = model.get_model()
 
     def zeros(self, shape):
         """Returns a TensorFlow zero tensor with the given shape."""


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Corrected the customized model initialization in the trainer `__init__` and update the model in basic/basic.py to make it compatible with this change.

## Description
<!--- Describe your changes in detail -->
The custom model should be passed as a class in the starting program and then initialized as an instance in trainer `__init__` by `self.model = model.get_model()`, otherwise the server and clients will share the same model object.

Any custom model should have the method `get_model()` implemented for obtaining an instance of it in the trainer. For example, the method should be like the followings:
```
    @staticmethod
    def get_model(*args):
        """Obtaining an instance of this model."""
        return Model()
```
or
```
    @staticmethod
    def get_model(*args):
        """Obtaining an instance of this model."""
        if hasattr(Config().trainer, 'num_classes'):
            return Model(num_classes=Config().trainer.num_classes)
        return Model()
```



<!--- Describe motivation and context -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
Tested with a customized model and with basic/basic.py.

<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) Fixes #
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
