### PR TITLE
Enhanced the get() functions for the trainers of Plato

### DIFF
--- a/plato/trainers/loss_criterion.py
+++ b/plato/trainers/loss_criterion.py
@@ -24,15 +24,25 @@ def get(**kwargs: Union[str, dict]):
         "KLDivLoss": nn.KLDivLoss,
     }
 
-    loss_criterion_name = kwargs[
-        "loss_criterion"] if "loss_criterion" in kwargs else (
-            Config().trainer.loss_criterion if hasattr(
-                Config.trainer, "loss_criterion") else "CrossEntropyLoss")
+    loss_criterion_name = (
+        kwargs["loss_criterion"]
+        if "loss_criterion" in kwargs
+        else (
+            Config().trainer.loss_criterion
+            if hasattr(Config.trainer, "loss_criterion")
+            else "CrossEntropyLoss"
+        )
+    )
 
-    loss_criterion_params = kwargs[
-        "loss_criterion_params"] if "loss_criterion_params" in kwargs else (
-            Config().parameters.loss_criterion._asdict() if hasattr(
-                Config.parameters, "loss_criterion") else {})
+    loss_criterion_params = (
+        kwargs["loss_criterion_params"]
+        if "loss_criterion_params" in kwargs
+        else (
+            Config().parameters.loss_criterion._asdict()
+            if hasattr(Config.parameters, "loss_criterion")
+            else {}
+        )
+    )
 
     loss_criterion = registered_loss_criterion.get(loss_criterion_name)
 

--- a/plato/trainers/loss_criterion.py
+++ b/plato/trainers/loss_criterion.py
@@ -1,12 +1,14 @@
 """
 Obtaining the loss criterion for training workloads according to the configuration file.
 """
+from typing import Union
+
 from torch import nn
 
 from plato.config import Config
 
 
-def get():
+def get(**kwargs: Union[str, dict]):
     """Get a loss function with its name from the configuration file."""
     registered_loss_criterion = {
         "L1Loss": nn.L1Loss,
@@ -22,16 +24,16 @@ def get():
         "KLDivLoss": nn.KLDivLoss,
     }
 
-    loss_criterion_name = (
-        Config().trainer.loss_criterion
-        if hasattr(Config.trainer, "loss_criterion")
-        else "CrossEntropyLoss"
-    )
-    loss_criterion = registered_loss_criterion.get(loss_criterion_name)
+    loss_criterion_name = kwargs[
+        "loss_criterion"] if "loss_criterion" in kwargs else (
+            Config().trainer.loss_criterion if hasattr(
+                Config.trainer, "loss_criterion") else "CrossEntropyLoss")
 
-    if hasattr(Config().parameters, "loss_criterion"):
-        loss_criterion_params = Config().parameters.loss_criterion._asdict()
-    else:
-        loss_criterion_params = {}
+    loss_criterion_params = kwargs[
+        "loss_criterion_params"] if "loss_criterion_params" in kwargs else (
+            Config().parameters.loss_criterion._asdict() if hasattr(
+                Config.parameters, "loss_criterion") else {})
+
+    loss_criterion = registered_loss_criterion.get(loss_criterion_name)
 
     return loss_criterion(**loss_criterion_params)

--- a/plato/trainers/lr_schedulers.py
+++ b/plato/trainers/lr_schedulers.py
@@ -1,10 +1,10 @@
 """
 Returns a learning rate scheduler according to the configuration.
 """
-
 import bisect
 import sys
 from types import SimpleNamespace
+from typing import Union
 
 import numpy as np
 from timm import scheduler
@@ -13,7 +13,7 @@ from torch import optim
 from plato.config import Config
 
 
-def get(optimizer: optim.Optimizer, iterations_per_epoch: int):
+def get(optimizer: optim.Optimizer, iterations_per_epoch: int, **kwargs: Union[str, dict]):
     """Returns a learning rate scheduler according to the configuration."""
 
     registered_schedulers = {
@@ -33,8 +33,8 @@ def get(optimizer: optim.Optimizer, iterations_per_epoch: int):
         "timm": scheduler.create_scheduler,
     }
 
-    _scheduler = Config().trainer.lr_scheduler
-    lr_params = Config().parameters.learning_rate._asdict()
+    _scheduler = kwargs["lr_scheduler"] if "lr_scheduler" in kwargs else Config().trainer.lr_scheduler
+    lr_params = kwargs["lr_params"] if "lr_params" in kwargs else Config().parameters.learning_rate._asdict()
 
     # First, look up the registered factories of LR schedulers
     if _scheduler in registered_factories:

--- a/plato/trainers/lr_schedulers.py
+++ b/plato/trainers/lr_schedulers.py
@@ -13,36 +13,48 @@ from torch import optim
 from plato.config import Config
 
 
