### PR TITLE
Bug fix: FEMNIST test set is None in cross-silo.

### DIFF
--- a/plato/servers/fedavg_cs.py
+++ b/plato/servers/fedavg_cs.py
@@ -148,7 +148,7 @@ class Server(fedavg.Server):
                 hasattr(Config().server, "edge_do_test")
                 and Config().server.edge_do_test
             ):
-                self.datasource = datasources_registry.get(client_id=Config().args.id)
+                self.datasource = datasources_registry.get(client_id=0)
                 self.testset = self.datasource.get_test_set()
 
                 if hasattr(Config().data, "testset_sampler"):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix the bug where the test set in cross-silo is none for FEMNIST (and potential future other partitioned datasets). This prevents FEMNIST testing from working in cross-silo mode

## Description
<!--- Describe your changes in detail -->
<!--- Describe motivation and context -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The original code uses the edge server id as argument for obtaining datasource. However, the FEMNIST object only has testing dataset when the client_id argument is 0. Thus, the original code essentially makes it impossible to perform testing on the edge servers. The change will force the edge server to obtain the datasource pretending as the global server, ensuring uniform testing across all servers. An alternative would be to change the femnist datasource file to consider edge servers (it currently does not). However, it is hard to see a use case where each edge server would want different testing data, hence the current change was perfered.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested on config files under MNIST.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) Fixes #
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been formatted using Black and checked using PyLint.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
