### PR TITLE
Added client callbacks to adjust the processors in the runtime

### DIFF
--- a/docs/client.md
+++ b/docs/client.md
@@ -35,3 +35,31 @@ Within the implementation of these callback methods, one can access additional i
 
 To use callbacks, subclass the `ClientCallback` class in `plato.callbacks.client`, and override the following methods:
 
+
+````{admonition} **on_inbound_process(self, client, inbound_processor)**
+Override this method to complete additional tasks before the inbound processors start to process the data received from the server.
+
+`inbound_processor` the pipeline of inbound processors, where each of them can be accessed through list `inbound_processor.processors`.
+
+**Example:**
+
+```py
+def on_inbound_process(self, client, inbound_processor):
+    # insert a customized processor to the inbound processor list
+    inbound_processor.processors.insert(0, customized_processor) 
+```
+````
+
+````{admonition} **on_outbound_process(self, client, outbound_processor)**
+Override this method to complete additional tasks before the outbound processors start to process the data to be sent to the server.
+
+`outbound_processor` the pipeline of outbound processors, where each of them can be accessed through list `outbound_processor.processors`.
+
+**Example:**
+
+```py
+def on_outbound_process(self, client, outbound_processor):
+    # remove the first processor from the outbound processor list
+    outbound_processor.processors.pop() 
+```
+````

--- a/docs/client.md
+++ b/docs/client.md
@@ -39,13 +39,19 @@ To use callbacks, subclass the `ClientCallback` class in `plato.callbacks.client
 ````{admonition} **on_inbound_process(self, client, inbound_processor)**
 Override this method to complete additional tasks before the inbound processors start to process the data received from the server.
 
-`inbound_processor` the pipeline of inbound processors, where each of them can be accessed through list `inbound_processor.processors`.
+`inbound_processor` the pipeline of inbound processors. The list of inbound processor instances can be accessed through its attribute 'processors', as in the following example.
 
 **Example:**
 
 ```py
-def on_inbound_process(self, client, inbound_processor):
-    # insert a customized processor to the inbound processor list
+def on_inbound_process(self, client, inbound_processor: list):
+    # insert a customized processor to the list of inbound processors
+    customized_processor = DummyProcessor(
+            client_id=client.client_id,
+            current_round=client.current_round,
+            name="DummyProcessor",
+        )
+
     inbound_processor.processors.insert(0, customized_processor) 
 ```
 ````
@@ -53,13 +59,13 @@ def on_inbound_process(self, client, inbound_processor):
 ````{admonition} **on_outbound_process(self, client, outbound_processor)**
 Override this method to complete additional tasks before the outbound processors start to process the data to be sent to the server.
 
-`outbound_processor` the pipeline of outbound processors, where each of them can be accessed through list `outbound_processor.processors`.
+`outbound_processor` the pipeline of outbound processors. The list of inbound processor instances can be accessed through its attribute 'processors', as in the following example.
 
 **Example:**
 
 ```py
 def on_outbound_process(self, client, outbound_processor):
