### PR TITLE
Refactored the design of the all_inclusive sampler.

### DIFF
--- a/.github/workflows/mindspore_tests.yml
+++ b/.github/workflows/mindspore_tests.yml
@@ -30,7 +30,7 @@ jobs:
           sudo apt-get update
           sudo apt install -y python3-pip
           conda activate plato
-          conda install mindspore-cpu=1.8.0 -c mindspore -c conda-forge -y
+          conda install mindspore-cpu -c mindspore -c conda-forge -y
           pip3 install numpy python-socketio aiohttp requests boto3 pyyaml pynvml psutil datasets
 
       - name: Training workloads

--- a/Dockerfile_MindSpore
+++ b/Dockerfile_MindSpore
@@ -22,7 +22,7 @@ RUN apt-get update \
     && ~/miniconda3/envs/plato_gpu/bin/pip install -r ~/requirements.txt \
     && ~/miniconda3/envs/plato_gpu/bin/pip install plato-learn \
     && ~/miniconda3/bin/conda create -n plato_cpu -c conda-forge python=3.9.0 \
-    && ~/miniconda3/bin/conda install mindspore-cpu=1.8.0 -c mindspore -c conda-forge -n plato_cpu -y \
+    && ~/miniconda3/bin/conda install mindspore-cpu -c mindspore -c conda-forge -n plato_cpu -y \
     && ~/miniconda3/envs/plato_cpu/bin/pip install -r ~/requirements.txt \
     && ~/miniconda3/envs/plato_cpu/bin/pip install plato-learn
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -277,7 +277,7 @@ Where the test dataset is located.
 ```
 ````
 
-````{admonition} sampler
+````{admonition} **sampler**
 How to divide the entire dataset to the clients. The following options are available:
 
 - `iid`
@@ -308,18 +308,10 @@ If the sampler is `mixed`, the indices of clients whose datasets are non-i.i.d. 
 ````
 
 ````{admonition} test_set_sampler
-How the test dataset is sampled when clients test locally. Any sampler is valid. 
+How the test dataset is sampled when clients test locally. Any sampler type is valid. 
 
 ```{note}
-Without this parameter, each client's test dataset is the test dataset of the datasource.
-```
-````
-
-````{admonition} edge_test_set_sampler
-How the test dataset is sampled when edge servers test locally. Any sampler is valid.
-
-```{note}
-Without this parameter, edge servers' test datasets are the test dataset of the datasource if they locally test their aggregated models in cross-silo FL.
+Without this parameter, the test dataset on either the client or the server is the entire test dataset of the datasource.
 ```
 ````
 

--- a/docs/patches/base.py.patch
+++ b/docs/patches/base.py.patch
@@ -1,14 +1,13 @@
---- base.py	2022-02-05 11:37:18.000000000 -0500
-+++ base_cc.py	2022-02-05 11:35:10.000000000 -0500
-@@ -234,10 +234,7 @@
+--- servers/base.py     2022-08-16 08:39:27.000000000 -0400
++++ servers/base_cc.py  2022-08-16 09:36:46.000000000 -0400
+@@ -297,9 +297,7 @@
  
          app = web.Application()
          self.sio.attach(app)
--        web.run_app(app,
--                    host=Config().server.address,
--                    port=port,
--                    loop=asyncio.get_event_loop())
+-        web.run_app(
+-            app, host=Config().server.address, port=port, loop=asyncio.get_event_loop()
+-        )
 +        web.run_app(app, host=Config().server.address, port=port)
  
      async def register_client(self, sid, client_id):
-         """ Adding a newly arrived client to the list of clients. """
+         """Adding a newly arrived client to the list of clients."""

--- a/docs/patches/config.py.patch
+++ b/docs/patches/config.py.patch
@@ -1,0 +1,10 @@
+--- config.py   2022-08-14 13:31:48.000000000 -0400
++++ config_cc.py        2022-08-16 09:33:19.000000000 -0400
+@@ -348,7 +348,4 @@
+                 else:
+                     device = "cuda:0"
+ 
+-            if torch.has_mps:
+-                device = "mps"
+-
+         return device

--- a/docs/patches/patch_cc.sh
+++ b/docs/patches/patch_cc.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
 patch -u -b ./plato/servers/base.py -i ./docs/patches/base.py.patch
+patch -u -b ./plato/config.py -i ./docs/patches/config.py.patch

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -44,7 +44,7 @@ pip install tensorflow-macos tensorflow-datasets
 **MindSpore.** Plato currently supports the latest MindSpore release, 1.8.0. Follow the installation instructions in the [official MindSpore website](https://mindspore.cn/install/en) to install MindSpore in your conda environment. For example, on an M1 Mac, use the command:
 
 ```shell
