### PR TITLE
Supported a custom datasource on the server

### DIFF
--- a/docs/Design.md
+++ b/docs/Design.md
@@ -60,18 +60,22 @@ server.run(client)
 
 ### Implementing custom models and data sources
 
-To define a custom model, one does not need to inherit from any base class in Plato, as Plato uses standard model classes in each machine learning framework. For example, Plato uses `nn.Module` as the base class in PyTorch, `nn.Cell` as the base class in MindSpore, and `keras.Model` as the base class in TensorFlow.
-
-For example (excerpt from `examples/custom_model.py`), one can define a simple model in PyTorch as follows:
+To define a custom model, one does not need to inherit from any base class in Plato, as Plato uses standard model classes in each machine learning framework. Only `get_model()` needs to be implemented in the `Model` class. For example (excerpt from `examples/basic/basic.py`), one can define a simple model in PyTorch as follows:
 
 ```python
-model = nn.Sequential(
-        nn.Linear(28 * 28, 128),
-        nn.ReLU(),
-        nn.Linear(128, 128),
-        nn.ReLU(),
-        nn.Linear(128, 10),
-    )
+class Model():
+    """ A custom model. """
+
+    @staticmethod
+    def get_model():
+        """Obtaining an instance of this model."""
+        return nn.Sequential(
+            nn.Linear(28 * 28, 128),
+            nn.ReLU(),
+            nn.Linear(128, 128),
+            nn.ReLU(),
+            nn.Linear(128, 10),
+        )
 ```
 
 If a custom `DataSource` is also needed for a custom training session, one can inherit from the `base.DataSource` class (assuming PyTorch is used as the framework), as in the following example (excerpt from `examples/custom_model.py`):
@@ -94,11 +98,12 @@ class DataSource(base.DataSource):
                              transform=ToTensor())
 ```
 
-Then, a `DataSource` object can be initialized and passed to the client, along with a custom model if desired:
+Then, a `DataSource` object can be initialized and passed to the client, along with a custom model and a custom trainer if desired:
 
 ```python
