### PR TITLE
removed looping through dictionaries for more efficient lookup

### DIFF
--- a/plato/models/registry.py
+++ b/plato/models/registry.py
@@ -54,34 +54,33 @@ def get():
     )
     model = None
 
-    for name, registered_model in registered_models.items():
-        if name.startswith(model_type):
-            num_classes = (
-                Config().trainer.num_classes
-                if hasattr(Config().trainer, "num_classes")
-                else 10
-            )
+    model = registered_models.get(model_type, None)
 
-            cut_layer = None
+    if model:
+        num_classes = (
+            Config().trainer.num_classes
+            if hasattr(Config().trainer, "num_classes")
+            else 10
+        )
 
-            if hasattr(Config().algorithm, "cut_layer"):
-                # Initialize the model with the cut_layer set, so that all the training
-                # will only use the layers after the cut_layer
-                cut_layer = Config().algorithm.cut_layer
-            model = registered_model(num_classes=num_classes, cut_layer=cut_layer)
+        cut_layer = None
 
-    if model is None:
-        for name, registered_factory in registered_factories.items():
-            if name.startswith(model_type):
-                num_classes = (
-                    Config().trainer.num_classes
-                    if hasattr(Config().trainer, "num_classes")
-                    else None
-                )
-                model = registered_factory.get(
-                    model_name=model_name,
-                    num_classes=num_classes,
-                )
+        if hasattr(Config().algorithm, "cut_layer"):
+            # Initialize the model with the cut_layer set, so that all the training
+            # will only use the layers after the cut_layer
+            cut_layer = Config().algorithm.cut_layer
+
+        model = model(num_classes=num_classes, cut_layer=cut_layer)
+    else:
+        # In the case it doesn't exist we check registered
+        model = registered_factories.get(model_type, None)
+        num_classes = (
+            Config().trainer.num_classes
+            if hasattr(Config().trainer, "num_classes")
+            else None
+        )
+        if model is not None:
+            model = model.get(model_name=model_name, num_classes=num_classes)
 
     if model_name == "yolov5":
         from plato.models import yolov5


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Utilised .get that comes with dictionaries to look up key-value pairs in O(1) amortised time instead of looping through the dictionary which would be O(n) time worst case.

## How has this been tested?
This has been tested by running HuggingFace (./run -c  configs/HuggingFace/fedavg_shakespeare_bert.yml), Vgg (changing model type to vgg), and resetnet (./run -c configs/CIFAR10/fedavg_resnet18_torchhub.yml) and works the same as original

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) Fixes #
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