-conda install mindspore-cpu=1.8.0 -c mindspore -c conda-forge
+conda install mindspore-cpu -c mindspore -c conda-forge
 ```
 
 To use trainers and servers based on MindSpore, assign `true` to `use_mindspore` in the `trainer` section of the configuration file. If GPU is not available when MindSpore is used, assign `true` to `cpuonly` in the `trainer` section as well. These variables are unassigned by default, and *Plato* would use PyTorch as its default framework. As examples of using MindSpore as its underlying deep learning framework, two configuration files have been provided: `configs/MNIST/fedavg_lenet5_mindspore.yml` and `configs/MNIST/mistnet_lenet5_mindspore.yml`. For example:

--- a/examples/fedreId/fedreId_client.py
+++ b/examples/fedreId/fedreId_client.py
@@ -26,7 +26,7 @@ class fedReIdClient(simple.Client):
     def cos_feature_distance(self, old_weights, new_weights):
         if old_weights == None:
             logging.info("old_weights is None")
-            return self.sampler.trainset_size()
+            return self.sampler.num_samples()
         dis = []
         # option II
         # self.load_payload(old_weights)

--- a/examples/fedsaw/fedsaw_MNIST_lenet5.yml
+++ b/examples/fedsaw/fedsaw_MNIST_lenet5.yml
@@ -47,7 +47,7 @@ data:
     # IID or non-IID?
     sampler: iid
 
-    edge_testset_sampler: iid
+    testset_sampler: iid
     testset_size: 1000
 
     # The random seed for sampling data

--- a/examples/mistnetplus/mistnetplus_client.py
+++ b/examples/mistnetplus/mistnetplus_client.py
@@ -53,7 +53,7 @@ class MistnetplusClient(simple.Client):
 
             # Generate a report for the server, performing model testing if applicable
             return (
-                Report(self.sampler.trainset_size(), len(features), "features"),
+                Report(self.sampler.num_samples(), len(features), "features"),
                 features,
             )
         else:
@@ -62,7 +62,7 @@ class MistnetplusClient(simple.Client):
             self.algorithm.complete_train(config, self.trainset, self.sampler)
             weights = self.algorithm.extract_weights()
             # Generate a report, signal the end of train
-            return Report(self.sampler.trainset_size(), 0, "weights"), weights
+            return Report(self.sampler.num_samples(), 0, "weights"), weights
 
 
 def main():

--- a/examples/split_learning/split_learning_client.py
+++ b/examples/split_learning/split_learning_client.py
@@ -52,11 +52,11 @@ class Client(simple.Client):
             features = self.algorithm.extract_features(self.trainset, self.sampler)
 
             # Generate a report for the server, performing model testing if applicable
-            return Report(self.sampler.trainset_size(), "features"), features
+            return Report(self.sampler.num_samples(), "features"), features
         else:
             # Perform a complete training with gradients received
             config = Config().trainer._asdict()
             self.algorithm.complete_train(config, self.trainset, self.sampler)
             weights = self.algorithm.extract_weights()
             # Generate a report, signal the end of train
-            return Report(self.sampler.trainset_size(), "weights"), weights
+            return Report(self.sampler.num_samples(), "weights"), weights

--- a/examples/sub_fedavg_cs/subcs_MNIST_lenet5.yml
+++ b/examples/sub_fedavg_cs/subcs_MNIST_lenet5.yml
@@ -47,7 +47,7 @@ data:
     # IID or non-IID?
     sampler: iid
 
-    edge_testset_sampler: iid
+    testset_sampler: iid
     testset_size: 1000
 
     # The random seed for sampling data

--- a/plato/clients/mistnet.py
+++ b/plato/clients/mistnet.py
@@ -37,7 +37,7 @@ class Client(simple.Client):
         comm_time = time.time()
         return (
             SimpleNamespace(
-                num_samples=self.sampler.trainset_size(),
+                num_samples=self.sampler.num_samples(),
                 accuracy=0,
                 training_time=training_time,
                 comm_time=comm_time,

--- a/plato/clients/simple.py
+++ b/plato/clients/simple.py
@@ -162,7 +162,7 @@ class Client(base.Client):
             avg_training_time = Config().clients.avg_training_time
 
             report = SimpleNamespace(
-                num_samples=self.sampler.trainset_size(),
+                num_samples=self.sampler.num_samples(),
                 accuracy=accuracy,
                 training_time=(avg_training_time + sleep_seconds)
                 * Config().trainer.epochs,
@@ -171,7 +171,7 @@ class Client(base.Client):
             )
         else:
             report = SimpleNamespace(
-                num_samples=self.sampler.trainset_size(),
+                num_samples=self.sampler.num_samples(),
                 accuracy=accuracy,
                 training_time=training_time,
                 comm_time=comm_time,

--- a/plato/samplers/all_inclusive.py
+++ b/plato/samplers/all_inclusive.py
@@ -23,6 +23,8 @@ class Sampler(base.Sampler):
                 self.data_samples = random.sample(
                     all_inclusive, Config().data.testset_size
                 )
+            else:
+                self.data_samples = all_inclusive
         else:
             self.data_samples = range(len(datasource.get_train_set()))
 

--- a/plato/samplers/all_inclusive.py
+++ b/plato/samplers/all_inclusive.py
@@ -2,6 +2,7 @@
 Samples all the data from a dataset. Applicable in cases where the dataset comes from
 local sources only. Used by the Federated EMNIST dataset and the MistNet server.
 """
+import random
 
 from plato.samplers import base
 from plato.config import Config
@@ -9,26 +10,36 @@ from plato.config import Config
 
 class Sampler(base.Sampler):
     """Create a data sampler that samples all the data in the dataset.
-       Used by the MistNet server.
+    Used by the MistNet server.
     """
+
     def __init__(self, datasource, client_id=0, testing=False):
         super().__init__()
         self.client_id = client_id
 
         if testing:
-            self.all_inclusive = range(datasource.num_test_examples())
+            all_inclusive = range(len(datasource.get_test_set()))
+            if hasattr(Config().data, "testset_size"):
+                self.data_samples = random.sample(
+                    all_inclusive, Config().data.testset_size
+                )
         else:
-            self.all_inclusive = range(datasource.num_train_examples())
+            self.data_samples = range(len(datasource.get_train_set()))
 
     def get(self):
-        if hasattr(Config().trainer, 'use_mindspore'):
-            return list(self.all_inclusive)
-        elif hasattr(Config().trainer, 'use_tensorflow'):
-            return list(self.all_inclusive)
+        if hasattr(Config().trainer, "use_mindspore"):
+            return list(self.data_samples)
+        elif hasattr(Config().trainer, "use_tensorflow"):
+            return list(self.data_samples)
         else:
-            from torch.utils.data import SubsetRandomSampler
-            return SubsetRandomSampler(self.all_inclusive)
+            import torch
 
-    def trainset_size(self):
-        """Returns the length of the dataset after sampling. """
-        return len(self.all_inclusive)
+            gen = torch.Generator()
+            gen.manual_seed(self.random_seed)
+            return torch.utils.data.SubsetRandomSampler(
+                self.data_samples, generator=gen
+            )
+
+    def num_samples(self):
+        """Returns the length of the dataset after sampling."""
+        return len(self.data_samples)

--- a/plato/samplers/base.py
+++ b/plato/samplers/base.py
@@ -23,8 +23,8 @@ class Sampler:
 
     @abstractmethod
     def get(self):
-        """Obtains an instance of the sampler. """
+        """Obtains an instance of the sampler."""
 
     @abstractmethod
-    def trainset_size(self):
-        """Returns the length of the dataset after sampling. """
+    def num_samples(self):
+        """Returns the length of the dataset after sampling."""

--- a/plato/samplers/iid.py
+++ b/plato/samplers/iid.py
@@ -33,24 +33,20 @@ class Sampler(base.Sampler):
         # add extra samples to make it evenly divisible, if needed
         if len(indices) < total_size:
             while len(indices) < total_size:
-                indices += indices[:(total_size - len(indices))]
+                indices += indices[: (total_size - len(indices))]
         else:
             indices = indices[:total_size]
         assert len(indices) == total_size
 
         # Compute the indices of data in the subset for this client
-        self.subset_indices = indices[(int(client_id) -
-                                       1):total_size:total_clients]
+        self.subset_indices = indices[(int(client_id) - 1) : total_size : total_clients]
 
     def get(self):
-        """Obtains an instance of the sampler. """
+        """Obtains an instance of the sampler."""
         gen = torch.Generator()
         gen.manual_seed(self.random_seed)
-        version = torch.__version__.split(".")
-        if int(version[0]) <= 1 and int(version[1]) <= 5:
-            return SubsetRandomSampler(self.subset_indices)
         return SubsetRandomSampler(self.subset_indices, generator=gen)
 
-    def trainset_size(self):
-        """Returns the length of the dataset after sampling. """
+    def num_samples(self):
+        """Returns the length of the dataset after sampling."""
         return len(self.subset_indices)

--- a/plato/samplers/label_quantity_noniid.py
+++ b/plato/samplers/label_quantity_noniid.py
@@ -1,4 +1,4 @@
-'''
+"""
 Samples data from a dataset, biased across labels, and the number of labels
 (corresponding classes) in different clients is the same.
 
@@ -25,7 +25,7 @@ This sampler implements one type of label distribution skew called:
 
         We have N clients while K clients contain class c. As class c contains D_c samples,
          each client in K will contain D_c / K samples of this class.
-'''
+"""
 
 import numpy as np
 import torch
@@ -40,6 +40,7 @@ from plato.samplers import sampler_utils
 class Sampler(base.Sampler):
     """Create a data sampler for each client to use a divided partition of the
     dataset, biased across classes according to the parameter per_client_classes_size."""
+
     def __init__(self, datasource, client_id, testing):
         super().__init__()
         self.client_id = client_id
@@ -73,18 +74,21 @@ class Sampler(base.Sampler):
             dataset_labels=self.targets_list,
             dataset_classes=classes_id_list,
             num_clients=total_clients,
-            per_client_classes_size=per_client_classes_size)
+            per_client_classes_size=per_client_classes_size,
+        )
 
         self.subset_indices = self.clients_dataidx_map[client_id - 1]
 
-    def quantity_label_skew(self, dataset_labels, dataset_classes, num_clients,
-                            per_client_classes_size):
-        """ Achieve the quantity-based lable skewness """
+    def quantity_label_skew(
+        self, dataset_labels, dataset_classes, num_clients, per_client_classes_size
+    ):
+        """Achieve the quantity-based lable skewness"""
         client_id = self.client_id
         # each client contains the full classes
         if per_client_classes_size == len(dataset_classes):
             self.clients_dataidx_map = sampler_utils.assign_fully_classes(
-                dataset_labels, dataset_classes, num_clients, client_id)
+                dataset_labels, dataset_classes, num_clients, client_id
+            )
         else:
             self.clients_dataidx_map = sampler_utils.assign_sub_classes(
                 dataset_labels,
@@ -93,23 +97,23 @@ class Sampler(base.Sampler):
                 per_client_classes_size,
                 anchor_classes=None,
                 consistent_clients=None,
-                keep_anchor_classes_size=None)
+                keep_anchor_classes_size=None,
+            )
 
     def get(self):
-        """Obtains an instance of the sampler. """
+        """Obtains an instance of the sampler."""
         gen = torch.Generator()
         gen.manual_seed(self.random_seed)
 
         return SubsetRandomSampler(self.subset_indices, generator=gen)
 
-    def trainset_size(self):
-        """Returns the length of the dataset after sampling. """
+    def num_samples(self):
+        """Returns the length of the dataset after sampling."""
         return len(self.subset_indices)
 
     def get_trainset_condition(self):
-        """ Obtain the detailed information in the trainser """
+        """Obtain the detailed information in the trainser"""
         targets_array = np.array(self.targets_list)
         client_sampled_subset_labels = targets_array[self.subset_indices]
-        unique, counts = np.unique(client_sampled_subset_labels,
-                                   return_counts=True)
+        unique, counts = np.unique(client_sampled_subset_labels, return_counts=True)
         return np.asarray((unique, counts)).T

--- a/plato/samplers/mindspore/dirichlet.py
+++ b/plato/samplers/mindspore/dirichlet.py
@@ -24,30 +24,37 @@ class Sampler(base.Sampler):
         self.partition_size = Config().data.partition_size
 
         # Concentration parameter to be used in the Dirichlet distribution
-        concentration = Config().data.concentration if hasattr(
-            Config().data, 'concentration') else 1.0
+        concentration = (
+            Config().data.concentration
+            if hasattr(Config().data, "concentration")
+            else 1.0
+        )
 
         # The list of labels (targets) for all the examples
         target_list = datasource.targets()
         class_list = datasource.classes()
 
         target_proportions = np.random.dirichlet(
-            np.repeat(concentration, len(class_list)))
+            np.repeat(concentration, len(class_list))
+        )
 
         self.sample_weights = target_proportions[target_list]
 
     def get(self):
-        """Obtains an instance of the sampler. """
+        """Obtains an instance of the sampler."""
         ds.config.set_seed(self.random_seed)
 
         # Samples without replacement using the sample weights
         subset_indices = list(
-            WeightedRandomSampler(weights=self.sample_weights,
-                                  num_samples=self.partition_size,
-                                  replacement=False))
+            WeightedRandomSampler(
+                weights=self.sample_weights,
+                num_samples=self.partition_size,
+                replacement=False,
+            )
+        )
 
         return SubsetRandomSampler(subset_indices)
 
-    def trainset_size(self):
-        """Returns the length of the dataset after sampling. """
+    def num_samples(self):
+        """Returns the length of the dataset after sampling."""
         return self.partition_size

--- a/plato/samplers/mindspore/iid.py
+++ b/plato/samplers/mindspore/iid.py
@@ -13,6 +13,7 @@ from plato.config import Config
 class Sampler(base.Sampler):
     """Create a data sampler for each client to use a randomly divided partition of the
     dataset."""
+
     def __init__(self, datasource, client_id=0, testing=False):
         super().__init__()
         self.client_id = client_id
@@ -27,20 +28,21 @@ class Sampler(base.Sampler):
 
         # add extra samples to make it evenly divisible, if needed
         if len(indices) < total_size:
-            indices += indices[:(total_size - len(indices))]
+            indices += indices[: (total_size - len(indices))]
         else:
             indices = indices[:total_size]
         assert len(indices) == total_size
 
         # Compute the indices of data in the subset for this client
-        self.subset_indices = indices[(int(self.client_id) -
-                                       1):total_size:total_clients]
+        self.subset_indices = indices[
+            (int(self.client_id) - 1) : total_size : total_clients
+        ]
 
     def get(self):
-        """Obtains an instance of the sampler. """
+        """Obtains an instance of the sampler."""
         ds.config.set_seed(self.random_seed)
         return SubsetRandomSampler(self.subset_indices)
 
-    def trainset_size(self):
-        """Returns the length of the dataset after sampling. """
+    def num_samples(self):
+        """Returns the length of the dataset after sampling."""
         return len(self.subset_indices)

--- a/plato/samplers/registry.py
+++ b/plato/samplers/registry.py
@@ -6,74 +6,79 @@ on a configuration at run-time.
 """
 import logging
 from collections import OrderedDict
+import numpy as np
 
 from plato.config import Config
 
-if hasattr(Config().trainer, 'use_mindspore'):
+if hasattr(Config().trainer, "use_mindspore"):
     from plato.samplers.mindspore import (
         iid as iid_mindspore,
         dirichlet as dirichlet_mindspore,
     )
 
-    registered_samplers = OrderedDict([
-        ('iid', iid_mindspore.Sampler),
-        ('noniid', dirichlet_mindspore.Sampler),
-    ])
-elif hasattr(Config().trainer, 'use_tensorflow'):
+    registered_samplers = OrderedDict(
+        [
+            ("iid", iid_mindspore.Sampler),
+            ("noniid", dirichlet_mindspore.Sampler),
+        ]
+    )
+elif hasattr(Config().trainer, "use_tensorflow"):
     from plato.samplers.tensorflow import base
-    registered_samplers = OrderedDict([
-        ('iid', base.Sampler),
-        ('noniid', base.Sampler),
-        ('mixed', base.Sampler),
-    ])
-else:
-    from plato.samplers import (iid, dirichlet, mixed, orthogonal,
-                                all_inclusive, distribution_noniid,
-                                label_quantity_noniid,
-                                mixed_label_quantity_noniid,
-                                sample_quantity_noniid, modality_iid,
-                                modality_quantity_noniid)
 
-    registered_samplers = OrderedDict([
-        ('iid', iid.Sampler),
-        ('noniid', dirichlet.Sampler),
-        ('mixed', mixed.Sampler),
-        ('orthogonal', orthogonal.Sampler),
-        ('all_inclusive', all_inclusive.Sampler),
-        ('distribution_noniid', distribution_noniid.Sampler),
-        ('label_quantity_noniid', label_quantity_noniid.Sampler),
-        ('mixed_label_quantity_noniid', mixed_label_quantity_noniid.Sampler),
-        ('sample_quantity_noniid', sample_quantity_noniid.Sampler),
-        ('modality_iid', modality_iid.Sampler),
-        ('modality_quantity_noniid', modality_quantity_noniid.Sampler),
-    ])
+    registered_samplers = OrderedDict(
+        [
+            ("iid", base.Sampler),
+            ("noniid", base.Sampler),
+            ("mixed", base.Sampler),
+        ]
+    )
+else:
+    from plato.samplers import (
+        iid,
+        dirichlet,
+        mixed,
+        orthogonal,
+        all_inclusive,
+        distribution_noniid,
+        label_quantity_noniid,
+        mixed_label_quantity_noniid,
+        sample_quantity_noniid,
+        modality_iid,
+        modality_quantity_noniid,
+    )
+
+    registered_samplers = OrderedDict(
+        [
+            ("iid", iid.Sampler),
+            ("noniid", dirichlet.Sampler),
+            ("mixed", mixed.Sampler),
+            ("orthogonal", orthogonal.Sampler),
+            ("all_inclusive", all_inclusive.Sampler),
+            ("distribution_noniid", distribution_noniid.Sampler),
+            ("label_quantity_noniid", label_quantity_noniid.Sampler),
+            ("mixed_label_quantity_noniid", mixed_label_quantity_noniid.Sampler),
+            ("sample_quantity_noniid", sample_quantity_noniid.Sampler),
+            ("modality_iid", modality_iid.Sampler),
+            ("modality_quantity_noniid", modality_quantity_noniid.Sampler),
+        ]
+    )
 
 
 def get(datasource, client_id, testing=False):
     """Get an instance of the sampler."""
-    if testing == 'edge':
-        if hasattr(Config().data, 'edge_testset_sampler'):
-            sampler_type = Config().data.edge_testset_sampler
-            logging.info("[Edge Server #%d] Test set sampler: %s", client_id,
-                         sampler_type)
-    elif testing:
-        if hasattr(Config().data, 'testset_sampler'):
-            sampler_type = Config().data.testset_sampler
-            logging.info("[Client #%d] Test set sampler: %s", client_id,
-                         sampler_type)
-    else:
-        if hasattr(Config().data, 'sampler'):
-            sampler_type = Config().data.sampler
-        else:
-            sampler_type = 'iid'
 
+    if testing and hasattr(Config().data, "testset_sampler"):
+        sampler_type = Config().data.testset_sampler
+        logging.info("[Client #%d] Test set sampler: %s", client_id, sampler_type)
+    else:
+        sampler_type = Config().data.sampler
         logging.info("[Client #%d] Sampler: %s", client_id, sampler_type)
 
     if sampler_type in registered_samplers:
-        registered_sampler = registered_samplers[sampler_type](datasource,
-                                                               client_id,
-                                                               testing=testing)
+        registered_sampler = registered_samplers[sampler_type](
+            datasource, client_id, testing=testing
+        )
     else:
-        raise ValueError('No such sampler: {}'.format(sampler_type))
+        raise ValueError(f"No such sampler: {sampler_type}")
 
     return registered_sampler

--- a/plato/samplers/tensorflow/base.py
+++ b/plato/samplers/tensorflow/base.py
@@ -1,16 +1,15 @@
 """
 Base class for sampling data so that a dataset can be divided across the clients.
 """
-import os
 from abc import abstractmethod
 
-from plato.config import Config
 from plato.samplers import base
 
 
 class Sampler(base.Sampler):
     """Base class for data samplers so that the dataset is divided into
     partitions across the clients."""
+
     def __init__(self, datasource, client_id=0, testing=False):
         super().__init__()
         self.client_id = client_id
@@ -22,8 +21,8 @@ class Sampler(base.Sampler):
 
     @abstractmethod
     def get(self):
-        """Obtains an instance of the sampler. """
+        """Obtains an instance of the sampler."""
         return None
 
-    def trainset_size(self):
+    def num_samples(self):
         return len(self.all_inclusive)

--- a/plato/servers/fedavg.py
+++ b/plato/servers/fedavg.py
@@ -97,7 +97,10 @@ class Server(base.Server):
                 self.datasource = self.custom_datasource()
 
             self.testset = self.datasource.get_test_set()
-            self.testset_sampler = all_inclusive.Sampler(self.datasource, testing=True)
+            if hasattr(Config().data, "testset_size"):
+                self.testset_sampler = all_inclusive.Sampler(
+                    self.datasource, testing=True
+                )
 
         # Initialize the csv file which will record results
         result_csv_file = f"{Config().params['result_path']}/{os.getpid()}.csv"

--- a/plato/servers/fedavg_cs.py
+++ b/plato/servers/fedavg_cs.py
@@ -143,9 +143,10 @@ class Server(fedavg.Server):
                         self.datasource, Config().args.id, testing=True
                     )
                 else:
-                    self.testset_sampler = all_inclusive.Sampler(
-                        self.datasource, testing=True
-                    )
+                    if hasattr(Config().data, "testset_size"):
+                        self.testset_sampler = all_inclusive.Sampler(
+                            self.datasource, testing=True
+                        )
 
             # Initialize path of the result .csv file
             result_path = Config().params["result_path"]


### PR DESCRIPTION
Refactored the design of the `all_inclusive` sampler so that an optional `data -> testset_size` can be used to determine the number of samples to draw from a `SubsetRandomSampler`. By default, the `all_inclusive` sampler will draw from all the samples in the train or test dataset.

This refactoring also fixed a runtime error when the server specifies the `testset_size`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue) Fixes #
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