-def get(optimizer: optim.Optimizer, iterations_per_epoch: int, **kwargs: Union[str, dict]):
+def get(optimizer: optim.Optimizer, iterations_per_epoch: int,
+        **kwargs: Union[str, dict]):
     """Returns a learning rate scheduler according to the configuration."""
 
     registered_schedulers = {
-        "CosineAnnealingLR": optim.lr_scheduler.CosineAnnealingLR,
-        "LambdaLR": optim.lr_scheduler.LambdaLR,
-        "MultiStepLR": optim.lr_scheduler.MultiStepLR,
-        "StepLR": optim.lr_scheduler.StepLR,
-        "ReduceLROnPlateau": optim.lr_scheduler.ReduceLROnPlateau,
-        "ConstantLR": optim.lr_scheduler.ConstantLR,
-        "LinearLR": optim.lr_scheduler.LinearLR,
-        "ExponentialLR": optim.lr_scheduler.ExponentialLR,
-        "CyclicLR": optim.lr_scheduler.CyclicLR,
-        "CosineAnnealingWarmRestarts": optim.lr_scheduler.CosineAnnealingWarmRestarts,
+        "CosineAnnealingLR":
+        optim.lr_scheduler.CosineAnnealingLR,
+        "LambdaLR":
+        optim.lr_scheduler.LambdaLR,
+        "MultiStepLR":
+        optim.lr_scheduler.MultiStepLR,
+        "StepLR":
+        optim.lr_scheduler.StepLR,
+        "ReduceLROnPlateau":
+        optim.lr_scheduler.ReduceLROnPlateau,
+        "ConstantLR":
+        optim.lr_scheduler.ConstantLR,
+        "LinearLR":
+        optim.lr_scheduler.LinearLR,
+        "ExponentialLR":
+        optim.lr_scheduler.ExponentialLR,
+        "CyclicLR":
+        optim.lr_scheduler.CyclicLR,
+        "CosineAnnealingWarmRestarts":
+        optim.lr_scheduler.CosineAnnealingWarmRestarts,
     }
 
     registered_factories = {
         "timm": scheduler.create_scheduler,
     }
 
-    _scheduler = kwargs["lr_scheduler"] if "lr_scheduler" in kwargs else Config().trainer.lr_scheduler
-    lr_params = kwargs["lr_params"] if "lr_params" in kwargs else Config().parameters.learning_rate._asdict()
+    _scheduler = kwargs["lr_scheduler"] if "lr_scheduler" in kwargs else Config(
+    ).trainer.lr_scheduler
+    lr_params = kwargs["lr_params"] if "lr_params" in kwargs else Config(
+    ).parameters.learning_rate._asdict()
 
     # First, look up the registered factories of LR schedulers
     if _scheduler in registered_factories:
         scheduler_args = SimpleNamespace(**lr_params)
         scheduler_args.epochs = Config().trainer.epochs
         lr_scheduler, __ = registered_factories[_scheduler](
-            args=scheduler_args, optimizer=optimizer
-        )
+            args=scheduler_args, optimizer=optimizer)
         return lr_scheduler
 
     # The list containing the learning rate schedulers that must be returned or
@@ -55,12 +67,14 @@ def get(optimizer: optim.Optimizer, iterations_per_epoch: int, **kwargs: Union[s
     if "ChainedScheduler" in _scheduler:
         use_chained = True
         lr_scheduler = [
-            sched for sched in _scheduler.split(",") if sched != ("ChainedScheduler")
+            sched for sched in _scheduler.split(",")
+            if sched != ("ChainedScheduler")
         ]
     elif "SequentialLR" in _scheduler:
         use_sequential = True
         lr_scheduler = [
-            sched for sched in _scheduler.split(",") if sched != ("SequentialLR")
+            sched for sched in _scheduler.split(",")
+            if sched != ("SequentialLR")
         ]
     else:
         lr_scheduler = [_scheduler]
@@ -74,9 +88,8 @@ def get(optimizer: optim.Optimizer, iterations_per_epoch: int, **kwargs: Union[s
         if _scheduler == "CosineAnnealingLR":
             returned_schedulers.append(
                 retrieved_scheduler(
-                    optimizer, iterations_per_epoch * Config().trainer.epochs
-                )
-            )
+                    optimizer,
+                    iterations_per_epoch * Config().trainer.epochs))
         elif _scheduler == "LambdaLR":
             lambdas = [lambda it: 1.0]
 
@@ -85,53 +98,47 @@ def get(optimizer: optim.Optimizer, iterations_per_epoch: int, **kwargs: Union[s
                     Step.from_str(x, iterations_per_epoch).iteration
                     for x in lr_params["milestone_steps"].split(",")
                 ]
-                lambdas.append(
-                    lambda it, milestones=milestones: lr_params["gamma"]
-                    ** bisect.bisect(milestones, it)
-                )
+                lambdas.append(lambda it, milestones=milestones: lr_params[
+                    "gamma"]**bisect.bisect(milestones, it))
 
             # Add a linear learning rate warmup if specified
             if "warmup_steps" in lr_params:
-                warmup_iters = Step.from_str(
-                    lr_params["warmup_steps"], iterations_per_epoch
-                ).iteration
-                lambdas.append(
-                    lambda it, warmup_iters=warmup_iters: min(1.0, it / warmup_iters)
-                )
+                warmup_iters = Step.from_str(lr_params["warmup_steps"],
+                                             iterations_per_epoch).iteration
+                lambdas.append(lambda it, warmup_iters=warmup_iters: min(
+                    1.0, it / warmup_iters))
             returned_schedulers.append(
                 retrieved_scheduler(
                     optimizer,
-                    lambda it, lambdas=lambdas: np.product([l(it) for l in lambdas]),
-                )
-            )
+                    lambda it, lambdas=lambdas: np.product(
+                        [l(it) for l in lambdas]),
+                ))
         elif _scheduler == "MultiStepLR":
             milestones = [
-                int(x.split("ep")[0]) for x in lr_params["milestone_steps"].split(",")
+                int(x.split("ep")[0])
+                for x in lr_params["milestone_steps"].split(",")
             ]
             returned_schedulers.append(
-                retrieved_scheduler(
-                    optimizer, milestones=milestones, gamma=lr_params["gamma"]
-                )
-            )
+                retrieved_scheduler(optimizer,
+                                    milestones=milestones,
+                                    gamma=lr_params["gamma"]))
         else:
