### PR TITLE
Reimplemented split learning

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -123,10 +123,9 @@ Jiang et al., &ldquo;[Pisces: Efficient Federated Learning via Guided Asynchrono
 ````
 
 ````{admonition} **Split Learning**
-Split learning aims to collaboratively train deep learning models with the server performing a portion of the training process. In this example, the training process is separated into two phases: the clients first send extracted features at a specific cut layer to the server, and then the server continues the forward pass and computes gradients, which will be sent back to the clients to complete the backward pass of the training. This example uses client processors extensively for applying different processing mechanisms on inbound payload received from the server in different phases.
-
+Split learning aims to collaboratively train deep learning models with the server performing a portion of the training process. In split learning, each training iteration is separated into two phases: the clients first send extracted features at a specific cut layer to the server, and then the server continues the forward pass and computes gradients, which will be sent back to the clients to complete the backward pass of the training. Unlike federated learning, split learning clients sequentially interact with the server, and the global model is synchronized implicitly through the model on the server side, which is shared and updated by all clients.
 ```shell
-python examples/split_learning/split_learning.py -c examples/split_learning/split_learning_MNIST_lenet5.yml
+python examples/split_learning/split_learning.py -c examples/split_learning/split_learning_MNIST_lenet5.yml -l warn
 ```
 
 ```{note}

--- a/examples/dlg/dlg_trainer.py
+++ b/examples/dlg/dlg_trainer.py
@@ -75,7 +75,7 @@ class Trainer(basic.Trainer):
         self.target_grad = None
 
     def perform_forward_and_backward_passes(self, config, examples, labels):
-        """Perform the forward and backward passes of the training loop."""
+        """Perform forward and backward passes in the training loop."""
         # Store data in the first epoch (later epochs will still have the same partitioned data)
         if self.current_epoch == 1:
             try:

--- a/examples/split_learning/split_learning.py
+++ b/examples/split_learning/split_learning.py
@@ -16,7 +16,7 @@ import split_learning_trainer
 
 
 def main():
-    """ A Plato federated learning training session using the split learning algorithm. """
+    """A Plato federated learning training session using the split learning algorithm."""
     trainer = split_learning_trainer.Trainer
     algorithm = split_learning_algorithm.Algorithm
     client = split_learning_client.Client(algorithm=algorithm, trainer=trainer)

--- a/examples/split_learning/split_learning.py
+++ b/examples/split_learning/split_learning.py
@@ -3,10 +3,15 @@ A federated learning training session using split learning.
 
 Reference:
 
-Vepakomma, et al., "Split learning for health: Distributed deep learning without sharing
-raw patient data," in Proc. AI for Social Good Workshop, affiliated with ICLR 2018.
+Vepakomma, et al., "Split Learning for Health: Distributed Deep Learning without Sharing
+Raw Patient Data," in Proc. AI for Social Good Workshop, affiliated with ICLR 2018.
 
 https://arxiv.org/pdf/1812.00564.pdf
+
+Chopra, Ayush, et al. "AdaSplit: Adaptive Trade-offs for Resource-constrained Distributed 
+Deep Learning." arXiv preprint arXiv:2112.01637 (2021).
+
+https://arxiv.org/pdf/2112.01637.pdf
 """
 
 import split_learning_algorithm

--- a/examples/split_learning/split_learning.py
+++ b/examples/split_learning/split_learning.py
@@ -8,7 +8,7 @@ Raw Patient Data," in Proc. AI for Social Good Workshop, affiliated with ICLR 20
 
 https://arxiv.org/pdf/1812.00564.pdf
 
-Chopra, Ayush, et al. "AdaSplit: Adaptive Trade-offs for Resource-constrained Distributed 
+Chopra, Ayush, et al. "AdaSplit: Adaptive Trade-offs for Resource-constrained Distributed
 Deep Learning." arXiv preprint arXiv:2112.01637 (2021).
 
 https://arxiv.org/pdf/2112.01637.pdf

--- a/examples/split_learning/split_learning_MNIST_lenet5.yml
+++ b/examples/split_learning/split_learning_MNIST_lenet5.yml
@@ -3,7 +3,7 @@ clients:
     type: split_learning
 
     # The total number of clients
-    total_clients: 500
+    total_clients: 5
 
     # The number of clients selected in each round
     per_round: 1
@@ -11,18 +11,24 @@ clients:
     # Should the clients compute test accuracy locally?
     do_test: false
 
+    # Split learning iterations for each round
+    iteration: 20
+
 server:
     type: split_learning
     random_seed: 1
     address: 127.0.0.1
-    port: 8000
+    port: 8001
+
+    # Server doesn't have to do test for every round in split learning
+    do_test: false
 
 data:
     # The training and testing dataset
     datasource: MNIST
 
     # Number of samples in each partition
-    partition_size: 10000
+    partition_size: 60000
 
     # Fixed random seed
     random_seed: 1
@@ -35,10 +41,10 @@ trainer:
     type: split_learning
 
     # The maximum number of training rounds
-    rounds: 200
+    rounds: 50000
 
     # The maximum number of clients running concurrently
-    max_concurrency: 3
+    max_concurrency: 1
 
     # The target accuracy
     target_accuracy: 0.95
@@ -48,7 +54,7 @@ trainer:
 
     # Number of epoches for local training in each communication round
     epochs: 1
-    batch_size: 32
+    batch_size: 128
     optimizer: SGD
     
 algorithm:
@@ -61,7 +67,7 @@ algorithm:
 parameters:
     model:
         num_classes: 10
-        cut_layer: relu4
+        cut_layer: relu3
 
     optimizer:
         lr: 0.01

--- a/examples/split_learning/split_learning_MNIST_lenet5.yml
+++ b/examples/split_learning/split_learning_MNIST_lenet5.yml
@@ -71,4 +71,5 @@ parameters:
         momentum: 0.9
         weight_decay: 0.0
 
-results: round, accuracy
+results: 
+    types: round, accuracy, elapsed_time, comm_overhead

--- a/examples/split_learning/split_learning_MNIST_lenet5.yml
+++ b/examples/split_learning/split_learning_MNIST_lenet5.yml
@@ -28,7 +28,7 @@ data:
     datasource: MNIST
 
     # Number of samples in each partition
-    partition_size: 10000
+    partition_size: 12000
 
     # Fixed random seed
     random_seed: 1

--- a/examples/split_learning/split_learning_MNIST_lenet5.yml
+++ b/examples/split_learning/split_learning_MNIST_lenet5.yml
@@ -11,7 +11,7 @@ clients:
     # Should the clients compute test accuracy locally?
     do_test: false
 
-    # Split learning iterations for each round
+    # Split learning iterations for each client
     iteration: 20
 
 server:
@@ -28,7 +28,7 @@ data:
     datasource: MNIST
 
     # Number of samples in each partition
-    partition_size: 60000
+    partition_size: 10000
 
     # Fixed random seed
     random_seed: 1
@@ -42,9 +42,6 @@ trainer:
 
     # The maximum number of training rounds
     rounds: 50000
-
-    # The maximum number of clients running concurrently
-    max_concurrency: 1
 
     # The target accuracy
     target_accuracy: 0.95
@@ -67,7 +64,7 @@ algorithm:
 parameters:
     model:
         num_classes: 10
-        cut_layer: relu3
+        cut_layer: relu2
 
     optimizer:
         lr: 0.01

--- a/examples/split_learning/split_learning_algorithm.py
+++ b/examples/split_learning/split_learning_algorithm.py
@@ -3,10 +3,15 @@ A federated learning algorithm using split learning.
 
 Reference:
 
-Vepakomma, et al., "Split learning for health: Distributed deep learning without sharing
-raw patient data," in Proc. AI for Social Good Workshop, affiliated with ICLR 2018.
+Vepakomma, et al., "Split Learning for Health: Distributed Deep Learning without Sharing
+Raw Patient Data," in Proc. AI for Social Good Workshop, affiliated with ICLR 2018.
 
 https://arxiv.org/pdf/1812.00564.pdf
+
+Chopra, Ayush, et al. "AdaSplit: Adaptive Trade-offs for Resource-constrained Distributed 
+Deep Learning." arXiv preprint arXiv:2112.01637 (2021).
+
+https://arxiv.org/pdf/2112.01637.pdf
 """
 
 import logging

--- a/examples/split_learning/split_learning_algorithm.py
+++ b/examples/split_learning/split_learning_algorithm.py
@@ -58,7 +58,6 @@ class Algorithm(fedavg.Algorithm):
         self.input_dataset.append((inputs.detach().cpu(), targets.detach().cpu()))
 
         toc = time.perf_counter()
-
         logging.warn(
             "[Client #%d] Features extracted from %s examples in %.2f seconds.",
             self.client_id,

--- a/examples/split_learning/split_learning_algorithm.py
+++ b/examples/split_learning/split_learning_algorithm.py
@@ -11,7 +11,6 @@ https://arxiv.org/pdf/1812.00564.pdf
 
 import logging
 import time
-from copy import deepcopy
 
 import torch
 
@@ -25,18 +24,7 @@ class Algorithm(fedavg.Algorithm):
     server.
     """
 
-    def __init__(self, trainer=None):
-        super().__init__(trainer)
-        self.gradients_list = []
-        self.input_dataset = []
-        self.data_loader = None
-
-
-    def receive_gradients(self, gradients):
-        """Receive gradients from the server."""
-        self.gradients_list = deepcopy(gradients)
-
-    def extract_features(self):
+    def extract_features(self, dataset, sampler):
         """Extracting features using layers before the cut_layer."""
         self.model.to(self.trainer.device)
         self.model.eval()
@@ -44,9 +32,10 @@ class Algorithm(fedavg.Algorithm):
         tic = time.perf_counter()
 
         features_dataset = []
-        self.input_dataset = []
 
-        inputs, targets = next(self.data_loader)
+        inputs, targets = self.trainer.get_train_samples(
+            Config().trainer.batch_size, dataset, sampler
+        )
         with torch.no_grad():
             inputs, targets = inputs.to(self.trainer.device), targets.to(
                 self.trainer.device
@@ -54,7 +43,6 @@ class Algorithm(fedavg.Algorithm):
             logits = self.model.forward_to(inputs)
 
         features_dataset.append((logits.detach().cpu(), targets.detach().cpu()))
-        self.input_dataset.append((inputs.detach().cpu(), targets.detach().cpu()))
 
         toc = time.perf_counter()
         logging.warning(
@@ -66,32 +54,16 @@ class Algorithm(fedavg.Algorithm):
 
         return features_dataset, toc - tic
 
-    def complete_train(self):
+    def complete_train(self, gradients):
         """Update the model on the client/device with the gradients received
         from the server.
         """
-        self.model.to(self.trainer.device)
-        self.model.train()
-
-        data_loader = self.input_dataset
-
         tic = time.perf_counter()
 
-        # Initializing the optimizer
-        optimizer = self.trainer.get_optimizer(self.model)
-
-        grad_index = 0
-
-        for __, (examples, labels) in enumerate(data_loader):
-            examples, labels = examples.to(self.trainer.device), labels.to(
-                self.trainer.device
-            )
-
-            optimizer.zero_grad()
-            outputs = self.model.forward_to(examples)
-            outputs.backward(self.gradients_list[grad_index].to(self.trainer.device))
-            grad_index = grad_index + 1
-            optimizer.step()
+        # Retrieve the training samples and let trainer do the training
+        samples, sampler = self.trainer.retrieve_train_samples()
+        self.trainer.load_gradients(gradients)
+        self.train(samples, sampler)
 
         toc = time.perf_counter()
         logging.warning(
@@ -103,19 +75,10 @@ class Algorithm(fedavg.Algorithm):
         return toc - tic
 
     def train(self, trainset, sampler):
-        """Train the neural network model after the cut layer."""
+        """General training method that trains model with provided trainset and sampler."""
         self.trainer.train(
             feature_dataset.FeatureDataset(trainset.feature_dataset), sampler
         )
-
-    def load_data(self, dataset, sampler):
-        """Setting up the data loader."""
-        data_loader = torch.utils.data.DataLoader(
-            dataset,
-            batch_size=Config().trainer.batch_size,
-            sampler=sampler.get(),
-        )
-        self.data_loader = iter(data_loader)
 
     def update_weights_before_cut(self, weights):
         # Update the weights before cut layer, called when testing accuracy

--- a/examples/split_learning/split_learning_algorithm.py
+++ b/examples/split_learning/split_learning_algorithm.py
@@ -8,7 +8,7 @@ Raw Patient Data," in Proc. AI for Social Good Workshop, affiliated with ICLR 20
 
 https://arxiv.org/pdf/1812.00564.pdf
 
-Chopra, Ayush, et al. "AdaSplit: Adaptive Trade-offs for Resource-Constrained Distributed
+Chopra, Ayush, et al. "AdaSplit: Adaptive Trade-offs for Resource-constrained Distributed
 Deep Learning." arXiv preprint arXiv:2112.01637 (2021).
 
 https://arxiv.org/pdf/2112.01637.pdf

--- a/examples/split_learning/split_learning_algorithm.py
+++ b/examples/split_learning/split_learning_algorithm.py
@@ -8,7 +8,7 @@ Raw Patient Data," in Proc. AI for Social Good Workshop, affiliated with ICLR 20
 
 https://arxiv.org/pdf/1812.00564.pdf
 
-Chopra, Ayush, et al. "AdaSplit: Adaptive Trade-offs for Resource-constrained Distributed 
+Chopra, Ayush, et al. "AdaSplit: Adaptive Trade-offs for Resource-Constrained Distributed
 Deep Learning." arXiv preprint arXiv:2112.01637 (2021).
 
 https://arxiv.org/pdf/2112.01637.pdf
@@ -86,9 +86,10 @@ class Algorithm(fedavg.Algorithm):
         )
 
     def update_weights_before_cut(self, weights):
-        # Update the weights before cut layer, called when testing accuracy
+        """Update the weights before cut layer, called when testing accuracy."""
         current_weights = self.extract_weights()
         cut_layer_idx = self.model.layers.index(self.model.cut_layer)
+
         for i in range(0, cut_layer_idx):
             weight_name = f"{self.model.layers[i]}.weight"
             bias_name = f"{self.model.layers[i]}.bias"
@@ -98,4 +99,5 @@ class Algorithm(fedavg.Algorithm):
 
             if bias_name in current_weights:
                 current_weights[bias_name] = weights[bias_name]
+
         self.load_weights(current_weights)

--- a/examples/split_learning/split_learning_client.py
+++ b/examples/split_learning/split_learning_client.py
@@ -3,10 +3,15 @@ A federated learning client using split learning.
 
 Reference:
 
-Vepakomma, et al., "Split learning for health: Distributed deep learning without sharing
-raw patient data," in Proc. AI for Social Good Workshop, affiliated with ICLR 2018.
+Vepakomma, et al., "Split Learning for Health: Distributed Deep Learning without Sharing
+Raw Patient Data," in Proc. AI for Social Good Workshop, affiliated with ICLR 2018.
 
 https://arxiv.org/pdf/1812.00564.pdf
+
+Chopra, Ayush, et al. "AdaSplit: Adaptive Trade-offs for Resource-constrained Distributed 
+Deep Learning." arXiv preprint arXiv:2112.01637 (2021).
+
+https://arxiv.org/pdf/2112.01637.pdf
 """
 
 import logging

--- a/examples/split_learning/split_learning_client.py
+++ b/examples/split_learning/split_learning_client.py
@@ -53,7 +53,7 @@ class Client(simple.Client):
         # Preparing the client response
         report, payload = None, None
 
-        if info == "weights":
+        if info == "prompt":
             # Server prompts a new client to conduct split learning
             self.algorithm.load_context(self.client_id, self.trainset, self.sampler)
             report, payload = self._extract_features()

--- a/examples/split_learning/split_learning_client.py
+++ b/examples/split_learning/split_learning_client.py
@@ -8,7 +8,7 @@ Raw Patient Data," in Proc. AI for Social Good Workshop, affiliated with ICLR 20
 
 https://arxiv.org/pdf/1812.00564.pdf
 
-Chopra, Ayush, et al. "AdaSplit: Adaptive Trade-offs for Resource-constrained Distributed 
+Chopra, Ayush, et al. "AdaSplit: Adaptive Trade-offs for Resource-constrained Distributed
 Deep Learning." arXiv preprint arXiv:2112.01637 (2021).
 
 https://arxiv.org/pdf/2112.01637.pdf

--- a/examples/split_learning/split_learning_client.py
+++ b/examples/split_learning/split_learning_client.py
@@ -94,10 +94,11 @@ class Client(simple.Client):
                 # Continue feature extraction
                 report, payload = self._extract_features()
                 report.training_time += training_time
+
         return report, payload
 
     def _save_context(self, client_id):
-        """Saving the extracted weights and data sampler for a given client."""
+        """Saving the extracted weights and the data sampler for a given client."""
         # Sampler needs to be saved otherwise same data samples will be selected every round
         self.contexts[client_id] = (
             self.algorithm.extract_weights(),

--- a/examples/split_learning/split_learning_server.py
+++ b/examples/split_learning/split_learning_server.py
@@ -30,7 +30,7 @@ class Server(fedavg.Server):
         super().__init__(model, datasource, algorithm, trainer, callbacks)
         # Split learning clients interact with server sequentially
         assert Config().clients.per_round == 1
-        self.phase = "weights"
+        self.phase = "prompt"
         self.clients_list = []
         self.client_last = None
         self.next_client = True
@@ -52,9 +52,9 @@ class Server(fedavg.Server):
 
     def customize_server_payload(self, payload):
         """Wrap up generating the server payload with any additional information."""
-        if self.phase == "weights":
+        if self.phase == "prompt":
             # Split learning server doesn't send weights to client
-            return (None, "weights")
+            return (None, "prompt")
         else:
             # Send gradients back to client to complete the training
             return (self.gradients_to_send.pop(self.selected_client_id), "gradients")
@@ -94,7 +94,7 @@ class Server(fedavg.Server):
                     f"[{self}] Global model accuracy: {100 * self.test_accuracy:.2f}%\n"
                 )
             )
-            self.phase = "weights"
+            self.phase = "prompt"
             # Change client in next round
             self.next_client = True
 

--- a/examples/split_learning/split_learning_server.py
+++ b/examples/split_learning/split_learning_server.py
@@ -42,7 +42,7 @@ class Server(fedavg.Server):
         if len(self.clients_list) == 0 and self.next_client:
             # Shuffle the client list
             self.clients_list = super().choose_clients(clients_pool, len(clients_pool))
-            logging.warn(f"Client order: {self.clients_list}")
+            logging.warning(f"Client order: {self.clients_list}")
 
         if self.next_client:
             # Sequentially select clients
@@ -63,7 +63,7 @@ class Server(fedavg.Server):
         update = updates[0]
         report = update.report
         if report.type == "features":
-            logging.warn("[%s] Features received, compute gradients.", self)
+            logging.warning("[%s] Features received, compute gradients.", self)
             feature_dataset = feature.DataSource([update.payload])
 
             # Training the model using all the features received from the client
@@ -75,7 +75,7 @@ class Server(fedavg.Server):
             self.phase = "gradient"
 
         elif report.type == "weights":
-            logging.warn("[%s] Weights received, start testing accuracy.", self)
+            logging.warning("[%s] Weights received, start testing accuracy.", self)
             weights = update.payload
 
             # The weights after cut layer are not trained by clients
@@ -89,7 +89,7 @@ class Server(fedavg.Server):
                     self.datasource, testing=True
                 )
             self.test_accuracy = self.trainer.test(self.testset, self.testset_sampler)
-            logging.warn(
+            logging.warning(
                 fonts.colourize(
                     f"[{self}] Global model accuracy: {100 * self.test_accuracy:.2f}%\n"
                 )

--- a/examples/split_learning/split_learning_server.py
+++ b/examples/split_learning/split_learning_server.py
@@ -8,7 +8,7 @@ Raw Patient Data," in Proc. AI for Social Good Workshop, affiliated with ICLR 20
 
 https://arxiv.org/pdf/1812.00564.pdf
 
-Chopra, Ayush, et al. "AdaSplit: Adaptive Trade-offs for Resource-constrained Distributed 
+Chopra, Ayush, et al. "AdaSplit: Adaptive Trade-offs for Resource-constrained Distributed
 Deep Learning." arXiv preprint arXiv:2112.01637 (2021).
 
 https://arxiv.org/pdf/2112.01637.pdf

--- a/examples/split_learning/split_learning_server.py
+++ b/examples/split_learning/split_learning_server.py
@@ -3,10 +3,15 @@ A federated learning server using split learning.
 
 Reference:
 
-Vepakomma, et al., "Split learning for health: Distributed deep learning without sharing
-raw patient data," in Proc. AI for Social Good Workshop, affiliated with ICLR 2018.
+Vepakomma, et al., "Split Learning for Health: Distributed Deep Learning without Sharing
+Raw Patient Data," in Proc. AI for Social Good Workshop, affiliated with ICLR 2018.
 
 https://arxiv.org/pdf/1812.00564.pdf
+
+Chopra, Ayush, et al. "AdaSplit: Adaptive Trade-offs for Resource-constrained Distributed 
+Deep Learning." arXiv preprint arXiv:2112.01637 (2021).
+
+https://arxiv.org/pdf/2112.01637.pdf
 """
 
 import logging

--- a/examples/split_learning/split_learning_server.py
+++ b/examples/split_learning/split_learning_server.py
@@ -104,8 +104,6 @@ class Server(fedavg.Server):
         updated_weights = self.algorithm.extract_weights()
         return updated_weights
 
-    def get_logged_items(self):
-        """Overwrite the logged accuracy by latest test accuracy."""
-        logged_items = super().get_logged_items()
-        logged_items["accuracy"] = self.test_accuracy
-        return logged_items
+    def clients_processed(self):
+        # Replace the default accuracy by manually tested accuracy
+        self.accuracy = self.test_accuracy

--- a/examples/split_learning/split_learning_server.py
+++ b/examples/split_learning/split_learning_server.py
@@ -17,6 +17,8 @@ from plato.config import Config
 from plato.datasources import feature
 from plato.samplers import all_inclusive
 from plato.servers import fedavg
+from plato.utils import fonts
+from plato.datasources import registry as datasources_registry
 
 
 class Server(fedavg.Server):
@@ -26,64 +28,78 @@ class Server(fedavg.Server):
         self, model=None, datasource=None, algorithm=None, trainer=None, callbacks=None
     ):
         super().__init__(model, datasource, algorithm, trainer, callbacks)
-
+        # Split learning clients interact with server sequentially
+        assert Config().clients.per_round == 1
         self.phase = "weights"
-        self.clients_selected_last = None
+        self.clients_list = []
+        self.client_last = None
+        self.next_client = True
         self.gradients_to_send = {}
+        self.test_accuracy = 0.0
 
     def choose_clients(self, clients_pool, clients_count):
-        """Choose the same clients every two rounds."""
-        if self.phase == "weights":
-            self.clients_selected_last = super().choose_clients(
-                clients_pool, clients_count
-            )
+        """Shuffle the clients and sequentially select them when the previous one is done."""
+        if len(self.clients_list) == 0 and self.next_client:
+            # Shuffle the client list
+            self.clients_list = super().choose_clients(clients_pool, len(clients_pool))
+            logging.warn(f"Client order: {self.clients_list}")
 
-        return self.clients_selected_last
+        if self.next_client:
+            # Sequentially select clients
+            self.client_last = [self.clients_list.pop(0)]
+            self.next_client = False
+        return self.client_last
 
     def customize_server_payload(self, payload):
         """Wrap up generating the server payload with any additional information."""
         if self.phase == "weights":
-            # Send global model weights to the clients
-            return (payload, "weights")
+            # Split learning server doesn't send weights to client
+            return (None, "weights")
         else:
             # Send gradients back to client to complete the training
             return (self.gradients_to_send.pop(self.selected_client_id), "gradients")
 
     async def aggregate_weights(self, updates, baseline_weights, weights_received):
-        """Compute gradients and aggregate weights in different rounds."""
-        if self.phase == "weights":
-            for update in updates:
-                feature_dataset = feature.DataSource([update.payload])
+        update = updates[0]
+        report = update.report
+        if report.type == "features":
+            logging.warn("[%s] Features received, compute gradients.", self)
+            feature_dataset = feature.DataSource([update.payload])
 
-                # Training the model using all the features received from the client
-                sampler = all_inclusive.Sampler(feature_dataset)
-                self.algorithm.train(feature_dataset, sampler)
+            # Training the model using all the features received from the client
+            sampler = all_inclusive.Sampler(feature_dataset)
+            self.algorithm.train(feature_dataset, sampler)
 
-                # Compute the gradients and get ready to be sent
-                self.gradients_to_send[update.client_id] = self._load_gradients()
+            # Compute the gradients and get ready to be sent
+            self.gradients_to_send[update.client_id] = self._load_gradients()
+            self.phase = "gradient"
 
-            self.phase = "gradients"
-            # No weights update in this round
-            return baseline_weights
+        elif report.type == "weights":
+            logging.warn("[%s] Weights received, start testing accuracy.", self)
+            weights = update.payload
 
-        elif self.phase == "gradients":
-            # Perform federated averaging algorithm (copied from fedavg.Server for convenience)
-            self.total_samples = sum(update.report.num_samples for update in updates)
-            updated_weights = {
-                name: self.trainer.zeros(weight.shape)
-                for name, weight in weights_received[0].items()
-            }
+            # The weights after cut layer are not trained by clients
+            self.algorithm.update_weights_before_cut(weights)
 
-            for i, update in enumerate(weights_received):
-                report = updates[i].report
-                num_samples = report.num_samples
-
-                for name, weight in update.items():
-                    # Use weighted average by the number of samples
-                    updated_weights[name] += weight * (num_samples / self.total_samples)
-
+            # Manually Set up the testset since do_test is turned off in config
+            if self.datasource is None:
+                self.datasource = datasources_registry.get(client_id=0)
+                self.testset = self.datasource.get_test_set()
+                self.testset_sampler = all_inclusive.Sampler(
+                    self.datasource, testing=True
+                )
+            self.test_accuracy = self.trainer.test(self.testset, self.testset_sampler)
+            logging.warn(
+                fonts.colourize(
+                    f"[{self}] Global model accuracy: {100 * self.test_accuracy:.2f}%\n"
+                )
+            )
             self.phase = "weights"
-            return updated_weights
+            # Change client in next round
+            self.next_client = True
+
+        updated_weights = self.algorithm.extract_weights()
+        return updated_weights
 
     def _load_gradients(self):
         """Loading gradients from a file."""
@@ -96,3 +112,9 @@ class Server(fedavg.Server):
         )
 
         return torch.load(model_gradients_path)
+
+    def get_logged_items(self):
+        """Overwrite the logged accuracy by latest test accuracy."""
+        logged_items = super().get_logged_items()
+        logged_items["accuracy"] = self.test_accuracy
+        return logged_items

--- a/examples/split_learning/split_learning_server.py
+++ b/examples/split_learning/split_learning_server.py
@@ -61,7 +61,9 @@ class Server(fedavg.Server):
             # Send gradients back to client to complete the training
             return (self.trainer.get_gradients(), "gradients")
 
+    # pylint: disable=unused-argument
     async def aggregate_weights(self, updates, baseline_weights, weights_received):
+        """Aggregate weight updates from the clients or train the model."""
         update = updates[0]
         report = update.report
         if report.type == "features":
@@ -80,14 +82,16 @@ class Server(fedavg.Server):
             # The weights after cut layer are not trained by clients
             self.algorithm.update_weights_before_cut(weights)
 
-            # Manually Set up the testset since do_test is turned off in config
+            # Manually set up the testset since do_test is turned off in config
             if self.datasource is None:
                 self.datasource = datasources_registry.get(client_id=0)
                 self.testset = self.datasource.get_test_set()
                 self.testset_sampler = all_inclusive.Sampler(
                     self.datasource, testing=True
                 )
+
             self.test_accuracy = self.trainer.test(self.testset, self.testset_sampler)
+
             logging.warning(
                 fonts.colourize(
                     f"[{self}] Global model accuracy: {100 * self.test_accuracy:.2f}%\n"

--- a/examples/split_learning/split_learning_trainer.py
+++ b/examples/split_learning/split_learning_trainer.py
@@ -69,9 +69,9 @@ class Trainer(basic.Trainer):
         Returns: loss values after the current batch has been processed.
         """
         if self.client_id == 0:
-            return self.server_train_loop(config, examples, labels)
+            return self._server_train_loop(config, examples, labels)
         else:
-            return self.client_train_loop(examples)
+            return self._client_train_loop(examples)
 
     def train_run_end(self, config):
         """Aditional tasks after training."""
@@ -87,11 +87,10 @@ class Trainer(basic.Trainer):
 
         return self.last_optimizer
 
-    """Client side functions"""
-
     def get_train_samples(self, batch_size, trainset, sampler):
-        """Get a batch of training samples to extract feature,
-        trainer has to save these samples to complete training later.
+        """
+        Get a batch of training samples to extract feature, the trainer has to save these
+        samples to complete training later.
         """
         data_loader = torch.utils.data.DataLoader(
             dataset=trainset, shuffle=False, batch_size=batch_size, sampler=sampler
@@ -111,7 +110,7 @@ class Trainer(basic.Trainer):
         """Load the gradients which will be used to complete client training."""
         self.gradients = gradients
 
-    def client_train_loop(self, examples):
+    def _client_train_loop(self, examples):
         """Complete the client side training with gradients from server."""
         self.optimizer.zero_grad()
         outputs = self.model.forward_to(examples)
@@ -125,10 +124,8 @@ class Trainer(basic.Trainer):
         self._loss_tracker.update(loss, examples.size(0))
         return loss
 
-    """Server side functions"""
-
-    def server_train_loop(self, config, examples, labels):
-
+    def _server_train_loop(self, config, examples, labels):
+        """The training loop on the server."""
         examples = examples.detach().requires_grad_(True)
 
         loss = super().perform_forward_and_backward_passes(config, examples, labels)

--- a/examples/split_learning/split_learning_trainer.py
+++ b/examples/split_learning/split_learning_trainer.py
@@ -54,7 +54,11 @@ class Trainer(basic.Trainer):
         examples = examples.detach().requires_grad_(True)
 
         loss = super().perform_forward_and_backward_passes(config, examples, labels)
-
+        logging.warn(
+            "[Server #%d] Gradients computed with training loss: %.4f",
+            os.getpid(),
+            loss,
+        )
         # Record gradients within the cut layer
         self.cut_layer_grad.append(examples.grad.clone().detach())
 

--- a/examples/split_learning/split_learning_trainer.py
+++ b/examples/split_learning/split_learning_trainer.py
@@ -8,6 +8,7 @@ raw patient data," in Proc. AI for Social Good Workshop, affiliated with ICLR 20
 
 https://arxiv.org/pdf/1812.00564.pdf
 """
+from itertools import cycle
 import logging
 import os
 
@@ -15,6 +16,8 @@ import torch
 from plato.config import Config
 
 from plato.trainers import basic
+from plato.datasources import feature
+from plato.samplers import all_inclusive
 
 
 class Trainer(basic.Trainer):
@@ -28,6 +31,15 @@ class Trainer(basic.Trainer):
         callbacks: The callbacks that this trainer uses.
         """
         super().__init__(model=model, callbacks=callbacks)
+        self.last_client_id = None
+        self.last_optimizer = None
+
+        # Client side variables
+        self.training_samples = None
+        self.gradients = None
+        self.data_loader = None
+
+        # Server side variables
         self.cut_layer_grad = []
 
     def get_train_loader(self, batch_size, trainset, sampler, **kwargs):
@@ -51,6 +63,67 @@ class Trainer(basic.Trainer):
 
         Returns: loss values after the current batch has been processed.
         """
+        if self.client_id == 0:
+            return self.server_train_loop(config, examples, labels)
+        else:
+            return self.client_train_loop(examples)
+
+    def train_run_end(self, config):
+        """Aditional tasks after training."""
+        if self.client_id == 0:
+            # Server needs to save gradients, clients not
+            self.save_gradients(config)
+
+    def get_optimizer(self, model):
+        """Return the optimizer used last round to avoid reconfiguration."""
+        if self.last_optimizer is None or self.last_client_id != self.client_id:
+            self.last_optimizer = super().get_optimizer(model)
+            self.last_client_id = self.client_id
+
+        return self.last_optimizer
+
+    """Client side functions"""
+
+    def get_train_samples(self, batch_size, trainset, sampler):
+        """Get a batch of training samples to extract feature,
+        trainer has to save these samples to complete training later.
+        """
+        data_loader = torch.utils.data.DataLoader(
+            dataset=trainset, shuffle=False, batch_size=batch_size, sampler=sampler
+        )
+        data_loader = iter(data_loader)
+        self.training_samples = next(data_loader)
+        return self.training_samples
+
+    def retrieve_train_samples(self):
+        """Retrieve the training samples to complete client training."""
+        # Wrap the training samples with datasource and sampler to be fed into Plato trainer
+        samples = feature.DataSource([[self.training_samples]])
+        sampler = all_inclusive.Sampler(samples)
+        return samples, sampler
+
+    def load_gradients(self, gradients):
+        """Load the gradients which will be used to complete client training."""
+        self.gradients = gradients
+
+    def client_train_loop(self, examples):
+        """Complete the client side training with gradients from server."""
+        self.optimizer.zero_grad()
+        outputs = self.model.forward_to(examples)
+
+        # Back propagate with gradients from server
+        outputs.backward(self.gradients)
+        self.optimizer.step()
+
+        # No loss value on the client side
+        loss = torch.zeros(1)
+        self._loss_tracker.update(loss, examples.size(0))
+        return loss
+
+    """Server side functions"""
+
+    def server_train_loop(self, config, examples, labels):
+
         examples = examples.detach().requires_grad_(True)
 
         loss = super().perform_forward_and_backward_passes(config, examples, labels)
@@ -60,12 +133,12 @@ class Trainer(basic.Trainer):
             loss,
         )
         # Record gradients within the cut layer
-        self.cut_layer_grad.append(examples.grad.clone().detach())
+        self.cut_layer_grad = [examples.grad.clone().detach()]
 
         return loss
 
-    def train_run_end(self, config):
-        """Saving recorded gradients to a file."""
+    def save_gradients(self, config):
+        """Server saves recorded gradients to a file."""
         model_name = config["model_name"]
         model_path = Config().params["model_path"]
 
@@ -78,3 +151,15 @@ class Trainer(basic.Trainer):
         logging.info(
             "[Server #%d] Gradients saved to %s.", os.getpid(), model_gradients_path
         )
+
+    def get_gradients(self):
+        """Read gradients from a file."""
+        model_path = Config().params["model_path"]
+        model_name = Config().trainer.model_name
+
+        model_gradients_path = f"{model_path}/{model_name}_gradients.pth"
+        logging.info(
+            "[Server #%d] Loading gradients from %s.", os.getpid(), model_gradients_path
+        )
+
+        return torch.load(model_gradients_path)

--- a/examples/split_learning/split_learning_trainer.py
+++ b/examples/split_learning/split_learning_trainer.py
@@ -3,12 +3,17 @@ A federated learning trainer using split learning.
 
 Reference:
 
-Vepakomma, et al., "Split learning for health: Distributed deep learning without sharing
-raw patient data," in Proc. AI for Social Good Workshop, affiliated with ICLR 2018.
+Vepakomma, et al., "Split Learning for Health: Distributed Deep Learning without Sharing
+Raw Patient Data," in Proc. AI for Social Good Workshop, affiliated with ICLR 2018.
 
 https://arxiv.org/pdf/1812.00564.pdf
+
+Chopra, Ayush, et al. "AdaSplit: Adaptive Trade-offs for Resource-constrained Distributed 
+Deep Learning." arXiv preprint arXiv:2112.01637 (2021).
+
+https://arxiv.org/pdf/2112.01637.pdf
 """
-from itertools import cycle
+
 import logging
 import os
 

--- a/examples/split_learning/split_learning_trainer.py
+++ b/examples/split_learning/split_learning_trainer.py
@@ -59,7 +59,7 @@ class Trainer(basic.Trainer):
         return trainset
 
     def perform_forward_and_backward_passes(self, config, examples, labels):
-        """Perform the forward and backward passes of the training loop.
+        """Perform forward and backward passes in the training loop.
 
         Arguments:
         config: the configuration.
@@ -70,17 +70,17 @@ class Trainer(basic.Trainer):
         """
         if self.client_id == 0:
             return self._server_train_loop(config, examples, labels)
-        else:
-            return self._client_train_loop(examples)
+
+        return self._client_train_loop(examples)
 
     def train_run_end(self, config):
-        """Aditional tasks after training."""
+        """Additional tasks after training."""
         if self.client_id == 0:
             # Server needs to save gradients, clients not
             self.save_gradients(config)
 
     def get_optimizer(self, model):
-        """Return the optimizer used last round to avoid reconfiguration."""
+        """Return the optimizer used in the last round to avoid reconfiguration."""
         if self.last_optimizer is None or self.last_client_id != self.client_id:
             self.last_optimizer = super().get_optimizer(model)
             self.last_client_id = self.client_id

--- a/examples/split_learning/split_learning_trainer.py
+++ b/examples/split_learning/split_learning_trainer.py
@@ -8,7 +8,7 @@ Raw Patient Data," in Proc. AI for Social Good Workshop, affiliated with ICLR 20
 
 https://arxiv.org/pdf/1812.00564.pdf
 
-Chopra, Ayush, et al. "AdaSplit: Adaptive Trade-offs for Resource-constrained Distributed 
+Chopra, Ayush, et al. "AdaSplit: Adaptive Trade-offs for Resource-constrained Distributed
 Deep Learning." arXiv preprint arXiv:2112.01637 (2021).
 
 https://arxiv.org/pdf/2112.01637.pdf

--- a/examples/split_learning/split_learning_trainer.py
+++ b/examples/split_learning/split_learning_trainer.py
@@ -54,7 +54,7 @@ class Trainer(basic.Trainer):
         examples = examples.detach().requires_grad_(True)
 
         loss = super().perform_forward_and_backward_passes(config, examples, labels)
-        logging.warn(
+        logging.warning(
             "[Server #%d] Gradients computed with training loss: %.4f",
             os.getpid(),
             loss,

--- a/plato/trainers/basic.py
+++ b/plato/trainers/basic.py
@@ -163,7 +163,7 @@ class Trainer(base.Trainer):
             self.save_model(filename)
 
     def perform_forward_and_backward_passes(self, config, examples, labels):
-        """Perform the forward and backward passes of the training loop.
+        """Perform forward and backward passes in the training loop.
 
         Arguments:
         config: the configuration.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR aims to reimplement the split learning example strictly following the original design, compared with the previous implementation, the following changes are made.
1. Clients communicate with the server for each iteration of training.
2. Clients sequentially interact with the server, which means only one client is selected to conduct split learning with the server until it is done when a preset round number is reached.
3. No aggregation among clients. The client-side model is implicitly synchronized through the server model, which is shared and updated by all clients.   

## How has this been tested?
This has been tested by running
`
python examples/split_learning/split_learning.py -c examples/split_learning/split_learning_MNIST_lenet5.yml -l warn
`
The status of split learning is logged in the warning level, therefore we can use `-l warn` to skip unnecessary logs.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) Fixes #
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been formatted using Black and checked using PyLint.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
