### PR TITLE
Added the remaining learning rate schedulers found in PyTorch

### DIFF
--- a/plato/trainers/basic.py
+++ b/plato/trainers/basic.py
@@ -89,12 +89,13 @@ class Trainer(base.Trainer):
         else:
             logging.info("[Client #%d] Loading a model from %s.",
                          self.client_id, model_path)
-        
+
         pretrained = None
         if torch.cuda.is_available():
             pretrained = torch.load(model_path)
         else:
-            pretrained = torch.load(model_path, map_location=torch.device('cpu'))
+            pretrained = torch.load(model_path,
+                                    map_location=torch.device('cpu'))
         self.model.load_state_dict(pretrained, strict=True)
 
     def simulate_sleep_time(self):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The learning rate schedulers: ChainedScheduler, SequentialLR, MultiStepLR, StepLR, ConstantLR, LinearLR, ExponentialLR, CyclicLR, and CosineAnnealingWarmRestarts were added into plato/utils/optimizers.py according to the documentation found at https://pytorch.org/docs/stable/optim.html#how-to-adjust-learning-rate.

## Description
<!--- Describe your changes in detail -->
To use the different schedulers, the "lr_schedule" would be set equal to any of the schedulers above as usual. In the case of ChainedScheduler and SequentialLR which calls other schedulers, "lr_schedule" would be set equal to a comma-separated list of required schedulers along with either ChainedScheduler or SequentialLR.
<!--- Describe motivation and context -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
This was tested by running ```./run -c configs/CIFAR10/fedavg_resnet18.yml``` using each newly added scheduler once.
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) Fixes #
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
