### PR TITLE
Added HuggingFace ViT into model types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,6 +141,7 @@ tests/data/
 
 # Models and checkpoints
 pretrained/
+models/
 logs/
 checkpoints/
 *.pth

--- a/.gitignore
+++ b/.gitignore
@@ -141,7 +141,6 @@ tests/data/
 
 # Models and checkpoints
 pretrained/
-models/
 logs/
 checkpoints/
 *.pth

--- a/configs/ViT/fedavg_cifar10_swinv2.yml
+++ b/configs/ViT/fedavg_cifar10_swinv2.yml
@@ -1,0 +1,70 @@
+clients:
+    # Type
+    type: simple
+
+    # The total number of clients
+    total_clients: 2
+
+    # The number of clients selected in each round
+    per_round: 2
+
+    # Should the clients compute test accuracy locally?
+    do_test: false
+
+server:
+    address: 127.0.0.1
+    port: 8000
+    simulate_wall_time: false
+    checkpoint_path: checkpoints/huggingface/fedavg
+    model_path: models/huggingface/fedavg
+
+data:
+    # The training and testing dataset
+    datasource: CIFAR10
+
+    # Number of samples in each partition
+    partition_size: 5000
+
+    # IID or non-IID?
+    sampler: iid
+
+    # The random seed for sampling data
+    random_seed: 1
+
+trainer:
+    # The type of the trainer
+    type: basic
+
+    # The maximum number of training rounds
+    rounds: 30
+
+    # The maximum number of clients running concurrently
+    max_concurrency: 2
+
+    # The machine learning model
+    model_type: vit
+    model_name: microsoft@swinv2-tiny-patch4-window8-256
+
+    # Number of epoches for local training in each communication round
+    epochs: 5
+    batch_size: 64
+    optimizer: AdamW
+    lr_scheduler: CosineAnnealingLR
+    global_lr_scheduler: true
+
+algorithm:
+    # Aggregation algorithm
+    type: fedavg
+
+parameters:
+    model:
+        num_labels: 10
+
+    optimizer:
+        lr: 0.00004
+        weight_decay: 0.00000001
+
+    learning_rate:
+        eta_min: 0
+        T_max: 30
+

--- a/configs/ViT/fedavg_tinyimagenet_levit.yml
+++ b/configs/ViT/fedavg_tinyimagenet_levit.yml
@@ -1,0 +1,82 @@
+clients:
+    # Type
+    type: simple
+
+    # The total number of clients
+    total_clients: 2
+
+    # The number of clients selected in each round
+    per_round: 2
+
+    # Should the clients compute test accuracy locally?
+    do_test: false
+
+server:
+    address: 127.0.0.1
+    port: 8000
+    simulate_wall_time: false
+    checkpoint_path: checkpoints/huggingface/fedavg
+    model_path: models/huggingface/fedavg
+
+data:
+    # The training and testing dataset
+    datasource: TinyImageNet
+    data_path: /data/dixi/tiny-imagenet-200
+
+    # Number of samples in each partition
+    partition_size: 10000
+
+    # IID or non-IID?
+    sampler: iid
+
+    # The random seed for sampling data
+    random_seed: 1
+
+trainer:
+    # The type of the trainer
+    type: timm_basic
+
+    # The maximum number of training rounds
+    rounds: 200
+
+    # The maximum number of clients running concurrently
+    max_concurrency: 2
+
+    # The machine learning model
+    model_type: vit
+    model_name: facebook@levit-128
+
+    # Number of epoches for local training in each communication round
+    epochs: 5
+    batch_size: 256
+    optimizer: AdamW
+    lr_scheduler: timm
+    global_lr_scheduler: true
+
+algorithm:
+    # Aggregation algorithm
+    type: fedavg
+
+parameters:
+    #model:
+    #    num_labels: 200
+
+    optimizer:
+        lr: 0.0005
+        #weight_decay: 0.025
+        eps: 0.00000001
+
+    learning_rate:
+        sched: cosine
+        num_epochs: 100
+        min_lr: 0.00001
+        warmup_lr: 0.000001
+        warmup_epochs: 5
+        cooldown_epochs: 10
+        noise_pct: 0.67
+        noise_std: 1.0
+        decay_epochs: 30
+        decay_rate: 0.1
+        patience_epochs: 10 
+        
+

--- a/configs/ViT/fedavg_tinyimagenet_levit.yml
+++ b/configs/ViT/fedavg_tinyimagenet_levit.yml
@@ -37,7 +37,7 @@ trainer:
     type: timm_basic
 
     # The maximum number of training rounds
-    rounds: 200
+    rounds: 100
 
     # The maximum number of clients running concurrently
     max_concurrency: 2
@@ -63,7 +63,7 @@ parameters:
 
     optimizer:
         lr: 0.0005
-        #weight_decay: 0.025
+        weight_decay: 0.025
         eps: 0.00000001
 
     learning_rate:

--- a/configs/ViT/fedavg_tinyimagenet_levit.yml
+++ b/configs/ViT/fedavg_tinyimagenet_levit.yml
@@ -21,7 +21,7 @@ server:
 data:
     # The training and testing dataset
     datasource: TinyImageNet