-            returned_schedulers.append(retrieved_scheduler(optimizer, **lr_params))
+            returned_schedulers.append(
+                retrieved_scheduler(optimizer, **lr_params))
 
     if use_chained:
         return optim.lr_scheduler.ChainedScheduler(returned_schedulers)
 
     if use_sequential:
-        sequential_milestones = (
-            Config().trainer.lr_sequential_milestones
-            if hasattr(Config().trainer, "lr_sequential_milestones")
-            else 2
-        )
+        sequential_milestones = (Config().trainer.lr_sequential_milestones
+                                 if hasattr(Config().trainer,
+                                            "lr_sequential_milestones") else 2)
         sequential_milestones = [
             int(epoch) for epoch in sequential_milestones.split(",")
         ]
 
-        return optim.lr_scheduler.SequentialLR(
-            optimizer, returned_schedulers, sequential_milestones
-        )
+        return optim.lr_scheduler.SequentialLR(optimizer, returned_schedulers,
+                                               sequential_milestones)
     else:
         return returned_schedulers[0]
 
@@ -156,8 +163,10 @@ class Step:
         return Step(iteration, iterations_per_epoch)
 
     @staticmethod
-    def from_epoch(epoch: int, iteration: int, iterations_per_epoch: int) -> "Step":
-        return Step(epoch * iterations_per_epoch + iteration, iterations_per_epoch)
+    def from_epoch(epoch: int, iteration: int,
+                   iterations_per_epoch: int) -> "Step":
+        return Step(epoch * iterations_per_epoch + iteration,
+                    iterations_per_epoch)
 
     @staticmethod
     def from_str(s: str, iterations_per_epoch: int) -> "Step":
@@ -210,8 +219,7 @@ class Step:
             raise ValueError(f"Invalid type for other: {other}.")
         if self.iterations_per_epoch != other.iterations_per_epoch:
             raise ValueError(
-                "Cannot compare steps when epochs are of different lengths."
-            )
+                "Cannot compare steps when epochs are of different lengths.")
 
     def __lt__(self, other):
         self._check(other)

--- a/plato/trainers/lr_schedulers.py
+++ b/plato/trainers/lr_schedulers.py
@@ -13,49 +13,47 @@ from torch import optim
 from plato.config import Config
 
 
-def get(optimizer: optim.Optimizer, iterations_per_epoch: int,
-        **kwargs: Union[str, dict]):
+def get(
+    optimizer: optim.Optimizer, iterations_per_epoch: int, **kwargs: Union[str, dict]
+):
     """Returns a learning rate scheduler according to the configuration."""
 
     registered_schedulers = {
-        "CosineAnnealingLR":
-        optim.lr_scheduler.CosineAnnealingLR,
-        "LambdaLR":
-        optim.lr_scheduler.LambdaLR,
-        "MultiStepLR":
-        optim.lr_scheduler.MultiStepLR,
-        "StepLR":
-        optim.lr_scheduler.StepLR,
-        "ReduceLROnPlateau":
-        optim.lr_scheduler.ReduceLROnPlateau,
-        "ConstantLR":
-        optim.lr_scheduler.ConstantLR,
-        "LinearLR":
-        optim.lr_scheduler.LinearLR,
-        "ExponentialLR":
-        optim.lr_scheduler.ExponentialLR,
-        "CyclicLR":
-        optim.lr_scheduler.CyclicLR,
-        "CosineAnnealingWarmRestarts":
-        optim.lr_scheduler.CosineAnnealingWarmRestarts,
+        "CosineAnnealingLR": optim.lr_scheduler.CosineAnnealingLR,
+        "LambdaLR": optim.lr_scheduler.LambdaLR,
+        "MultiStepLR": optim.lr_scheduler.MultiStepLR,
+        "StepLR": optim.lr_scheduler.StepLR,
+        "ReduceLROnPlateau": optim.lr_scheduler.ReduceLROnPlateau,
+        "ConstantLR": optim.lr_scheduler.ConstantLR,
+        "LinearLR": optim.lr_scheduler.LinearLR,
+        "ExponentialLR": optim.lr_scheduler.ExponentialLR,
+        "CyclicLR": optim.lr_scheduler.CyclicLR,
+        "CosineAnnealingWarmRestarts": optim.lr_scheduler.CosineAnnealingWarmRestarts,
     }
 
     registered_factories = {
         "timm": scheduler.create_scheduler,
     }
 
