### PR TITLE
Implemented the general Multi-layer Perceptron (MLP)

### DIFF
--- a/configs/Purchase100/fedavg_customized_multilayer.yml
+++ b/configs/Purchase100/fedavg_customized_multilayer.yml
@@ -1,0 +1,89 @@
+clients:
+    # Type
+    type: simple
+
+    # The total number of clients
+    total_clients: 100
+
+    # The number of clients selected in each round
+    per_round: 5
+
+    # Should the clients compute test accuracy locally?
+    do_test: false
+
+server:
+    address: 127.0.0.1
+    port: 8080
+    simulate_wall_time: true
+
+data:
+    # The training and testing dataset
+    datasource: Purchase
+
+    # Number of samples in each partition
+    partition_size: 2000
+
+    # IID or non-IID?
+    sampler: noniid
+
+    # The random seed for sampling data
+    random_seed: 1
+
+trainer:
+    # The type of the trainer
+    type: basic
+    # type: diff_privacy
+    # dp_epsilon: 2
+    # dp_delta: 0.00001
+    # dp_max_grad_norm: 1
+
+    # The maximum number of training rounds
+    rounds: 100
+
+    # The maximum number of clients running concurrently
+    max_concurrency: 10
+
+    # The target accuracy
+    target_accuracy: 0.80
+
+    # The machine learning model
+    model_type: general_multilayer
+    model_name: customized_mlp
+
+    # Number of epoches for local training in each communication round
+    epochs: 5
+    batch_size: 32
+    optimizer: SGD
+
+algorithm:
+    # Aggregation algorithm
+    type: fedavg
+
+parameters:
+    model:
+        input_dim: 600
+        output_dim: 100
+        hidden_layers_dim:
+          - 1024
+          - 256
+        batch_norms:
+          - null
+          - null
+          - null
+        activations:
+          - tanh
+          - tanh
+          - tanh
+        dropout_ratios:
+          - 0.0
+          - 0.0
+          - 0.0
+
+    optimizer:
+        lr: 0.01
+        momentum: 0.9
+        weight_decay: 0.0
+
+results:
+    # Write the following parameter(s) into a CSV
+    types: round, elapsed_time, accuracy

--- a/configs/Purchase100/fedavg_customized_multilayer.yml
+++ b/configs/Purchase100/fedavg_customized_multilayer.yml
@@ -65,8 +65,12 @@ parameters:
         output_dim: 100
         hidden_layers_dim:
           - 1024
+          - 512
           - 256
+          - 128
         batch_norms:
+          - null
+          - null
           - null
           - null
           - null
@@ -74,7 +78,11 @@ parameters:
           - tanh
           - tanh
           - tanh
+          - tanh
+          - null
         dropout_ratios:
+          - 0.0
+          - 0.0
           - 0.0
           - 0.0
           - 0.0

--- a/configs/Purchase100/fedavg_general_mlp.yml
+++ b/configs/Purchase100/fedavg_general_mlp.yml
@@ -1,0 +1,74 @@
+clients:
+    # Type
+    type: simple
+
+    # The total number of clients
+    total_clients: 100
+
+    # The number of clients selected in each round
+    per_round: 5
+
+    # Should the clients compute test accuracy locally?
+    do_test: false
+
+server:
+    address: 127.0.0.1
+    port: 8080
+    simulate_wall_time: true
+
+data:
+    # The training and testing dataset
+    datasource: Purchase
+
+    # Number of samples in each partition
+    partition_size: 2000
+
+    # IID or non-IID?
+    sampler: noniid
+
+    # The random seed for sampling data
+    random_seed: 1
+
+trainer:
+    # The type of the trainer
+    type: basic
+    # type: diff_privacy
+    # dp_epsilon: 2
+    # dp_delta: 0.00001
+    # dp_max_grad_norm: 1
+
+    # The maximum number of training rounds
+    rounds: 100
+
+    # The maximum number of clients running concurrently
+    max_concurrency: 10
+
+    # The target accuracy
+    target_accuracy: 0.80
+
+    # The machine learning model
+    model_type: general_multilayer
+    model_name: linear_mlp
+
+    # Number of epoches for local training in each communication round
+    epochs: 5
+    batch_size: 32
+    optimizer: SGD
+
+algorithm:
+    # Aggregation algorithm
+    type: fedavg
+
+parameters:
+    model:
+        input_dim: 600
+        output_dim: 100
+
+    optimizer:
+        lr: 0.01
+        momentum: 0.9
+        weight_decay: 0.0
+
+results:
+    # Write the following parameter(s) into a CSV
+    types: round, elapsed_time, accuracy