-datasource = DataSource()
-trainer = Trainer(model=model)
-client = simple.Client(model=model, datasource=datasource)
+model = Model
+datasource = DataSource
+trainer = Trainer
+client = simple.Client(model=model, datasource=datasource, trainer=trainer)
 ```
 

--- a/examples/FedRep/fedrep_server.py
+++ b/examples/FedRep/fedrep_server.py
@@ -49,9 +49,9 @@ class Server(fedavg.Server):
         logging.info("Representation_weights: %s",
                      self.representation_param_names)
 
-    def load_trainer(self):
-        """ Rewrite the load_trainer func to further extract the representaion keys """
-        super().load_trainer()
+    def init_trainer(self):
+        """ Extract representation parameter names after initializing the trainer. """
+        super().init_trainer()
 
         self.extract_representation_param_names()
 

--- a/examples/basic/basic.py
+++ b/examples/basic/basic.py
@@ -102,12 +102,12 @@ def main():
        A Plato federated learning training session using a custom model,
        datasource, and trainer.
     """
-    datasource = DataSource
     model = Model
+    datasource = DataSource
     trainer = Trainer
 
     client = simple.Client(model=model, datasource=datasource, trainer=trainer)
-    server = fedavg.Server(model=model, trainer=trainer)
+    server = fedavg.Server(model=model, datasource=datasource, trainer=trainer)
     server.run(client)
 
 

--- a/examples/catalyst/catalyst_example.py
+++ b/examples/catalyst/catalyst_example.py
@@ -26,6 +26,7 @@ class DataSource(base.DataSource):
     """A custom datasource with custom training and validation
        datasets.
     """
+
     def __init__(self):
         super().__init__()
 
@@ -41,6 +42,7 @@ class DataSource(base.DataSource):
 
 class Trainer(basic.Trainer):
     """A custom trainer with custom training and testing loops. """
+
     def train_model(self, config, trainset, sampler, cut_layer=None):  # pylint: disable=unused-argument
         """A custom training loop. """
         criterion = nn.CrossEntropyLoss()
@@ -83,16 +85,24 @@ class Trainer(basic.Trainer):
         return accuracy
 
 
+class Model():
+    """ A custom model. """
+
+    @staticmethod
+    def get_model():
+        """Obtaining an instance of this model."""
+        return nn.Sequential(nn.Flatten(), nn.Linear(28 * 28, 10))
+
+
 def main():
     """A Plato federated learning training session using a custom model. """
 
-    model = nn.Sequential(nn.Flatten(), nn.Linear(28 * 28, 10))
-
-    datasource = DataSource()
-    trainer = Trainer(model=model)
+    model = Model
+    datasource = DataSource
+    trainer = Trainer
 
     client = simple.Client(model=model, datasource=datasource, trainer=trainer)
-    server = fedavg.Server(model=model, trainer=trainer)
+    server = fedavg.Server(model=model, datasource=datasource, trainer=trainer)
     server.run(client)
 
 

--- a/examples/customized/custom_client.py
+++ b/examples/customized/custom_client.py
@@ -95,6 +95,21 @@ class CustomClient(simple.Client):
         logging.info("A customized client has been initialized.")
 
 
+class Model():
+    """ A custom model. """
+
+    @staticmethod
+    def get_model():
+        """Obtaining an instance of this model."""
+        return nn.Sequential(
+            nn.Linear(28 * 28, 128),
+            nn.ReLU(),
+            nn.Linear(128, 128),
+            nn.ReLU(),
+            nn.Linear(128, 10),
+        )
+
+
 def main():
     """
     A Plato federated learning training session using a custom client.
@@ -102,14 +117,8 @@ def main():
     To run this example:
     python custom_client.py -i <client_id>
     """
-    model = nn.Sequential(
-        nn.Linear(28 * 28, 128),
-        nn.ReLU(),
-        nn.Linear(128, 128),
-        nn.ReLU(),
-        nn.Linear(128, 10),
-    )
-    datasource = DataSource()
+    model = Model
+    datasource = DataSource
     trainer = Trainer
 
     client = CustomClient(model=model, datasource=datasource, trainer=trainer)

--- a/examples/fedreId/fedreId_client.py
+++ b/examples/fedreId/fedreId_client.py
@@ -12,10 +12,16 @@ from fedreId import DataSource, Trainer
 from plato.clients import simple
 from plato.config import Config
 
+
 class fedReIdClient(simple.Client):
-    def __init__(self, model=None, datasource=None, algorithm=None, trainer=None):
+
+    def __init__(self,
+                 model=None,
+                 datasource=None,
+                 algorithm=None,
+                 trainer=None):
         super().__init__(model=model, datasource=datasource, trainer=trainer)
-    
+
     async def train(self):
         old_weights = self.algorithm.extract_weights()
         report, weights = await super().train()
@@ -45,22 +51,34 @@ class fedReIdClient(simple.Client):
 
         print(dis)
         return sum(dis) / len(dis)
-    
+
+
+class Model():
+    """ A custom model. """
+
+    @staticmethod
+    def get_model():
+        """Obtaining an instance of this model."""
+        return nn.Sequential(
+            nn.Linear(28 * 28, 128),
+            nn.ReLU(),
+            nn.Linear(128, 128),
+            nn.ReLU(),
+            nn.Linear(128, 10),
+        )
+
+
 def main():
     """A Plato federated learning training session using a custom client. """
-    model = nn.Sequential(
-        nn.Linear(28 * 28, 128),
-        nn.ReLU(),
-        nn.Linear(128, 128),
-        nn.ReLU(),
-        nn.Linear(128, 10),
-    )
-    datasource = DataSource()
-    trainer = Trainer(model=model)
+    model = Model
+    datasource = DataSource
+    trainer = Trainer
+
     client = fedReIdClient(model=model, datasource=datasource, trainer=trainer)
     client.configure()
     loop = asyncio.get_event_loop()
     loop.run_until_complete(client.start_client())
+
 
 if __name__ == "__main__":
     main()

--- a/examples/nnrt/nnrt.py
+++ b/examples/nnrt/nnrt.py
@@ -10,25 +10,32 @@ from plato.config import Config
 from plato.clients.mistnet import Client
 
 
+class Model():
+    """ A custom model. """
+
+    @staticmethod
+    def get_model():
+        """Obtaining an instance of this model."""
+        return acl_inference.Inference(int(Config().trainer.deviceID),
+                                       Config().trainer.om_path,
+                                       Config().data.input_height,
+                                       Config().data.input_width)
+
+
 def main():
-    """ A Plato mistnet training sesstion using a nnrt yolo model, datasource and trainer. """
-    datasource = nnrt_datasource.DataSource(
-    )  # special datasource for yolo model
-
-    model = acl_inference.Inference(int(Config().trainer.deviceID),
-                                    Config().trainer.om_path,
-                                    Config().data.input_height,
-                                    Config().data.input_width)
-
-    trainer = nnrt_trainer.Trainer(model=model)
-    algorithm = mistnet.Algorithm(trainer)
+    """ A Plato mistnet training session using an nnrt yolo model, datasource and trainer. """
+    model = Model
+    datasource = nnrt_datasource.DataSource  # special datasource for yolo model
+    trainer = nnrt_trainer.Trainer
+    algorithm = mistnet.Algorithm
 
     client = Client(model=model,
                     datasource=datasource,
                     algorithm=algorithm,
                     trainer=trainer)
+
     client.load_data()
-    _, features = client.train()
+    __, __ = client.train()
 
 
 if __name__ == "__main__":

--- a/plato/clients/simple.py
+++ b/plato/clients/simple.py
@@ -54,15 +54,13 @@ class Client(base.Client):
     def configure(self) -> None:
         """Prepare this client for training."""
         super().configure()
-        if self.custom_model is not None:
+        if self.model is None and self.custom_model is not None:
             self.model = self.custom_model
-            self.custom_model = None
 
         if self.trainer is None and self.custom_trainer is None:
             self.trainer = trainers_registry.get(model=self.model)
         elif self.trainer is None and self.custom_trainer is not None:
             self.trainer = self.custom_trainer(model=self.model)
-            self.custom_trainer = None
 
         self.trainer.set_client_id(self.client_id)
 
@@ -70,7 +68,6 @@ class Client(base.Client):
             self.algorithm = algorithms_registry.get(trainer=self.trainer)
         elif self.algorithm is None and self.custom_algorithm is not None:
             self.algorithm = self.custom_algorithm(trainer=self.trainer)
-            self.custom_algorithm = None
 
         self.algorithm.set_client_id(self.client_id)
 
@@ -94,7 +91,6 @@ class Client(base.Client):
                 client_id=self.client_id)
         elif self.datasource is None and self.custom_datasource is not None:
             self.datasource = self.custom_datasource()
-            self.custom_datasource = None
 
         logging.info("[%s] Dataset size: %s", self,
                      self.datasource.num_train_examples())

--- a/plato/servers/fedavg.py
+++ b/plato/servers/fedavg.py
@@ -19,7 +19,11 @@ from plato.utils import csv_processor
 class Server(base.Server):
     """Federated learning server using federated averaging."""
 
-    def __init__(self, model=None, algorithm=None, trainer=None):
+    def __init__(self,
+                 model=None,
+                 datasource=None,
+                 algorithm=None,
+                 trainer=None):
         super().__init__()
 
         self.custom_model = model
@@ -31,7 +35,9 @@ class Server(base.Server):
         self.custom_trainer = trainer
         self.trainer = None
 
+        self.custom_datasource = datasource
         self.datasource = None
+
         self.testset = None
         self.testset_sampler = None
         self.total_samples = 0
@@ -81,7 +87,12 @@ class Server(base.Server):
 
         if not (hasattr(Config().server, 'do_test')
                 and not Config().server.do_test):
-            self.datasource = datasources_registry.get(client_id=0)
+            if self.datasource is None and self.custom_datasource is None:
+                self.datasource = datasources_registry.get(client_id=0)
+            elif self.datasource is None and self.custom_datasource is not None:
+                self.datasource = self.custom_datasource()
+                self.custom_datasource = None
+
             self.testset = self.datasource.get_test_set()
 
             if hasattr(Config().data, 'testset_size'):

--- a/plato/servers/fedavg.py
+++ b/plato/servers/fedavg.py
@@ -91,7 +91,6 @@ class Server(base.Server):
                 self.datasource = datasources_registry.get(client_id=0)
             elif self.datasource is None and self.custom_datasource is not None:
                 self.datasource = self.custom_datasource()
-                self.custom_datasource = None
 
             self.testset = self.datasource.get_test_set()
 
@@ -129,19 +128,16 @@ class Server(base.Server):
         """Setting up the global model to be trained via federated learning."""
         if self.model is None and self.custom_model is not None:
             self.model = self.custom_model
-            self.custom_model = None
 
         if self.trainer is None and self.custom_trainer is None:
             self.trainer = trainers_registry.get(model=self.model)
         elif self.trainer is None and self.custom_trainer is not None:
             self.trainer = self.custom_trainer(model=self.model)
-            self.custom_trainer = None
 
         if self.algorithm is None and self.custom_algorithm is None:
             self.algorithm = algorithms_registry.get(trainer=self.trainer)
         elif self.algorithm is None and self.custom_algorithm is not None:
             self.algorithm = self.custom_algorithm(trainer=self.trainer)
-            self.custom_algorithm = None
 
     async def select_clients(self, for_next_batch=False):
         await super().select_clients(for_next_batch=for_next_batch)

--- a/plato/servers/fedavg.py
+++ b/plato/servers/fedavg.py
@@ -78,7 +78,7 @@ class Server(base.Server):
         else:
             logging.info("Training: %s rounds\n", total_rounds)
 
-        self.load_trainer()
+        self.init_trainer()
 
         # Prepares this server for processors that processes outbound and inbound
         # data payloads
@@ -124,8 +124,8 @@ class Server(base.Server):
             csv_processor.initialize_csv(accuracy_csv_file, accuracy_headers,
                                          Config().params['result_path'])
 
-    def load_trainer(self):
-        """Setting up the global model to be trained via federated learning."""
+    def init_trainer(self):
+        """ Setting up the global model, trainer, and algorithm. """
         if self.model is None and self.custom_model is not None:
             self.model = self.custom_model
 
@@ -138,9 +138,6 @@ class Server(base.Server):
             self.algorithm = algorithms_registry.get(trainer=self.trainer)
         elif self.algorithm is None and self.custom_algorithm is not None:
             self.algorithm = self.custom_algorithm(trainer=self.trainer)
-
-    async def select_clients(self, for_next_batch=False):
-        await super().select_clients(for_next_batch=for_next_batch)
 
     def compute_weight_deltas(self, updates):
         """Extract the model weight updates from client updates."""

--- a/plato/servers/fedavg_cs.py
+++ b/plato/servers/fedavg_cs.py
@@ -106,7 +106,7 @@ class Server(fedavg.Server):
                 Config().args.id, os.getpid(),
                 Config().algorithm.local_rounds)
 
-            self.load_trainer()
+            self.init_trainer()
             self.trainer.set_client_id(Config().args.id)
 
             # Prepares this server for processors that processes outbound and inbound

--- a/plato/servers/mistnet.py
+++ b/plato/servers/mistnet.py
@@ -23,9 +23,9 @@ class Server(fedavg.Server):
         # MistNet requires one round of client-server communication
         assert Config().trainer.rounds == 1
 
-    def load_trainer(self):
-        """Setting up a pre-trained model to be loaded on the server."""
-        super().load_trainer()
+    def init_trainer(self):
+        """ Setting up a pre-trained model to be loaded on the server. """
+        super().init_trainer()
 
         model_path = Config().params['model_path']
         model_file_name = Config().trainer.pretrained_model if hasattr(

--- a/plato/utils/reinforcement_learning/rl_server.py
+++ b/plato/utils/reinforcement_learning/rl_server.py
@@ -23,7 +23,7 @@ class RLServer(fedavg.Server):
         self.model = None
         self.trainer = None
         self.algorithm = None
-        self.load_trainer()
+        self.init_trainer()
 
         self.current_round = 0
 

--- a/tests/fedavg_tests.py
+++ b/tests/fedavg_tests.py
@@ -43,7 +43,7 @@ async def test_fedavg_aggregation(self):
     server = fedavg_server.Server(model=model,
                                   algorithm=algorithm,
                                   trainer=trainer)
-    server.load_trainer()
+    server.init_trainer()
 
     weights = copy.deepcopy(self.algorithm.extract_weights())
     print(f"Report 1 weights: {weights}")


### PR DESCRIPTION
This PR supports the use of a custom datasource on the FL server, and modified related examples that uses custom models and datasources to be compatible with the latest changes of passing classes rather than instances into Plato.

## How has this been tested?

```
python examples/basic/basic.py -c configs/MNIST/fedavg_lenet5.yml
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) Fixes #
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