-    _scheduler = kwargs["lr_scheduler"] if "lr_scheduler" in kwargs else Config(
-    ).trainer.lr_scheduler
-    lr_params = kwargs["lr_params"] if "lr_params" in kwargs else Config(
-    ).parameters.learning_rate._asdict()
+    _scheduler = (
+        kwargs["optim.lr_scheduler"]
+        if "optim.lr_scheduler" in kwargs
+        else Config().trainer.optim.lr_scheduler
+    )
+    lr_params = (
+        kwargs["lr_params"]
+        if "lr_params" in kwargs
+        else Config().parameters.learning_rate._asdict()
+    )
 
     # First, look up the registered factories of LR schedulers
     if _scheduler in registered_factories:
         scheduler_args = SimpleNamespace(**lr_params)
         scheduler_args.epochs = Config().trainer.epochs
-        lr_scheduler, __ = registered_factories[_scheduler](
-            args=scheduler_args, optimizer=optimizer)
-        return lr_scheduler
+        optim.lr_scheduler, __ = registered_factories[_scheduler](
+            args=scheduler_args, optimizer=optimizer
+        )
+        return optim.lr_scheduler
 
     # The list containing the learning rate schedulers that must be returned or
     # the learning rate schedulers that ChainedScheduler or SequentialLR will
@@ -66,20 +64,18 @@ def get(optimizer: optim.Optimizer, iterations_per_epoch: int,
     use_sequential = False
     if "ChainedScheduler" in _scheduler:
         use_chained = True
-        lr_scheduler = [
-            sched for sched in _scheduler.split(",")
-            if sched != ("ChainedScheduler")
+        optim.lr_scheduler = [
+            sched for sched in _scheduler.split(",") if sched != ("ChainedScheduler")
         ]
     elif "SequentialLR" in _scheduler:
         use_sequential = True
-        lr_scheduler = [
-            sched for sched in _scheduler.split(",")
-            if sched != ("SequentialLR")
+        optim.lr_scheduler = [
+            sched for sched in _scheduler.split(",") if sched != ("SequentialLR")
         ]
     else:
-        lr_scheduler = [_scheduler]
+        optim.lr_scheduler = [_scheduler]
 
-    for _scheduler in lr_scheduler:
+    for _scheduler in optim.lr_scheduler:
         retrieved_scheduler = registered_schedulers.get(_scheduler)
 
         if retrieved_scheduler is None:
@@ -88,8 +84,9 @@ def get(optimizer: optim.Optimizer, iterations_per_epoch: int,
         if _scheduler == "CosineAnnealingLR":
             returned_schedulers.append(
                 retrieved_scheduler(
-                    optimizer,
-                    iterations_per_epoch * Config().trainer.epochs))
+                    optimizer, iterations_per_epoch * Config().trainer.epochs
+                )
+            )
         elif _scheduler == "LambdaLR":
             lambdas = [lambda it: 1.0]
 
@@ -98,47 +95,53 @@ def get(optimizer: optim.Optimizer, iterations_per_epoch: int,
                     Step.from_str(x, iterations_per_epoch).iteration
                     for x in lr_params["milestone_steps"].split(",")
                 ]
-                lambdas.append(lambda it, milestones=milestones: lr_params[
-                    "gamma"]**bisect.bisect(milestones, it))
+                lambdas.append(
+                    lambda it, milestones=milestones: lr_params["gamma"]
+                    ** bisect.bisect(milestones, it)
+                )
 
             # Add a linear learning rate warmup if specified
             if "warmup_steps" in lr_params:
-                warmup_iters = Step.from_str(lr_params["warmup_steps"],
-                                             iterations_per_epoch).iteration
-                lambdas.append(lambda it, warmup_iters=warmup_iters: min(
-                    1.0, it / warmup_iters))
+                warmup_iters = Step.from_str(
+                    lr_params["warmup_steps"], iterations_per_epoch
+                ).iteration
+                lambdas.append(
+                    lambda it, warmup_iters=warmup_iters: min(1.0, it / warmup_iters)
+                )
             returned_schedulers.append(
                 retrieved_scheduler(
                     optimizer,
-                    lambda it, lambdas=lambdas: np.product(
-                        [l(it) for l in lambdas]),
-                ))
+                    lambda it, lambdas=lambdas: np.product([l(it) for l in lambdas]),
+                )
+            )
         elif _scheduler == "MultiStepLR":
             milestones = [
-                int(x.split("ep")[0])
-                for x in lr_params["milestone_steps"].split(",")
+                int(x.split("ep")[0]) for x in lr_params["milestone_steps"].split(",")
             ]
             returned_schedulers.append(
-                retrieved_scheduler(optimizer,
-                                    milestones=milestones,
-                                    gamma=lr_params["gamma"]))
+                retrieved_scheduler(
+                    optimizer, milestones=milestones, gamma=lr_params["gamma"]
+                )
+            )
         else:
