### PR TITLE
fixed bug, making timm scheduler work when setting global_scheduler: true

### DIFF
--- a/configs/MNIST/fedavg_lenet5_timm_globalLR.yml
+++ b/configs/MNIST/fedavg_lenet5_timm_globalLR.yml
@@ -1,0 +1,72 @@
+clients:
+    # Type
+    type: simple
+
+    # The total number of clients
+    total_clients: 10
+
+    # The number of clients selected in each round
+    per_round: 2
+
+    # Should the clients compute test accuracy locally?
+    do_test: false
+
+    # Processors for outbound data payloads
+    outbound_processors:
+        - unstructured_pruning
+        - model_compress
+
+server:
+    address: 127.0.0.1
+    port: 8000
+    random_seed: 1
+    simulate_wall_time: true
+
+    # Processors for inbound data payloads
+    inbound_processors:
+        - model_decompress
+
+data: !include mnist_iid.yml
+
+trainer:
+    # The type of the trainer
+    type: timm_basic
+
+    # The maximum number of training rounds
+    rounds: 5
+
+    # The maximum number of clients running concurrently
+    max_concurrency: 1
+
+    # The target accuracy
+    target_accuracy: 0.99
+
+    # The machine learning model
+    model_name: lenet5
+
+    # Number of epoches for local training in each communication round
+    epochs: 5
+    batch_size: 32
+    optimizer: SGD
+    lr_scheduler: timm
+    global_lr_scheduler: true
+
+algorithm:
+    # Aggregation algorithm
+    type: fedavg
+
+parameters:
+    model:
+        num_classes: 10
+
+    optimizer:
+        lr: 0.01
+        momentum: 0.9
+        weight_decay: 0.0
+
+    learning_rate:
+        sched: cosine
+        min_lr: 1.e-6
+        warmup_lr: 0.0001
+        warmup_epochs: 3
+        cooldown_epochs: 10

--- a/plato/trainers/basic.py
+++ b/plato/trainers/basic.py
@@ -574,17 +574,20 @@ class TrainerWithTimmScheduler(Trainer):
         """Method called at the beginning of a training epoch."""
         super().train_epoch_start(config)
         self.num_updates = self.current_epoch * len(self.train_loader)
+
         if "global_lr_scheduler" in config and config["global_lr_scheduler"]:
             self.num_updates += self.past_epochs * len(self.train_loader)
 
     def lr_scheduler_step(self):
         self.num_updates += 1
+
         if self.lr_scheduler is not None:
             self.lr_scheduler.step_update(num_updates=self.num_updates)
 
     def train_epoch_end(self, config):
         """Method called at the end of a training epoch."""
         super().train_epoch_end(config)
+
         if self.lr_scheduler is not None:
             if "global_lr_scheduler" in config and config["global_lr_scheduler"]:
                 self.lr_scheduler.step(self.past_epochs + self.current_epoch + 1)

--- a/plato/trainers/basic.py
+++ b/plato/trainers/basic.py
@@ -568,11 +568,14 @@ class TrainerWithTimmScheduler(Trainer):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.num_updates = None
+        self.past_epochs = None
 
     def train_epoch_start(self, config):
         """Method called at the beginning of a training epoch."""
         super().train_epoch_start(config)
         self.num_updates = self.current_epoch * len(self.train_loader)
+        if "global_lr_scheduler" in config and config["global_lr_scheduler"]:
+            self.num_updates += self.past_epochs * len(self.train_loader)
 
     def lr_scheduler_step(self):
         self.num_updates += 1
@@ -583,4 +586,21 @@ class TrainerWithTimmScheduler(Trainer):
         """Method called at the end of a training epoch."""
         super().train_epoch_end(config)
         if self.lr_scheduler is not None:
-            self.lr_scheduler.step(self.current_epoch + 1)
+            if "global_lr_scheduler" in config and config["global_lr_scheduler"]:
+                self.lr_scheduler.step(self.past_epochs + self.current_epoch + 1)
+            else:
+                self.lr_scheduler.step(self.current_epoch + 1)
+
+    def _adjust_lr(self, config, lr_scheduler, optimizer) -> torch.optim.Optimizer:
+        """Returns an optimizer with an initial learning rate that has been
+        adjusted according to the current round, so that learning rate
+        schedulers can be effective throughout the communication rounds."""
+
+        if "global_lr_scheduler" in config and config["global_lr_scheduler"]:
+            past_epochs = (self.current_round - 1) * Config().trainer.epochs
+            self.past_epochs = past_epochs
+
+            lr_scheduler.step(past_epochs)
+            lr_scheduler.step_update(past_epochs * len(self.train_loader))
+
+        return optimizer

--- a/plato/trainers/basic.py
+++ b/plato/trainers/basic.py
@@ -573,6 +573,7 @@ class TrainerWithTimmScheduler(Trainer):
     def train_epoch_start(self, config):
         """Method called at the beginning of a training epoch."""
         super().train_epoch_start(config)
+
         self.num_updates = self.current_epoch * len(self.train_loader)
 
         if "global_lr_scheduler" in config and config["global_lr_scheduler"]:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
When I used the timm scheduler where the trainer type is timm_basic, I also set the config global_lr_scheduler to true and it will give out such error report: 
```
plato/trainers/basic.py", line 518, in _adjust_lr
    initial_lr = global_lr_scheduler.get_last_lr()
AttributeError: 'CosineLRScheduler' object has no attribute 'get_last_lr'
```
That is because ```timm``` scheduler does not have class function ```get_last_lr``` only has private function ```_get_lr```.  


## Description
<!--- Describe your changes in detail -->
Override the ```_adjust_lr``` function in class ```TrainerWithTimmScheduler```. The update of timm scheduler is different from torch scheduler. First it has ```step``` and ```step_update```, the scheduler  will automatically decide step on epochs and step on num of updates. The parameter is epoch or num of updates, and we need to put in all cumulated epochs/updates we want to ```step``` function and the lr will be scheduled. 

As a result, besides modifying ```_adjust_lr```, I also modify the ```train_epoch_start``` and ```train_epoch_end```. I added a condition check whether the ```global_lr_scheduler``` is ```true``` and if so, it will let scheduler step with global cumulated epochs/updates.

<!--- Describe motivation and context -->
Because when I want to train the vit models, they need global scheduler and the scheduler in ```timm```, to support warmup and cool down scheduling.
<!--- Why is this change required? What problem does it solve? -->
Fix the error raised when using timm scheduler and setting ```global_slr_scheduler``` to ```true``` at the same time.
<!--- If it fixes an open issue, please link to the issue here. -->
I did not open an issue.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
Run the command
```
./run -c configs/MNIST/fedavg_lenet5_timm_globalLR.yml
```
<!--- Include details of your testing environment, tests ran to see how -->
The configuration file is only different with ```configs/MNIST/fedavg_lenet5_timm.yml``` that I added ```global_lr_scheduler: true```.
The ```timm``` version I used is 
```
timm==0.6.11
```
The source code of ```timm```. [Link](https://github.com/rwightman/pytorch-image-models/tree/main/timm/scheduler)
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) Fixes #
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been formatted using Black and checked using PyLint.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
