### PR TITLE
Enhanced the get() function of Plato's model register 

### DIFF
--- a/plato/models/registry.py
+++ b/plato/models/registry.py
@@ -4,6 +4,8 @@ The registry for machine learning models.
 Having a registry of all available classes is convenient for retrieving an instance
 based on a configuration at run-time.
 """
+from typing import Union
+
 from plato.config import Config
 
 if hasattr(Config().trainer, "use_mindspore"):
@@ -41,18 +43,31 @@ else:
     }
 
 
-def get():
+def get(**kwargs: Union[str, dict]):
     """Get the model with the provided name."""
-    model_name = Config().trainer.model_name
-    model_type = (
-        Config().trainer.model_type
-        if hasattr(Config().trainer, "model_type")
-        else model_name.split("_")[0]
+    model_name = (
+        kwargs["model_name"] if "model_name" in kwargs else Config().trainer.model_name
     )
-    if hasattr(Config().parameters, "model"):
-        model_params = Config().parameters.model._asdict()
-    else:
-        model_params = {}
+
+    model_type = (
+        kwargs["model_type"]
+        if "model_type" in kwargs
+        else (
+            Config().trainer.model_type
+            if hasattr(Config().trainer, "model_type")
+            else model_name.split("_")[0]
+        )
+    )
+
+    model_params = (
+        kwargs["model_params"]
+        if "model_params" in kwargs
+        else (
+            Config().parameters.model._asdict()
+            if hasattr(Config().parameters, "model")
+            else {}
+        )
+    )
 
     if model_type in registered_models:
         registered_model = registered_models[model_type]

--- a/tests/TestsConfig/personalized_config.yml
+++ b/tests/TestsConfig/personalized_config.yml
@@ -59,12 +59,11 @@ trainer:
 
     # The machine learning model
     model_name: lenet5
+    personalized_model_name: resnet_18
 
 algorithm:
     # Aggregation algorithm
     type: fedavg
-
-parameters:
 
 parameters:
     optimizer:
@@ -90,3 +89,10 @@ parameters:
 
     personalized_loss_criterion:
       label_smoothing: 0.5
+
+    model:
+        num_classes: 10
+
+    personalized_model:
+        num_classes: 20
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This is a series of work related to [PR#263](https://github.com/TL-System/plato/pull/263). To be specific, following the same target and mechanism of adding `**kwargs` argument, this PR aims to enhance the ```get()``` functions of `registry.py` under `models` folder of Plato. 


## Description
<!--- Describe your changes in detail -->
<!--- Describe motivation and context -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Following the same motivation as [PR#263](https://github.com/TL-System/plato/pull/263), the modification purpose of this PR is to allow the ```get()``` function to support more flexible and extensive model definitions.

For example, in the personalized federated learning domain, the global model can be defined by calling `model_registry.get()` while the personalized model can be directly defined by calling 
```
model_registry.get(
model_name=Config().trainer.personalized_model_name, 
model_params=Config().parameters.personalized_model._asdict()
)
```

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Two tests, including the `examples` and the unit test running, are performed to guarantee that this modification does not influence the existing Plato code and supports the personalized model definition. 

More details can be accessed in the [PR#263](https://github.com/TL-System/plato/pull/263).

For convenience and clarity, we show how to run unit tests below.

After switching to Plato's root folder, you can run
```console
plato@user:~$ python tests/personalization_tests.py
```


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) Fixes #
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been formatted using Black and checked using PyLint.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