-            returned_schedulers.append(
-                retrieved_scheduler(optimizer, **lr_params))
+            returned_schedulers.append(retrieved_scheduler(optimizer, **lr_params))
 
     if use_chained:
         return optim.lr_scheduler.ChainedScheduler(returned_schedulers)
 
     if use_sequential:
-        sequential_milestones = (Config().trainer.lr_sequential_milestones
-                                 if hasattr(Config().trainer,
-                                            "lr_sequential_milestones") else 2)
+        sequential_milestones = (
+            Config().trainer.lr_sequential_milestones
+            if hasattr(Config().trainer, "lr_sequential_milestones")
+            else 2
+        )
         sequential_milestones = [
             int(epoch) for epoch in sequential_milestones.split(",")
         ]
 
-        return optim.lr_scheduler.SequentialLR(optimizer, returned_schedulers,
-                                               sequential_milestones)
+        return optim.lr_scheduler.SequentialLR(
+            optimizer, returned_schedulers, sequential_milestones
+        )
     else:
         return returned_schedulers[0]
 
@@ -163,10 +166,8 @@ class Step:
         return Step(iteration, iterations_per_epoch)
 
     @staticmethod
-    def from_epoch(epoch: int, iteration: int,
-                   iterations_per_epoch: int) -> "Step":
-        return Step(epoch * iterations_per_epoch + iteration,
-                    iterations_per_epoch)
+    def from_epoch(epoch: int, iteration: int, iterations_per_epoch: int) -> "Step":
+        return Step(epoch * iterations_per_epoch + iteration, iterations_per_epoch)
 
     @staticmethod
     def from_str(s: str, iterations_per_epoch: int) -> "Step":
@@ -219,7 +220,8 @@ class Step:
             raise ValueError(f"Invalid type for other: {other}.")
         if self.iterations_per_epoch != other.iterations_per_epoch:
             raise ValueError(
-                "Cannot compare steps when epochs are of different lengths.")
+                "Cannot compare steps when epochs are of different lengths."
+            )
 
     def __lt__(self, other):
         self._check(other)

--- a/plato/trainers/optimizers.py
+++ b/plato/trainers/optimizers.py
@@ -8,6 +8,7 @@ from torch import optim
 
 from plato.config import Config
 
+
 def get(model, **kwargs: Union[str, dict]) -> optim.Optimizer:
     """Get an optimizer with its name and parameters obtained from the configuration file."""
     registered_optimizers = {
@@ -27,8 +28,12 @@ def get(model, **kwargs: Union[str, dict]) -> optim.Optimizer:
         "SGD": optim.SGD,
     }
 
-    optimizer_name = kwargs["optimizer_name"] if "optimizer_name" in kwargs else Config().trainer.optimizer
-    optim_params = kwargs["optim_params"] if "optim_params" in kwargs else Config().parameters.optimizer._asdict()
+    optimizer_name = kwargs[
+        "optimizer_name"] if "optimizer_name" in kwargs else Config(
+        ).trainer.optimizer
+    optim_params = kwargs[
+        "optim_params"] if "optim_params" in kwargs else Config(
+        ).parameters.optimizer._asdict()
 
     optimizer = registered_optimizers.get(optimizer_name)
     if optimizer is not None:

--- a/plato/trainers/optimizers.py
+++ b/plato/trainers/optimizers.py
@@ -28,12 +28,16 @@ def get(model, **kwargs: Union[str, dict]) -> optim.Optimizer:
         "SGD": optim.SGD,
     }
 
-    optimizer_name = kwargs[
-        "optimizer_name"] if "optimizer_name" in kwargs else Config(
-        ).trainer.optimizer
-    optim_params = kwargs[
-        "optim_params"] if "optim_params" in kwargs else Config(
-        ).parameters.optimizer._asdict()
+    optimizer_name = (
+        kwargs["optimizer_name"]
+        if "optimizer_name" in kwargs
+        else Config().trainer.optimizer
+    )
+    optim_params = (
+        kwargs["optim_params"]
+        if "optim_params" in kwargs
+        else Config().parameters.optimizer._asdict()
+    )
 
     optimizer = registered_optimizers.get(optimizer_name)
     if optimizer is not None:

--- a/plato/trainers/optimizers.py
+++ b/plato/trainers/optimizers.py
@@ -1,14 +1,14 @@
 """
 Optimizers for training workloads.
 """
+from typing import Union
 
 import torch_optimizer as torch_optim
 from torch import optim
 
 from plato.config import Config
 