-    # remove the first processor from the outbound processor list
+    # remove the first processor from the list of outbound processors
     outbound_processor.processors.pop() 
 ```
 ````

--- a/examples/FedRep/fedrep_client.py
+++ b/examples/FedRep/fedrep_client.py
@@ -17,12 +17,16 @@ from plato.clients import simple
 class Client(simple.Client):
     """A personalized federated learning client using the FedRep algorithm."""
 
-    def __init__(self,
-                 model=None,
-                 datasource=None,
-                 algorithm=None,
-                 trainer=None):
-        super().__init__(model, datasource, algorithm, trainer)
+    def __init__(
+        self, model=None, datasource=None, algorithm=None, trainer=None, callbacks=None
+    ):
+        super().__init__(
+            model=model,
+            datasource=datasource,
+            algorithm=algorithm,
+            trainer=trainer,
+            callbacks=callbacks,
+        )
 
         # parameter names of the representation
         #   As mentioned by Eq. 1 and Fig. 2 of the paper, the representation
@@ -34,8 +38,7 @@ class Client(simple.Client):
         super().process_server_response(server_response)
 
         # obtain the representation sent by the server
-        self.representation_param_names = server_response[
-            "representation_param_names"]
+        self.representation_param_names = server_response["representation_param_names"]
 
         # The trainer responsible for optimizing the model should know
         # which part parameters behave as the representation and which
@@ -44,10 +47,12 @@ class Client(simple.Client):
         # representation is optimized in the 'Server Update', as mentioned
         # in Section 3 of the FedRep paper.
         self.trainer.set_representation_and_head(
-            representation_param_names=self.representation_param_names)
+            representation_param_names=self.representation_param_names
+        )
 
         # The algorithm only operates on the representation without
         # considering the head as the head is solely known by each client
         # because of personalization.
         self.algorithm.set_representation_param_names(
-            representation_param_names=self.representation_param_names)
+            representation_param_names=self.representation_param_names
+        )

--- a/examples/adaptive_hgb/adaptive_hgb_client.py
+++ b/examples/adaptive_hgb/adaptive_hgb_client.py
@@ -37,8 +37,21 @@ class Report(base.Report):
 class Client(simple.Client):
     """A federated learning client with support for Adaptive gradient blending."""
 
-    def __init__(self, model=None, datasource=None, algorithm=None, trainer=None):
-        super().__init__()
+    def __init__(
+        self,
+        model=None,
+        datasource=None,
+        algorithm=None,
+        trainer=None,
+        callbacks=None,
+    ):
+        super().__init__(
+            model=model,
+            datasource=datasource,
+            algorithm=algorithm,
+            trainer=trainer,
+            callbacks=callbacks,
+        )
         self.model = model
         self.datasource = datasource
         self.algorithm = algorithm

--- a/examples/customized_processor/customize_callback.py
+++ b/examples/customized_processor/customize_callback.py
@@ -2,6 +2,7 @@
 Customize the inbound and outbound processor list through callbacks. 
 """
 
+import logging
 from plato.callbacks.client import ClientCallback
 
 from dummy_processor import DummyProcessor
@@ -16,12 +17,42 @@ class CustomizeProcessorCallback(ClientCallback):
         """
         Insert a dummy processor to the inbound processor list.
         """
-        customized_processor = DummyProcessor(client.client_id, client.current_round)
+        logging.info(
+            "[%s] Current inbound processor list: %s.",
+            client,
+            inbound_processor.processors,
+        )
+        customized_processor = DummyProcessor(
+            client_id=client.client_id,
+            current_round=client.current_round,
+            processor_name="DummyProcessor",
+        )
         inbound_processor.processors.insert(0, customized_processor)
+
+        logging.info(
+            "[%s] Inbound processor list after modification: %s.",
+            client,
+            inbound_processor.processors,
+        )
 
     def on_outbound_process(self, client, outbound_processor):
         """
         Insert a dummy processor to the outbound processor list.
         """
-        customized_processor = DummyProcessor(client.client_id, client.current_round)
+        logging.info(
+            "[%s] Current outbound processor list: %s.",
+            client,
+            outbound_processor.processors,
+        )
+        customized_processor = DummyProcessor(
+            client_id=client.client_id,
+            current_round=client.current_round,
+            processor_name="DummyProcessor",
+        )
         outbound_processor.processors.insert(0, customized_processor)
+
+        logging.info(
+            "[%s] Outbound processor list after modification: %s.",
+            client,
+            outbound_processor.processors,
+        )

--- a/examples/customized_processor/customize_callback.py
+++ b/examples/customized_processor/customize_callback.py
@@ -3,12 +3,13 @@ Customize the inbound and outbound processor list through callbacks.
 """
 
 from plato.callbacks.client import ClientCallback
+
 from dummy_processor import DummyProcessor
 
 
 class CustomizeProcessorCallback(ClientCallback):
     """
-    A client callback that dynamically inserts a dummy processor to the existing processor list .
+    A client callback that dynamically inserts a dummy processor to the existing processor list.
     """
 
     def on_inbound_process(self, client, inbound_processor):

--- a/examples/customized_processor/customize_callback.py
+++ b/examples/customized_processor/customize_callback.py
@@ -1,0 +1,26 @@
+""" 
+Customize the inbound and outbound processor list through callbacks. 
+"""
+
+from plato.callbacks.client import ClientCallback
+from dummy_processor import DummyProcessor
+
+
+class CustomizeProcessorCallback(ClientCallback):
+    """
+    A client callback that dynamically inserts a dummy processor to the existing processor list .
+    """
+
+    def on_inbound_process(self, client, inbound_processor):
+        """
+        Insert a dummpy processor to the inbound processor list.
+        """
+        customized_processor = DummyProcessor(client.client_id, client.current_round)
+        inbound_processor.processors.insert(0, customized_processor)
+
+    def on_outbound_process(self, client, outbound_processor):
+        """
+        Insert a dummpy processor to the outbound processor list.
+        """
+        customized_processor = DummyProcessor(client.client_id, client.current_round)
+        outbound_processor.processors.insert(0, customized_processor)

--- a/examples/customized_processor/customize_callback.py
+++ b/examples/customized_processor/customize_callback.py
@@ -18,41 +18,41 @@ class CustomizeProcessorCallback(ClientCallback):
         Insert a dummy processor to the inbound processor list.
         """
         logging.info(
-            "[%s] Current inbound processor list: %s.",
+            "[%s] Current list of inbound processors: %s.",
             client,
             inbound_processor.processors,
         )
         customized_processor = DummyProcessor(
             client_id=client.client_id,
             current_round=client.current_round,
-            processor_name="DummyProcessor",
+            name="DummyProcessor",
         )
         inbound_processor.processors.insert(0, customized_processor)
 
         logging.info(
-            "[%s] Inbound processor list after modification: %s.",
+            "[%s] List of inbound processors after modification: %s.",
             client,
             inbound_processor.processors,
         )
 
     def on_outbound_process(self, client, outbound_processor):
         """
-        Insert a dummy processor to the outbound processor list.
+        Insert a dummy processor to the list of outbound processors.
         """
         logging.info(
-            "[%s] Current outbound processor list: %s.",
+            "[%s] Current list of outbound processors: %s.",
             client,
             outbound_processor.processors,
         )
         customized_processor = DummyProcessor(
             client_id=client.client_id,
             current_round=client.current_round,
-            processor_name="DummyProcessor",
+            name="DummyProcessor",
         )
         outbound_processor.processors.insert(0, customized_processor)
 
         logging.info(
-            "[%s] Outbound processor list after modification: %s.",
+            "[%s] List of outbound processors after modification: %s.",
             client,
             outbound_processor.processors,
         )

--- a/examples/customized_processor/customize_callback.py
+++ b/examples/customized_processor/customize_callback.py
@@ -14,14 +14,14 @@ class CustomizeProcessorCallback(ClientCallback):
 
     def on_inbound_process(self, client, inbound_processor):
         """
-        Insert a dummpy processor to the inbound processor list.
+        Insert a dummy processor to the inbound processor list.
         """
         customized_processor = DummyProcessor(client.client_id, client.current_round)
         inbound_processor.processors.insert(0, customized_processor)
 
     def on_outbound_process(self, client, outbound_processor):
         """
-        Insert a dummpy processor to the outbound processor list.
+        Insert a dummy processor to the outbound processor list.
         """
         customized_processor = DummyProcessor(client.client_id, client.current_round)
         outbound_processor.processors.insert(0, customized_processor)

--- a/examples/customized_processor/customize_processor.py
+++ b/examples/customized_processor/customize_processor.py
@@ -9,7 +9,7 @@ from plato.clients import simple
 
 
 def main():
-    """A Plato federated learning training session using FedProx."""
+    """A Plato federated learning training session using CustomizeProcessorCallback."""
     client = simple.Client(callbacks=[CustomizeProcessorCallback])
     server = fedavg.Server()
     server.run(client)

--- a/examples/customized_processor/customize_processor.py
+++ b/examples/customized_processor/customize_processor.py
@@ -1,0 +1,19 @@
+"""
+Customize the inbound and outbound processors through client callbacks.
+"""
+
+from customize_callback import CustomizeProcessorCallback
+
+from plato.servers import fedavg
+from plato.clients import simple
+
+
+def main():
+    """A Plato federated learning training session using FedProx."""
+    client = simple.Client(callbacks=[CustomizeProcessorCallback])
+    server = fedavg.Server()
+    server.run(client)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/customized_processor/dummy_processor.py
+++ b/examples/customized_processor/dummy_processor.py
@@ -1,0 +1,26 @@
+"""
+Dummpy processor which can be used to test customize processor feature.
+"""
+
+import logging
+from typing import Any
+from plato.processors import base
+
+
+class DummyProcessor(base.Processor):
+    """A dummpy processor to be instantiated and inserted to the processor list in the runtime."""
+
+    def __init__(self, client_id, current_round, **kwargs) -> None:
+        super().__init__(**kwargs)
+
+        self.client_id = client_id
+        self.current_round = current_round
+
+    def process(self, data: Any) -> Any:
+
+        logging.info(
+            "[Client #%s] Customized dummmy processor is activated at round %s.",
+            self.client_id,
+            self.current_round,
+        )
+        return data

--- a/examples/customized_processor/dummy_processor.py
+++ b/examples/customized_processor/dummy_processor.py
@@ -1,5 +1,5 @@
 """
-Dummpy processor which can be used to test customize processor feature.
+Dummy processor which can be used to test customize processor feature.
 """
 
 import logging
@@ -8,7 +8,7 @@ from plato.processors import base
 
 
 class DummyProcessor(base.Processor):
-    """A dummpy processor to be instantiated and inserted to the processor list in the runtime."""
+    """A dummy processor to be instantiated and inserted to the processor list in the runtime."""
 
     def __init__(self, client_id, current_round, **kwargs) -> None:
         super().__init__(**kwargs)

--- a/examples/fedsarah/fedsarah_client.py
+++ b/examples/fedsarah/fedsarah_client.py
@@ -16,8 +16,16 @@ class Client(simple.Client):
     """A FedSarah federated learning client who sends weight updates
     and client control variates."""
 
-    def __init__(self, model=None, datasource=None, algorithm=None, trainer=None):
-        super().__init__(model, datasource, algorithm, trainer)
+    def __init__(
+        self, model=None, datasource=None, algorithm=None, trainer=None, callbacks=None
+    ):
+        super().__init__(
+            model=model,
+            datasource=datasource,
+            algorithm=algorithm,
+            trainer=trainer,
+            callbacks=callbacks,
+        )
         self.client_control_variates = None
         self.server_control_variates = None
         self.new_client_control_variates = None

--- a/examples/fedunlearning/fedunlearning_client.py
+++ b/examples/fedunlearning/fedunlearning_client.py
@@ -21,15 +21,16 @@ from plato.config import Config
 class Client(simple.Client):
     """A federated learning client of federated unlearning."""
 
-    def __init__(self,
-                 model=None,
-                 datasource=None,
-                 algorithm=None,
-                 trainer=None):
-        super().__init__(model=model,
-                         datasource=datasource,
-                         algorithm=algorithm,
-                         trainer=trainer)
+    def __init__(
+        self, model=None, datasource=None, algorithm=None, trainer=None, callbacks=None
+    ):
+        super().__init__(
+            model=model,
+            datasource=datasource,
+            algorithm=algorithm,
+            trainer=trainer,
+            callbacks=None,
+        )
 
         self.previous_round = {}
 
@@ -49,9 +50,11 @@ class Client(simple.Client):
             logging.info(
                 "[%s] Unlearning sampler deployed: %s%% of the samples were deleted.",
                 self,
-                Config().clients.deleted_data_ratio * 100)
+                Config().clients.deleted_data_ratio * 100,
+            )
 
-            self.sampler = unlearning_iid.Sampler(self.datasource,
-                                                  self.client_id, False)
+            self.sampler = unlearning_iid.Sampler(
+                self.datasource, self.client_id, False
+            )
 
         self.previous_round[self.client_id] = self.current_round

--- a/examples/scaffold/scaffold_client.py
+++ b/examples/scaffold/scaffold_client.py
@@ -23,8 +23,21 @@ class Client(simple.Client):
     """A SCAFFOLD federated learning client who sends weight updates
     and client control variate."""
 
-    def __init__(self, model=None, datasource=None, algorithm=None, trainer=None):
-        super().__init__(model, datasource, algorithm, trainer)
+    def __init__(
+        self,
+        model=None,
+        datasource=None,
+        algorithm=None,
+        trainer=None,
+        callbacks=None,
+    ):
+        super().__init__(
+            model=model,
+            datasource=datasource,
+            algorithm=algorithm,
+            trainer=trainer,
+            callbacks=callbacks,
+        )
 
         self.client_control_variate = None
         self.server_control_variate = None

--- a/examples/split_learning/split_learning_client.py
+++ b/examples/split_learning/split_learning_client.py
@@ -20,9 +20,20 @@ class Report:
 class Client(simple.Client):
     """A split learning client."""
 
-    def __init__(self, model=None, datasource=None, algorithm=None, trainer=None):
+    def __init__(
+        self,
+        model=None,
+        datasource=None,
+        algorithm=None,
+        trainer=None,
+        callbacks=None,
+    ):
         super().__init__(
-            model=model, datasource=datasource, algorithm=algorithm, trainer=trainer
+            model=model,
+            datasource=datasource,
+            algorithm=algorithm,
+            trainer=trainer,
+            callbacks=callbacks,
         )
 
         self.model_received = False

--- a/plato/callbacks/client.py
+++ b/plato/callbacks/client.py
@@ -6,6 +6,7 @@ Defines a default callback to print local training progress.
 """
 
 from abc import ABC
+import logging
 
 
 class ClientCallback(ABC):
@@ -13,8 +14,30 @@ class ClientCallback(ABC):
     The abstract base class to be subclassed when creating new client callbacks.
     """
 
+    def on_inbound_process(self, client, inbound_processor):
+        """
+        Event called before inbound processors start to process data.
+        """
+
+    def on_outbound_process(self, client, outbound_processor):
+        """
+        Event called before outbound processors start to process data.
+        """
+
 
 class PrintProgressCallback(ClientCallback):
     """
     A callback which prints a message when needed.
     """
+
+    def on_inbound_process(self, client, inbound_processor):
+        """
+        Event called before inbound processors start to process data.
+        """
+        logging.info("[%s] Start to process inbound data.", client)
+
+    def on_outbound_process(self, client, outbound_processor):
+        """
+        Event called before outbound processors start to process data.
+        """
+        logging.info("[%s] Start to process outbound data.", client)

--- a/plato/clients/base.py
+++ b/plato/clients/base.py
@@ -189,6 +189,9 @@ class Client:
                 payload_size / 1024**2,
             )
 
+            self.callback_handler.call_event(
+                "on_inbound_process", self, self.inbound_processor
+            )
             self.server_payload = self.inbound_processor.process(self.server_payload)
 
             await self.start_training()
@@ -295,6 +298,9 @@ class Client:
     async def send(self, payload) -> None:
         """Sending the client payload to the server using simulation, S3 or socket.io."""
         # First apply outbound processors, if any
+        self.callback_handler.call_event(
+            "on_outbound_process", self, self.outbound_processor
+        )
         payload = self.outbound_processor.process(payload)
 
         if self.comm_simulation:

--- a/plato/clients/edge.py
+++ b/plato/clients/edge.py
@@ -14,10 +14,20 @@ class Client(simple.Client):
     """A federated learning client at the edge server in a cross-silo training workload."""
 
     def __init__(
-        self, server, model=None, datasource=None, algorithm=None, trainer=None
+        self,
+        server,
+        model=None,
+        datasource=None,
+        algorithm=None,
+        trainer=None,
+        callbacks=None,
     ):
         super().__init__(
-            model=model, datasource=datasource, algorithm=algorithm, trainer=trainer
+            model=model,
+            datasource=datasource,
+            algorithm=algorithm,
+            trainer=trainer,
+            callbacks=callbacks,
         )
         self.server = server
 

--- a/plato/clients/simple.py
+++ b/plato/clients/simple.py
@@ -19,8 +19,10 @@ from plato.utils import fonts
 class Client(base.Client):
     """A basic federated learning client who sends simple weight updates."""
 
-    def __init__(self, model=None, datasource=None, algorithm=None, trainer=None):
-        super().__init__()
+    def __init__(
+        self, model=None, datasource=None, algorithm=None, trainer=None, callbacks=None
+    ):
+        super().__init__(callbacks)
         self.custom_model = model
         self.model = None
 

--- a/plato/clients/simple.py
+++ b/plato/clients/simple.py
@@ -22,7 +22,7 @@ class Client(base.Client):
     def __init__(
         self, model=None, datasource=None, algorithm=None, trainer=None, callbacks=None
     ):
-        super().__init__(callbacks)
+        super().__init__(callbacks=callbacks)
         self.custom_model = model
         self.model = None
 

--- a/plato/processors/base.py
+++ b/plato/processors/base.py
@@ -11,8 +11,10 @@ class Processor:
     """
     The base Processor class does nothing on the data payload.
     """
-    def __init__(self, trainer=None, **kwargs) -> None:
-        """ Constructor for Processor. """
+
+    def __init__(self, processor_name=None, trainer=None, **kwargs) -> None:
+        """Constructor for Processor."""
+        self.processor_name = processor_name
         self.trainer = trainer
 
     @abstractmethod
@@ -27,3 +29,6 @@ class Processor:
         Processing an Iterable of data payload.
         """
         return map(self.process, data)
+
+    def __repr__(self) -> str:
+        return self.processor_name

--- a/plato/processors/base.py
+++ b/plato/processors/base.py
@@ -12,9 +12,9 @@ class Processor:
     The base Processor class does nothing on the data payload.
     """
 
-    def __init__(self, processor_name=None, trainer=None, **kwargs) -> None:
+    def __init__(self, name=None, trainer=None, **kwargs) -> None:
         """Constructor for Processor."""
-        self.processor_name = processor_name
+        self.name = name
         self.trainer = trainer
 
     @abstractmethod
@@ -31,4 +31,4 @@ class Processor:
         return map(self.process, data)
 
     def __repr__(self) -> str:
-        return self.processor_name
+        return self.name

--- a/plato/processors/registry.py
+++ b/plato/processors/registry.py
@@ -100,7 +100,7 @@ def get(
         else:
             this_kwargs = kwargs
 
-        return registered_processors[name](**this_kwargs)
+        return registered_processors[name](processor_name=name, **this_kwargs)
 
     outbound_processors = list(map(map_f, outbound_processors))
     inbound_processors = list(map(map_f, inbound_processors))

--- a/plato/processors/registry.py
+++ b/plato/processors/registry.py
@@ -100,7 +100,7 @@ def get(
         else:
             this_kwargs = kwargs
 
-        return registered_processors[name](processor_name=name, **this_kwargs)
+        return registered_processors[name](name=name, **this_kwargs)
 
     outbound_processors = list(map(map_f, outbound_processors))
     inbound_processors = list(map(map_f, inbound_processors))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Describe motivation and context -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Added client callbacks before the inbound and outbound processors start to process the data, which allows user to dynamically adjusting the processor lists or settings in the runtime.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

The new feature has been tested by running ```python examples/customized_processor/customize_processor.py -c configs/MNIST/fedavg_lenet5.yml```, which instantiates a dummy processor at each round and inserts it into the processor list.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) Fixes #
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