-    data_path: /data/dixi/tiny-imagenet-200
+    data_path: data/tiny-imagenet-200
 
     # Number of samples in each partition
     partition_size: 10000

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -473,8 +473,14 @@ The repository where the machine learning model should be retrieved from. The fo
 
 - `huggingface`
 - `torch_hub`
+- `vit`
 
 The name of the model should be specified below, in `model_name`.
+
+```{note}
+For `vit`, please replace the `/` in model name from https://huggingface.co/models with `@`. For example, use `google@vit-base-patch16-224-in21k` instead of `google/vit-base-patch16-224-in21k`.
+```
+
 ````
 
 ````{admonition} **model_name**

--- a/plato/models/registry.py
+++ b/plato/models/registry.py
@@ -23,6 +23,7 @@ else:
         vgg,
         torch_hub,
         huggingface,
+        vit,
     )
 
     registered_models = {
@@ -36,6 +37,7 @@ else:
         "vgg": vgg.Model,
         "torch_hub": torch_hub.Model,
         "huggingface": huggingface.Model,
+        "vit": vit.Model,
     }
 
 

--- a/plato/models/vit.py
+++ b/plato/models/vit.py
@@ -1,0 +1,55 @@
+"""
+Obtaining a ViT model for ImageClassification from the PyTorch Hub.
+"""
+
+from torch import nn
+from transformers import AutoModelForImageClassification, AutoConfig
+from plato.config import Config
+
+
+class ModelChangeResolution(nn.Module):
+    """
+    Ttansform image resolution to assigned resolution of loaded pretrain model.
+    """
+
+    def __init__(self, model_name, config) -> nn.Module:
+        super().__init__()
+        self.model = AutoModelForImageClassification.from_pretrained(
+            model_name,
+            config=config,
+            cache_dir=Config().params["model_path"] + "/huggingface",
+        )
+        self.resolution = config.image_size
+
+    def forward(self, image):
+        """
+        Forward function will first fit image resolution and finally output the logits.
+        """
+        if image.size(-1) != self.resolution:
+            image = nn.functional.interpolate(
+                image, size=self.resolution, mode="bicubic"
+            )
+        outputs = self.model(image)
+        return outputs.logits
+
+
+class Model:
+    """
+    The Transformer and other models loaded from HuggingFace.
+    Supported by HuggingFace
+    https://huggingface.co/docs/transformers/model_doc/auto#transformers.AutoModel
+    """
+
+    @staticmethod
+    def get(model_name=None, **kwargs):  # pylint: disable=unused-argument
+        """Returns a named model from HuggingFace."""
+        config_kwargs = {
+            "cache_dir": None,
+            "revision": "main",
+            "use_auth_token": None,
+        }
+
+        model_name = model_name.replace("@", "/")
+        config = AutoConfig.from_pretrained(model_name, **config_kwargs)
+
+        return ModelChangeResolution(model_name, config)

--- a/plato/models/vit.py
+++ b/plato/models/vit.py
@@ -1,5 +1,5 @@
 """
-Obtaining a ViT model for ImageClassification from the PyTorch Hub.
+Obtaining a ViT model for image classification from HuggingFace.
 """
 
 from torch import nn
@@ -7,9 +7,9 @@ from transformers import AutoModelForImageClassification, AutoConfig
 from plato.config import Config
 
 
-class ModelChangeResolution(nn.Module):
+class ResolutionAdjustedModel(nn.Module):
     """
-    Ttansform image resolution to assigned resolution of loaded pretrain model.
+    Transforms the image resolution to the assigned resolution of a pretrained model.
     """
 
     def __init__(self, model_name, config) -> nn.Module:
@@ -23,7 +23,7 @@ class ModelChangeResolution(nn.Module):
 
     def forward(self, image):
         """
-        Forward function will first fit image resolution and finally output the logits.
+        Adjusts the image resolution and outputs the logits.
         """
         if image.size(-1) != self.resolution:
             image = nn.functional.interpolate(
@@ -52,4 +52,4 @@ class Model:
         model_name = model_name.replace("@", "/")
         config = AutoConfig.from_pretrained(model_name, **config_kwargs)
 
-        return ModelChangeResolution(model_name, config)
+        return ResolutionAdjustedModel(model_name, config)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Previously, for model types hugging face, LM transformers are supported. Here, ViTs from HuggingFace are added

## Description
<!--- Describe your changes in detail -->
Added a model type in registered factories in ```plato/models/registry.py``` and added corresponding model in ```vit.py```.  In ```vit.py```, three changes are made. 
* Add resolution adjustment, the resolution of images will be automatically set to the same as required resolution as the given ViT pretrained models.
*  Extract ```logits``` from outputs of hugging face models.
*  For ViT models, on HuggingFace, many model name include ```/```, this will raise conflicts when using model name as the save path. As a result, in the document, I added requirement to replace ```/``` with ```@```  in model name. Then plato model API will handle it through ```model_name = model_name.replace("@", "/")``` at line 52 in ```vit.py```. 
<!--- Describe motivation and context -->
Support ViT models in plato.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
I added two configs, we can test with
```
python3 ./run -c ./configs/ViT/fedavg_cifar10_swinv2.yml 
```
and
```
python3 ./run -c ./configs/ViT/fedavg_tinyimagenet_levit.yml 
```
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) Fixes #
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been formatted using Black and checked using PyLint.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