-
-def get(model) -> optim.Optimizer:
+def get(model, **kwargs: Union[str, dict]) -> optim.Optimizer:
     """Get an optimizer with its name and parameters obtained from the configuration file."""
     registered_optimizers = {
         "Adam": optim.Adam,
@@ -27,8 +27,9 @@ def get(model) -> optim.Optimizer:
         "SGD": optim.SGD,
     }
 
-    optimizer_name = Config().trainer.optimizer
-    optim_params = Config().parameters.optimizer._asdict()
+    optimizer_name = kwargs["optimizer_name"] if "optimizer_name" in kwargs else Config().trainer.optimizer
+    optim_params = kwargs["optim_params"] if "optim_params" in kwargs else Config().parameters.optimizer._asdict()
+
     optimizer = registered_optimizers.get(optimizer_name)
     if optimizer is not None:
         return optimizer(model.parameters(), **optim_params)

--- a/tests/TestsConfig/personalized_config.yml
+++ b/tests/TestsConfig/personalized_config.yml
@@ -46,6 +46,7 @@ trainer:
     batch_size: 64
     optimizer: SGD
     lr_scheduler: MultiStepLR
+    loss_criterion: BCEWithLogitsLoss
 
     # Number of epochs for local training in each communication round
     #   The batch size for the downstream task can be larger as it
@@ -54,6 +55,7 @@ trainer:
     pers_batch_size: 12
     pers_optimizer: Adam
     pers_lr_scheduler: StepLR
+    pers_loss_criterion: CrossEntropyLoss
 
     # The machine learning model
     model_name: lenet5
@@ -82,3 +84,9 @@ parameters:
     pers_learning_rate:
         gamma: 0.3
         step_size: 10
+
+    loss_criterion:
+      reduction: mean
+
+    pers_loss_criterion:
+      label_smoothing: 0.5

--- a/tests/TestsConfig/personalized_config.yml
+++ b/tests/TestsConfig/personalized_config.yml
@@ -51,11 +51,11 @@ trainer:
     # Number of epochs for local training in each communication round
     #   The batch size for the downstream task can be larger as it
     # does not utilize the
-    pers_epochs: 10
-    pers_batch_size: 12
-    pers_optimizer: Adam
-    pers_lr_scheduler: StepLR
-    pers_loss_criterion: CrossEntropyLoss
+    personalized_epochs: 10
+    personalized_batch_size: 12
+    personalized_optimizer: Adam
+    personalized_lr_scheduler: StepLR
+    personalized_loss_criterion: CrossEntropyLoss
 
     # The machine learning model
     model_name: lenet5
@@ -72,7 +72,7 @@ parameters:
         momentum: 0.9
         weight_decay: 0.000001
 
-    pers_optimizer:
+    personalized_optimizer:
         lr: 0.1
         eps: 1.0e-6
         weight_decay: 0.0
@@ -81,12 +81,12 @@ parameters:
         gamma: 0.1
         milestone_steps: 150ep,350ep
 
-    pers_learning_rate:
+    personalized_learning_rate:
         gamma: 0.3
         step_size: 10
 
     loss_criterion:
       reduction: mean
 
-    pers_loss_criterion:
+    personalized_loss_criterion:
       label_smoothing: 0.5

--- a/tests/TestsConfig/personalized_config.yml
+++ b/tests/TestsConfig/personalized_config.yml
@@ -1,0 +1,84 @@
+clients:
+    # Type
+    type: simple
+
+    # The total number of clients
+    total_clients: 30
+
+    # The number of clients selected in each round
+    per_round: 30
+
+    # Should the clients compute test accuracy locally?
+    do_test: true
+
+server:
+    address: 127.0.0.1
+    port: 8000
+
+data:
+    # The training and testing dataset
+    datasource: MNIST
+
+    # Number of samples in each partition
+    partition_size: 2000
+
+    # IID or non-IID?
+    sampler: iid
+
+    # The random seed for sampling data
+    random_seed: 1
+
+trainer:
+    # The type of the trainer
+    type: basic
+
+    # The maximum number of training rounds
+    rounds: 5
+
+    # The maximum number of clients running concurrently
+    max_concurrency: 4
+
+    # The target accuracy
+    target_accuracy: 0.94
+
+    # Number of epoches for local training in each communication round
+    epochs: 3
+    batch_size: 64
+    optimizer: SGD
+    lr_scheduler: MultiStepLR
+
+    # Number of epochs for local training in each communication round
+    #   The batch size for the downstream task can be larger as it
+    # does not utilize the
+    pers_epochs: 10
+    pers_batch_size: 12
+    pers_optimizer: Adam
+    pers_lr_scheduler: StepLR
+
+    # The machine learning model
+    model_name: lenet5
+
+algorithm:
+    # Aggregation algorithm
+    type: fedavg
+
+parameters:
+
+parameters:
+    optimizer:
+        lr: 0.05
+        momentum: 0.9
+        weight_decay: 0.000001
+
+    pers_optimizer:
+        lr: 0.1
+        eps: 1.0e-6
+        weight_decay: 0.0
+
+    learning_rate:
+        gamma: 0.1
+        milestone_steps: 150ep,350ep
+
+    pers_learning_rate:
+        gamma: 0.3
+        step_size: 10