--- a/configs/Purchase100/fedavg_general_mlp.yml
+++ b/configs/Purchase100/fedavg_general_mlp.yml
@@ -48,7 +48,7 @@ trainer:
 
     # The machine learning model
     model_type: general_multilayer
-    model_name: linear_mlp
+    model_name: plato_multilayer
 
     # Number of epoches for local training in each communication round
     epochs: 5

--- a/plato/models/general_mlps.py
+++ b/plato/models/general_mlps.py
@@ -130,11 +130,12 @@ class Model:
             )
 
         if model_name == "simclr_projection_mlp":
+            projection_hidden_dim = kwargs["projection_hidden_dim"]
             return build_mlp_from_config(
                 dict(
                     output_dim=output_dim,
                     input_dim=input_dim,
-                    hidden_layers_dim=[Config.trainer.projection_hidden_dim],
+                    hidden_layers_dim=[projection_hidden_dim],
                     batch_norms=[None, None],
                     activations=["relu", None],
                     dropout_ratios=[0.0, 0.0],
@@ -142,13 +143,14 @@ class Model:
             )
 
         if model_name == "simsiam_projection_mlp":
+            projection_hidden_dim = kwargs["projection_hidden_dim"]
             return build_mlp_from_config(
                 dict(
                     output_dim=output_dim,
                     input_dim=input_dim,
                     hidden_layers_dim=[
-                        Config.trainer.projection_hidden_dim,
-                        Config.trainer.projection_hidden_dim,
+                        projection_hidden_dim,
+                        projection_hidden_dim,
                     ],
                     batch_norms=[
                         dict(momentum=0.1, eps=1e-5),
@@ -161,11 +163,12 @@ class Model:
             )
 
         if model_name == "simsiam_prediction_mlp":
+            prediction_hidden_dim = kwargs["prediction_hidden_dim"]
             return build_mlp_from_config(
                 dict(
                     output_dim=output_dim,
                     input_dim=input_dim,
-                    hidden_layers_dim=[Config.trainer.prediction_hidden_dim],
+                    hidden_layers_dim=[prediction_hidden_dim],
                     batch_norms=[dict(momentum=0.1, eps=1e-5), None],
                     activations=["relu", None],
                     dropout_ratios=[0.0, 0.0],
@@ -173,11 +176,12 @@ class Model:
             )
 
         if model_name == "byol_projection_mlp":
+            projection_hidden_dim = kwargs["projection_hidden_dim"]
             return build_mlp_from_config(
                 dict(
                     output_dim=output_dim,
                     input_dim=input_dim,
-                    hidden_layers_dim=[Config.trainer.projection_hidden_dim],
+                    hidden_layers_dim=[projection_hidden_dim],
                     batch_norms=[dict(momentum=0.1, eps=1e-5), None],
                     activations=["relu", None],
                     dropout_ratios=[0.0, 0.0],
@@ -185,23 +189,24 @@ class Model:
             )
 
         if model_name == "byol_prediction_mlp":
+            prediction_hidden_dim = kwargs["prediction_hidden_dim"]
             return build_mlp_from_config(
                 dict(
                     output_dim=output_dim,
                     input_dim=input_dim,
-                    hidden_layers_dim=[Config.trainer.prediction_hidden_dim],
+                    hidden_layers_dim=[prediction_hidden_dim],
                     batch_norms=[dict(momentum=0.1, eps=1e-5), None],
                     activations=["relu", None],
                     dropout_ratios=[0.0, 0.0],
                 )
             )
         if model_name == "moco_final_mlp":
+            projection_hidden_dim = kwargs["projection_hidden_dim"]
             return build_mlp_from_config(
                 dict(
-                    type="FullyConnectedHead",
                     output_dim=output_dim,
                     input_dim=input_dim,
-                    hidden_layers_dim=[Config.trainer.projection_hidden_dim],
+                    hidden_layers_dim=[projection_hidden_dim],
                     batch_norms=[None, None],
                     activations=["relu", None],
                     dropout_ratios=[0.0, 0.0],

--- a/plato/models/general_mlps.py
+++ b/plato/models/general_mlps.py
@@ -1,0 +1,210 @@
+"""
+The implementation of the general Multi-layer perceptron (MLP).
+
+I.e., build the fully-connected net based on the configs.
+
+This a very flexible MLP network generator to define any types of MLP networks.
+
+Note: The general order of components in one MLP layer is:
+    Schema A: From the original paper of bn and dropout.
+    fc -> bn -> activation -> dropout -> ....
+
+    Schema B: From the researcher "https://math.stackexchange.com/users/167500/pseudomarvin".
+    fc -> activation -> dropout -> bn -> ....
+
+    See more discussion in:
+    https://stackoverflow.com/questions/39691902/ordering-of-batch-normalization-and-dropout
+
+Our work use the schema A.
+
+Tricks:
+    - Usually, Just drop the Dropout(when you have BN)
+    as BN eliminates the need for Dropout in some cases cause BN provides similar
+    regularization benefits as Dropout intuitively.
+
+"""
+
+from collections import OrderedDict
+
+from torch import nn
+from plato.config import Config
+
+activations_func = {"relu": nn.ReLU, "sigmoid": nn.Sigmoid, "softmax": nn.Softmax}
+
+
+# pylint: disable=too-many-locals
+def build_mlp_from_config(mlp_configs, layer_name_prefix="layer"):
+    """Build one fully-connected network based the input setting.
+
+
+    Args:
+        mlp_configs (dict):
+    """
+    input_dim = mlp_configs["input_dim"]
+    output_dim = mlp_configs["output_dim"]
+
+    hidden_layers_dim = mlp_configs["hidden_layers_dim"]
+    hidden_n = len(hidden_layers_dim)
+
+    batch_norms = mlp_configs["batch_norms"]
+    activations = mlp_configs["activations"]
+    dropout_porbs = (
+        mlp_configs["dropout_ratios"]
+        if isinstance(mlp_configs["dropout_ratios"], list)
+        else [mlp_configs["dropout_ratios"]]
+    )
+
+    assert len(batch_norms) == len(activations) == len(dropout_porbs)
+    assert hidden_n == len(batch_norms) - 1
+
+    def build_one_layer(
+        layer_ipt_dim, layer_opt_dim, batch_norm_type, activation, dropout_prob
+    ):
+        """Build one layer of MLP. Default no hidden layer.
+
+        For the structure of one MLP layer. Please access the description
+        below the function 'build_mlp_from_config' for details.
+
+        """
+        layer_structure = OrderedDict()
+        layer_structure["fc"] = nn.Linear(layer_ipt_dim, layer_opt_dim)
+        # the batch_norm_type here can be:
+        #   - default if the user wants to use
+        #       the batch norm following the defualt parameters 'default_params'.
+        #   - dict if the use wants to set custom parameters
+        # however, once the batch_norm_type
+        if batch_norm_type is not None:
+            default_params = dict(momentum=0.1, eps=1e-5)
+            bn_params = (
+                default_params
+                if batch_norm_type == "default"
+                else default_params.update(batch_norm_type)
+            )
+            layer_structure["bn"] = nn.BatchNorm1d(layer_opt_dim, **bn_params)
+        if activation is not None:
+            layer_structure[activation] = activations_func[activation](inplace=True)
+        if dropout_prob != 0:
+            layer_structure["drop"] = nn.Dropout(p=dropout_prob)
+
+        return nn.Sequential(layer_structure)
+
+    mlp_layers = OrderedDict()
+    # add the final output layer to the hidden layer for building layers
+    hidden_layers_dim.append(output_dim)
+    for hid_id, hid_dim in enumerate(hidden_layers_dim):
+        layer_input_dim = input_dim if hid_id == 0 else hidden_layers_dim[hid_id - 1]
+        desired_batch_norm = batch_norms[hid_id]
+        activation = activations[hid_id]
+        dropout_prob = dropout_porbs[hid_id]
+        built_layer = build_one_layer(
+            layer_input_dim, hid_dim, desired_batch_norm, activation, dropout_prob
+        )
+        mlp_layers[layer_name_prefix + str(hid_id + 1)] = built_layer
+
+    fc_net = nn.Sequential(mlp_layers)
+
+    return fc_net
+
+
+class Model:
+    """The Multi-layer perceptron (MLP) model."""
+
+    # pylint: disable=too-few-public-methods
+    @staticmethod
+    def get(model_type, input_dim):
+        # pylint:disable=too-many-return-statements
+
+        """Get the desired MLP model with required input dimension (input_dim)."""
+        if model_type == "pure_one_layer_mlp":
+            return build_mlp_from_config(
+                mlp_configs=dict(
+                    type="FullyConnectedHead",
+                    output_dim=Config().trainer.num_classes,
+                    input_dim=input_dim,
+                    hidden_layers_dim=[],
+                    batch_norms=[None],
+                    activations=[None],
+                    dropout_ratios=[0],
+                )
+            )
+
+        if model_type == "simclr_projection_mlp":
+            return build_mlp_from_config(
+                dict(
+                    type="FullyConnectedHead",
+                    output_dim=Config.trainer.projection_dim,
+                    input_dim=input_dim,
+                    hidden_layers_dim=[Config.trainer.projection_hidden_dim],
+                    batch_norms=[None, None],
+                    activations=["relu", None],
+                    dropout_ratios=[0, 0],
+                )
+            )
+
+        if model_type == "simsiam_projection_mlp":
+            return build_mlp_from_config(
+                dict(
+                    type="FullyConnectedHead",
+                    output_dim=Config.trainer.projection_dim,
+                    input_dim=input_dim,
+                    hidden_layers_dim=[
+                        Config.trainer.projection_hidden_dim,
+                        Config.trainer.projection_hidden_dim,
+                    ],
+                    batch_norms=["default", "default", "default"],
+                    activations=["relu", "relu", None],
+                    dropout_ratios=[0, 0, 0],
+                )
+            )
+
+        if model_type == "simsiam_prediction_mlp":
+            return build_mlp_from_config(
+                dict(
+                    type="FullyConnectedHead",
+                    output_dim=Config.trainer.prediction_dim,
+                    input_dim=input_dim,
+                    hidden_layers_dim=[Config.trainer.prediction_hidden_dim],
+                    batch_norms=["default", None],
+                    activations=["relu", None],
+                    dropout_ratios=[0, 0],
+                )
+            )
+
+        if model_type == "byol_projection_mlp":
+            return build_mlp_from_config(
+                dict(
+                    type="FullyConnectedHead",
+                    output_dim=Config.trainer.projection_dim,
+                    input_dim=input_dim,
+                    hidden_layers_dim=[Config.trainer.projection_hidden_dim],
+                    batch_norms=["default", None],
+                    activations=["relu", None],
+                    dropout_ratios=[0, 0],
+                )
+            )
+
+        if model_type == "byol_prediction_mlp":
+            return build_mlp_from_config(
+                dict(
+                    type="FullyConnectedHead",
+                    output_dim=Config.trainer.prediction_dim,
+                    input_dim=input_dim,
+                    hidden_layers_dim=[Config.trainer.prediction_hidden_dim],
+                    batch_norms=["default", None],
+                    activations=["relu", None],
+                    dropout_ratios=[0, 0],
+                )
+            )
+        if model_type == "moco_final_mlp":
+            return build_mlp_from_config(
+                dict(
+                    type="FullyConnectedHead",
+                    output_dim=Config.trainer.projection_dim,
+                    input_dim=input_dim,
+                    hidden_layers_dim=[Config.trainer.projection_hidden_dim],
+                    batch_norms=[None, None],
+                    activations=["relu", None],
+                    dropout_ratios=[0, 0],
+                )
+            )
+        raise ValueError(f"No such MLP model: {model_type}")

--- a/plato/models/general_multilayer.py
+++ b/plato/models/general_multilayer.py
@@ -28,7 +28,12 @@ from collections import OrderedDict
 
 from torch import nn
 
-activations_func = {"relu": nn.ReLU, "sigmoid": nn.Sigmoid, "softmax": nn.Softmax}
+activations_func = {
+    "relu": nn.ReLU,
+    "sigmoid": nn.Sigmoid,
+    "softmax": nn.Softmax,
+    "tanh": nn.Tanh,
+}
 
 
 # pylint: disable=too-many-locals
@@ -82,13 +87,14 @@ def build_mlp_from_config(
         if batch_norm_param is not None:
             layer_structure["bn"] = nn.BatchNorm1d(layer_opt_dim, **batch_norm_param)
         if activation is not None:
-            layer_structure[activation] = activations_func[activation](inplace=True)
+            layer_structure[activation] = activations_func[activation]()
         if dropout_prob != 0.0:
             layer_structure["drop"] = nn.Dropout(p=dropout_prob)
 
         return nn.Sequential(layer_structure)
 
     mlp_layers = OrderedDict()
+
     # add the final output layer to the hidden layer for building layers
     hidden_layers_dim.append(output_dim)
     for hid_id, hid_dim in enumerate(hidden_layers_dim):
@@ -203,6 +209,7 @@ class Model:
                     dropout_ratios=[0.0, 0.0],
                 )
             )
+
         if model_name == "moco_final_mlp":
             projection_hidden_dim = kwargs["projection_hidden_dim"]
             return build_mlp_from_config(
@@ -213,6 +220,18 @@ class Model:
                     batch_norms=[None, None],
                     activations=["relu", None],
                     dropout_ratios=[0.0, 0.0],
+                )
+            )
+
+        if model_name == "plato_multilayer":
+            return build_mlp_from_config(
+                dict(
+                    output_dim=output_dim,
+                    input_dim=input_dim,
+                    hidden_layers_dim=[1024, 512, 256, 128],
+                    batch_norms=[None, None, None, None, None],
+                    activations=["tanh", "tanh", "tanh", "tanh", None],
+                    dropout_ratios=[0.0, 0.0, 0.0, 0.0, 0.0],
                 )
             )
 

--- a/plato/models/general_multilayer.py
+++ b/plato/models/general_multilayer.py
@@ -24,18 +24,16 @@ Tricks:
 
 """
 from typing import Union, Dict, List
-
 from collections import OrderedDict
 
 from torch import nn
-from plato.config import Config
 
 activations_func = {"relu": nn.ReLU, "sigmoid": nn.Sigmoid, "softmax": nn.Softmax}
 
 
 # pylint: disable=too-many-locals
 def build_mlp_from_config(
-    mlp_configs: Dict[str, Union[int, List[str, None, dict]]],
+    mlp_configs: Dict[str, Union[int, List[Union[str, None, dict]]]],
     layer_name_prefix: str = "layer",
 ):
     """
@@ -113,9 +111,14 @@ class Model:
 
     # pylint: disable=too-few-public-methods
     @staticmethod
-    def get(model_name, input_dim, output_dim, **kwargs):
+    def get(
+        model_name: str,
+        input_dim: int,
+        output_dim: int,
+        **kwargs: Dict[str, Union[int, List[Union[str, None, dict]]]]
+    ):
         # pylint:disable=too-many-return-statements
-        """Get the desired MLP model with required input dimension (input_dim)."""
+        """Get the desired MLP model with required hyper-parameters (input_dim)."""
 
         if model_name == "linear_mlp":
             return build_mlp_from_config(
@@ -215,6 +218,11 @@ class Model:
 
         # obtain the customized mlp layer if the required model does not
         # existed
-
-
-        raise ValueError(f"No such MLP model: {model_name}")
+        # then the user needs to put the corresponding hyper-parameters
+        # in the 'kwargs'
+        return build_mlp_from_config(
+            dict(
+                output_dim=output_dim,
+                input_dim=input_dim,
+            ).update(kwargs)
+        )

--- a/plato/models/general_multilayer.py
+++ b/plato/models/general_multilayer.py
@@ -246,11 +246,9 @@ class Model:
                 )
             )
 
-        # obtain the customized mlp layer if the required model does not
-        # existed
-        # then the user needs to put the corresponding hyper-parameters
+        # obtain the customized mlp laye
+        # the user needs to put the corresponding hyper-parameters
         # in the 'kwargs'
-
         if model_name == "customized_mlp":
             return build_mlp_from_config(
                 dict(output_dim=output_dim, input_dim=input_dim, **kwargs)

--- a/plato/models/general_multilayer.py
+++ b/plato/models/general_multilayer.py
@@ -1,18 +1,18 @@
 """
 The implementation of the general Multi-layer perceptron (MLP).
 
-I.e., build the fully-connected net based on the configs.
+I.e., build the fully-connected network based on the configuration.
 
-This a very flexible MLP network generator to define any types of MLP networks.
+This a very flexible MLP network generator to define any type of MLP network.
 
-Note: The general order of components in one MLP layer is:
+NOTE: The general order of components in one MLP layer is:
     Schema A: From the original paper of bn and dropout.
     fc -> bn -> activation -> dropout -> ....
 
     Schema B: From the researcher "https://math.stackexchange.com/users/167500/pseudomarvin".
     fc -> activation -> dropout -> bn -> ....
 
-    See more discussion in:
+    See more discussion on the website:
     https://stackoverflow.com/questions/39691902/ordering-of-batch-normalization-and-dropout
 
 Our work use the schema A.
@@ -78,7 +78,7 @@ def build_mlp_from_config(
         """Build one layer of MLP. Default no hidden layer.
 
         For the structure of one MLP layer. Please access the description
-        below the function 'build_mlp_from_config' for details.
+        in the NOTE part.
 
         """
         layer_structure = OrderedDict()
@@ -107,13 +107,24 @@ def build_mlp_from_config(
         )
         mlp_layers[layer_name_prefix + str(hid_id + 1)] = built_layer
 
-    fc_net = nn.Sequential(mlp_layers)
-
-    return fc_net
+    return nn.Sequential(mlp_layers)
 
 
 class Model:
-    """The Multi-layer perceptron (MLP) model."""
+    """The Multi-layer perceptron (MLP) model.
+
+    The implemented mlp networks are:
+    - linear_mlp, The mlp with one hidden layer.
+    - simclr_projection_mlp, The projection layer of SimCLR method.
+    - simsiam_projection_mlp, The projection layer of SimSiam method.
+    - simsiam_prediction_mlp, The prediction layer of SimSiam method.
+    - byol_projection_mlp, The projection layer of BYOL method.
+    - byol_prediction_mlp, The prediction layer of BYOL method.
+    - moco_final_mlp, The final layer of MoCo method.
+    - plato_multilayer, The Plato's multilayer.
+    - customized_mlp, The customized layer.
+
+    """
 
     # pylint: disable=too-few-public-methods
     @staticmethod
@@ -121,7 +132,7 @@ class Model:
         model_name: str,
         input_dim: int,
         output_dim: int,
-        **kwargs: Dict[str, Union[int, List[Union[str, None, dict]]]]
+        **kwargs: Dict[str, Union[int, List[Union[str, None, dict]]]],
     ):
         # pylint:disable=too-many-return-statements
         """Get the desired MLP model with required hyper-parameters (input_dim)."""
@@ -239,9 +250,10 @@ class Model:
         # existed
         # then the user needs to put the corresponding hyper-parameters
         # in the 'kwargs'
-        return build_mlp_from_config(
-            dict(
-                output_dim=output_dim,
-                input_dim=input_dim,
-            ).update(kwargs)
-        )
+
+        if model_name == "customized_mlp":
+            return build_mlp_from_config(
+                dict(output_dim=output_dim, input_dim=input_dim, **kwargs)
+            )
+
+        raise ValueError(f"No such MLP model: {model_name}")

--- a/plato/models/registry.py
+++ b/plato/models/registry.py
@@ -21,6 +21,7 @@ else:
         lenet5,
         dcgan,
         multilayer,
+        general_multilayer,
         resnet,
         vgg,
         torch_hub,
@@ -40,6 +41,7 @@ else:
         "torch_hub": torch_hub.Model,
         "huggingface": huggingface.Model,
         "vit": vit.Model,
+        "general_multilayer": general_multilayer.Model,
     }
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

A general Multi-layer Perceptron (MLP) implementation is added to Plato's ```models/general_multilayer.py```. 

This implementation provides a more flexible and general way to create all fully-connected layers. 

## Description
<!--- Describe your changes in detail -->
<!--- Describe motivation and context -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The current Plato's multilayer is pretty plain and only has one structure. However, many other models and tasks require different and complex MLPs. 

Thus, this PR is proposed to fill this gap by implementing a flexible and general way to define MLPs. 


**For details of this MLPs**: 

The general order of components in one MLP layer is:
- Schema A: From the original paper of bn and dropout.
```
    fc -> bn -> activation -> dropout -> ....
```
- Schema B: From the [researcher](https://math.stackexchange.com/users/167500/pseudomarvin).
```
    fc -> activation -> dropout -> bn -> ....
```

See more discussion on the [webiste](https://stackoverflow.com/questions/39691902/ordering-of-batch-normalization-and-dropout):

This implementation utilizes ***Schema A***.

For ease of use and understanding, there are many MLPs created ```models/general_multilayer.py```. These created MLPs can be utilized by directly setting the `model_name` in the configuration file. 


## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Two examples are implemented to support a comprehensive test of the ```models/general_multilayer.py```.

The first one is to test whether the MLPs can be defined based on the `model_name` in the configuration file. 
The user can change the 'model_name' according to the ones supported within ```models/general_multilayer.py``` to perform testing for different MLPs.
When setting `model_name: plato_multilayer`, the defined MLP model will have the same structure as Plato's ```models/multilayer.py```.

```console
plato@user:~$ ./run -c configs/Purchase100/fedavg_general_mlp.yml
```

The second is to test the customized MLPs, which define the structure in the `parameters` of configuration files.
The model structure of this test is the same as Plato's ```models/multilayer.py```.

```console
plato@user:~$ ./run -c configs/Purchase100/fedavg_customized_multilayer.yml
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) Fixes #
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been formatted using Black and checked using PyLint.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