--- a/tests/personalization_tests.py
+++ b/tests/personalization_tests.py
@@ -2,7 +2,7 @@
 import os
 import unittest
 
-os.environ['config_file'] = 'tests/TestsConfig/personalized_config.yml'
+os.environ["config_file"] = "tests/TestsConfig/personalized_config.yml"
 
 from plato.config import Config
 import plato.models.registry as models_registry
@@ -12,7 +12,6 @@ from plato.trainers import loss_criterion
 
 
 class LrSchedulerTest(unittest.TestCase):
-
     def setUp(self):
         super().setUp()
         __ = Config()
@@ -30,30 +29,34 @@ class LrSchedulerTest(unittest.TestCase):
         personalized_optimizer = optimizers.get(
             self.model,
             optimizer_name=Config().trainer.pers_optimizer,
-            optim_params=Config().parameters.pers_optimizer._asdict())
+            optim_params=Config().parameters.pers_optimizer._asdict(),
+        )
         # 2. lr scheduler
         personalized_lrs = lr_schedulers.get(
             personalized_optimizer,
             10,
             lr_scheduler=Config().trainer.pers_lr_scheduler,
-            lr_params=Config().parameters.pers_learning_rate._asdict())
+            lr_params=Config().parameters.pers_learning_rate._asdict(),
+        )
         # 3. loss function
         personalized_loss = loss_criterion.get(
             loss_criterion=Config().trainer.pers_loss_criterion,
-            loss_criterion_params=Config(
-            ).parameters.pers_loss_criterion._asdict())
+            loss_criterion_params=Config().parameters.pers_loss_criterion._asdict(),
+        )
 
         # test whether loading different hyper-parameters:
         # 1. for the optimizer.
-        self.assertNotEqual(self.optimizer.param_groups[0]['lr'],
-                            personalized_optimizer.param_groups[0]['lr'])
         self.assertNotEqual(
-            self.optimizer.param_groups[0]['weight_decay'],
-            personalized_optimizer.param_groups[0]['weight_decay'])
+            self.optimizer.param_groups[0]["lr"],
+            personalized_optimizer.param_groups[0]["lr"],
+        )
+        self.assertNotEqual(
+            self.optimizer.param_groups[0]["weight_decay"],
+            personalized_optimizer.param_groups[0]["weight_decay"],
+        )
 
         # 2. for the lr scheduler.
-        self.assertNotEqual(self.lrs.get_last_lr(),
-                            personalized_lrs.get_last_lr())
+        self.assertNotEqual(self.lrs.get_last_lr(), personalized_lrs.get_last_lr())
 
         # 3. for the loss function.
         self.assertNotEqual(self.loss.__str__(), personalized_loss.__str__())

--- a/tests/personalization_tests.py
+++ b/tests/personalization_tests.py
@@ -16,19 +16,19 @@ class LrSchedulerTest(unittest.TestCase):
         super().setUp()
         __ = Config()
 
-        print(Config().trainer)
-
         self.model = models_registry.get()
         self.optimizer = optimizers.get(self.model)
-        self.lrs = optimizers.get(self.model)
+        self.lrs = lr_schedulers.get(self.optimizer, 50)
 
-    def assert_unequal_lrs_config(self, customize_lr):
-        #self.assertEqual()
-        pass
+    def assert_unequal_lrs(self, customize_lr):
+        self.assertNotEqual(self.lrs.get_last_lr(), customize_lr.get_last_lr())
 
     def assert_unequal_optimizers(self, customize_optimizer):
-        #self.assertEqual()
-        pass
+        self.assertNotEqual(self.optimizer.param_groups[0]['lr'],
+                            customize_optimizer.param_groups[0]['lr'])
+        self.assertNotEqual(
+            self.optimizer.param_groups[0]['weight_decay'],
+            customize_optimizer.param_groups[0]['weight_decay'])
 
     def test_personalized_config(self):
 
@@ -42,8 +42,8 @@ class LrSchedulerTest(unittest.TestCase):
             lr_scheduler=Config().trainer.pers_lr_scheduler,
             lr_params=Config().parameters.pers_learning_rate._asdict())
 
-        print(personalized_optimizer)
-        print(personalized_lrs)
+        self.assert_unequal_optimizers(personalized_optimizer)
+        self.assert_unequal_lrs(personalized_lrs)
 
 
 if __name__ == "__main__":

--- a/tests/personalization_tests.py
+++ b/tests/personalization_tests.py
@@ -28,20 +28,20 @@ class LrSchedulerTest(unittest.TestCase):
         # 1. optimizer
         personalized_optimizer = optimizers.get(
             self.model,
-            optimizer_name=Config().trainer.pers_optimizer,
-            optim_params=Config().parameters.pers_optimizer._asdict(),
+            optimizer_name=Config().trainer.personalized_optimizer,
+            optim_params=Config().parameters.personalized_optimizer._asdict(),
         )
         # 2. lr scheduler
         personalized_lrs = lr_schedulers.get(
             personalized_optimizer,
             10,
-            lr_scheduler=Config().trainer.pers_lr_scheduler,
-            lr_params=Config().parameters.pers_learning_rate._asdict(),
+            lr_scheduler=Config().trainer.personalized_lr_scheduler,
+            lr_params=Config().parameters.personalized_learning_rate._asdict(),
         )
         # 3. loss function
         personalized_loss = loss_criterion.get(
-            loss_criterion=Config().trainer.pers_loss_criterion,
-            loss_criterion_params=Config().parameters.pers_loss_criterion._asdict(),
+            loss_criterion=Config().trainer.personalized_loss_criterion,
+            loss_criterion_params=Config().parameters.personalized_loss_criterion._asdict(),
         )
 
         # test whether loading different hyper-parameters:

--- a/tests/personalization_tests.py
+++ b/tests/personalization_tests.py
@@ -4,11 +4,9 @@ import unittest
 
 os.environ["config_file"] = "tests/TestsConfig/personalized_config.yml"
 
+from plato.models import registry as models_registry
 from plato.config import Config
-import plato.models.registry as models_registry
-from plato.trainers import optimizers
-from plato.trainers import lr_schedulers
-from plato.trainers import loss_criterion
+from plato.trainers import loss_criterion, lr_schedulers, optimizers
 
 
 class LrSchedulerTest(unittest.TestCase):
@@ -23,7 +21,6 @@ class LrSchedulerTest(unittest.TestCase):
         self.loss = loss_criterion.get()
 
     def test_personalized_config(self):
-
         # define the terms for personalization
         # 1. optimizer
         personalized_optimizer = optimizers.get(

--- a/tests/personalization_tests.py
+++ b/tests/personalization_tests.py
@@ -1,0 +1,50 @@
+"""Unit tests for the personalization."""
+import os
+import unittest
+
+os.environ['config_file'] = 'tests/TestsConfig/personalized_config.yml'
+
+from plato.config import Config
+import plato.models.registry as models_registry
+from plato.trainers import optimizers
+from plato.trainers import lr_schedulers
+
+
+class LrSchedulerTest(unittest.TestCase):
+
+    def setUp(self):
+        super().setUp()
+        __ = Config()
+
+        print(Config().trainer)
+
+        self.model = models_registry.get()
+        self.optimizer = optimizers.get(self.model)
+        self.lrs = optimizers.get(self.model)
+
+    def assert_unequal_lrs_config(self, customize_lr):
+        #self.assertEqual()
+        pass
+
+    def assert_unequal_optimizers(self, customize_optimizer):
+        #self.assertEqual()
+        pass
+
+    def test_personalized_config(self):
+
+        personalized_optimizer = optimizers.get(
+            self.model,
+            optimizer_name=Config().trainer.pers_optimizer,
+            optim_params=Config().parameters.pers_optimizer._asdict())
+        personalized_lrs = lr_schedulers.get(
+            personalized_optimizer,
+            10,
+            lr_scheduler=Config().trainer.pers_lr_scheduler,
+            lr_params=Config().parameters.pers_learning_rate._asdict())
+
+        print(personalized_optimizer)
+        print(personalized_lrs)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

The ```get()``` functions of training terms, including `lr_schedulers`, `optimizers`, and `loss_criterion` are enhanced by adding `**kwargs` argument.

By doing so, these functions are expected to support customized optimizers, lr schedulers, and loss functions based on the corresponding hyper-parameters.

## Description
<!--- Describe your changes in detail -->
<!--- Describe motivation and context -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Apart from improving the flexibility of these functions, this enhancement enables the trainers of Plato to be applied in more scenarios, such as personalized federated learning (pFL). 

There are two stages in general personalized federated learning. The first is the normal federated training paradigm, while the second is personalization training. These two stages should utilize different lr schedulers, optimizers, and loss functions. The user expects to set the corresponding hyper-parameters for these two stages in the same configuration file. 

With this `**kwargs`, the user can define specific training elements, such as the optimizer, for the personalization stage based on the corresponding hyper-parameters in the configuration file. 

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

This enhancement has been tested in two scenarios. 

The first test is performed to ensure this modification does not influence Plato's existing code and examples. Thus, we ran the [examples](https://github.com/TL-System/plato/blob/main/docs/examples.md) of Plato. 

For example, after switching to Plato's root folder, you can run
```console
plato@user:~$ python examples/fedprox/fedprox.py -c examples/fedprox/fedprox_MNIST_lenet5.yml`
```

The second is a simple unit test named `personalization_tests.py` placed under the `tests/` folder. The main purpose of this test is to guarantee that this enhancement can be successfully utilized in the personalized federated learning domain.
 
After switching to Plato's root folder, you can run
```console
plato@user:~$ python tests/personalization_tests.py
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) Fixes #
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been formatted using Black and checked using PyLint.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
