### PR TITLE
Added **kwargs to datasource

### DIFF
--- a/plato/datasources/celeba.py
+++ b/plato/datasources/celeba.py
@@ -19,17 +19,20 @@ class CelebA(datasets.CelebA):
     identity, which is used for non-IID samplers.
     """
 
-    def __init__(self,
-                 root: str,
-                 split: str = "train",
-                 target_type: Union[List[str], str] = "attr",
-                 transform: Optional[Callable] = None,
-                 target_transform: Optional[Callable] = None,
-                 download: bool = False) -> None:
-        super().__init__(root, split, target_type, transform, target_transform,
-                         download)
+    def __init__(
+        self,
+        root: str,
+        split: str = "train",
+        target_type: Union[List[str], str] = "attr",
+        transform: Optional[Callable] = None,
+        target_transform: Optional[Callable] = None,
+        download: bool = False,
+    ) -> None:
+        super().__init__(
+            root, split, target_type, transform, target_transform, download
+        )
         self.targets = self.identity.flatten().tolist()
-        self.classes = [f'Celebrity #{i}' for i in range(10177 + 1)]
+        self.classes = [f"Celebrity #{i}" for i in range(10177 + 1)]
 
 
 class DataSource(base.DataSource):
@@ -37,14 +40,16 @@ class DataSource(base.DataSource):
 
     def __init__(self, **kwargs):
         super().__init__()
-        _path = Config().params['data_path']
+        _path = Config().params["data_path"]
 
-        if not os.path.exists(os.path.join(_path, 'celeba')):
-            celeba_url = 'http://iqua.ece.toronto.edu/baochun/celeba.tar.gz'
+        if not os.path.exists(os.path.join(_path, "celeba")):
+            celeba_url = "http://iqua.ece.toronto.edu/baochun/celeba.tar.gz"
             DataSource.download(celeba_url, _path)
         else:
-            logging.info("CelebA data already decompressed under %s",
-                         os.path.join(_path, 'celeba'))
+            logging.info(
+                "CelebA data already decompressed under %s",
+                os.path.join(_path, "celeba"),
+            )
 
         target_types = []
         if hasattr(Config().data, "celeba_targets"):
@@ -54,34 +59,51 @@ class DataSource(base.DataSource):
             if hasattr(targets, "identity") and targets.identity:
                 target_types.append("identity")
         else:
-            target_types = ['attr', 'identity']
+            target_types = ["attr", "identity"]
 
         image_size = 64
-        if hasattr(Config().data, 'celeba_img_size'):
+        if hasattr(Config().data, "celeba_img_size"):
             image_size = Config().data.celeba_img_size
 
-        _transform = transforms.Compose([
-            transforms.Resize(image_size),
-            transforms.CenterCrop(image_size),
-            transforms.ToTensor(),
-            transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5)),
-        ])
-        _target_transform = None
-        if target_types:
-            _target_transform = DataSource._target_transform
+        train_transform = (
+            kwargs["train_transform"]
+            if "train_transform" in kwargs
+            else (
+                transforms.Compose(
+                    [
+                        transforms.Resize(image_size),
+                        transforms.CenterCrop(image_size),
+                        transforms.ToTensor(),
+                        transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5)),
+                    ]
+                )
+            )
+        )
 
-        self.trainset = CelebA(root=_path,
-                               split='train',
-                               target_type=target_types,
-                               download=False,
-                               transform=_transform,
-                               target_transform=_target_transform)
-        self.testset = CelebA(root=_path,
-                              split='test',
-                              target_type=target_types,
-                              download=False,
-                              transform=_transform,
-                              target_transform=_target_transform)
+        test_transform = train_transform
+
+        target_transform = (
+            kwargs["target_transform"]
+            if "target_transform" in kwargs
+            else (DataSource._target_transform if target_types else None)
+        )
+
+        self.trainset = CelebA(
+            root=_path,
+            split="train",
+            target_type=target_types,
+            download=False,
+            transform=train_transform,
+            target_transform=target_transform,
+        )
+        self.testset = CelebA(
+            root=_path,
+            split="test",
+            target_type=target_types,
+            download=False,
+            transform=test_transform,
+            target_transform=target_transform,
+        )
 
     @staticmethod
     def _target_transform(label):
@@ -96,18 +118,27 @@ class DataSource(base.DataSource):
                 return label[0]
             elif len(label) == 2:
                 attr, identity = label
-                return torch.cat((attr.reshape([
-                    -1,
-                ]), identity.reshape([
-                    -1,
-                ])))
+                return torch.cat(
+                    (
+                        attr.reshape(
+                            [
+                                -1,
+                            ]
+                        ),
+                        identity.reshape(
+                            [
+                                -1,
+                            ]
+                        ),
+                    )
+                )
         else:
             return label
 
     @staticmethod
     def input_shape():
         image_size = 64
-        if hasattr(Config().data, 'celeba_img_size'):
+        if hasattr(Config().data, "celeba_img_size"):
             image_size = Config().data.celeba_img_size
         return [162770, 3, image_size, image_size]
 

--- a/plato/datasources/celeba.py
+++ b/plato/datasources/celeba.py
@@ -35,7 +35,7 @@ class CelebA(datasets.CelebA):
 class DataSource(base.DataSource):
     """The CelebA dataset."""
 
-    def __init__(self):
+    def __init__(self, **kwargs):
         super().__init__()
         _path = Config().params['data_path']
 

--- a/plato/datasources/cifar10.py
+++ b/plato/datasources/cifar10.py
@@ -13,28 +13,46 @@ class DataSource(base.DataSource):
 
     def __init__(self, **kwargs):
         super().__init__()
-        _path = Config().params['data_path']
+        _path = Config().params["data_path"]
 
-        train_transform = transforms.Compose([
-            transforms.RandomHorizontalFlip(),
-            transforms.RandomCrop(32, 4),
-            transforms.ToTensor(),
-            transforms.Normalize([0.485, 0.456, 0.406], [0.229, 0.224, 0.225])
-        ])
+        train_transform = (
+            kwargs["train_transform"]
+            if "train_transform" in kwargs
+            else (
+                transforms.Compose(
+                    [
+                        transforms.RandomHorizontalFlip(),
+                        transforms.RandomCrop(32, 4),
+                        transforms.ToTensor(),
+                        transforms.Normalize(
+                            [0.485, 0.456, 0.406], [0.229, 0.224, 0.225]
+                        ),
+                    ]
+                )
+            )
+        )
 
-        test_transform = transforms.Compose([
-            transforms.ToTensor(),
-            transforms.Normalize([0.485, 0.456, 0.406], [0.229, 0.224, 0.225])
-        ])
+        test_transform = (
+            kwargs["test_transform"]
+            if "test_transform" in kwargs
+            else (
+                transforms.Compose(
+                    [
+                        transforms.ToTensor(),
+                        transforms.Normalize(
+                            [0.485, 0.456, 0.406], [0.229, 0.224, 0.225]
+                        ),
+                    ]
+                )
+            )
+        )
 
-        self.trainset = datasets.CIFAR10(root=_path,
-                                         train=True,
-                                         download=True,
-                                         transform=train_transform)
-        self.testset = datasets.CIFAR10(root=_path,
-                                        train=False,
-                                        download=True,
-                                        transform=test_transform)
+        self.trainset = datasets.CIFAR10(
+            root=_path, train=True, download=True, transform=train_transform
+        )
+        self.testset = datasets.CIFAR10(
+            root=_path, train=False, download=True, transform=test_transform
+        )
 
     def num_train_examples(self):
         return 50000

--- a/plato/datasources/cifar10.py
+++ b/plato/datasources/cifar10.py
@@ -11,7 +11,7 @@ from plato.datasources import base
 class DataSource(base.DataSource):
     """The CIFAR-10 dataset."""
 
-    def __init__(self):
+    def __init__(self, **kwargs):
         super().__init__()
         _path = Config().params['data_path']
 

--- a/plato/datasources/cifar100.py
+++ b/plato/datasources/cifar100.py
@@ -11,30 +11,32 @@ from plato.datasources import base
 class DataSource(base.DataSource):
     """The CIFAR-100 dataset."""
 
-    def __init__(self):
+    def __init__(self, **kwargs):
         super().__init__()
-        _path = Config().params['data_path']
+        _path = Config().params["data_path"]
 
-        train_transform = transforms.Compose([
-            transforms.RandomHorizontalFlip(),
-            transforms.RandomCrop(32, 4),
-            transforms.ToTensor(),
-            transforms.Normalize([0.485, 0.456, 0.406], [0.229, 0.224, 0.225])
-        ])
+        train_transform = transforms.Compose(
+            [
+                transforms.RandomHorizontalFlip(),
+                transforms.RandomCrop(32, 4),
+                transforms.ToTensor(),
+                transforms.Normalize([0.485, 0.456, 0.406], [0.229, 0.224, 0.225]),
+            ]
+        )
 
-        test_transform = transforms.Compose([
-            transforms.ToTensor(),
-            transforms.Normalize([0.485, 0.456, 0.406], [0.229, 0.224, 0.225])
-        ])
+        test_transform = transforms.Compose(
+            [
+                transforms.ToTensor(),
+                transforms.Normalize([0.485, 0.456, 0.406], [0.229, 0.224, 0.225]),
+            ]
+        )
 
-        self.trainset = datasets.CIFAR100(root=_path,
-                                         train=True,
-                                         download=True,
-                                         transform=train_transform)
-        self.testset = datasets.CIFAR100(root=_path,
-                                        train=False,
-                                        download=True,
-                                        transform=test_transform)
+        self.trainset = datasets.CIFAR100(
+            root=_path, train=True, download=True, transform=train_transform
+        )
+        self.testset = datasets.CIFAR100(
+            root=_path, train=False, download=True, transform=test_transform
+        )
 
     def num_train_examples(self):
         return 50000

--- a/plato/datasources/cifar100.py
+++ b/plato/datasources/cifar100.py
@@ -15,20 +15,36 @@ class DataSource(base.DataSource):
         super().__init__()
         _path = Config().params["data_path"]
 
-        train_transform = transforms.Compose(
-            [
-                transforms.RandomHorizontalFlip(),
-                transforms.RandomCrop(32, 4),
-                transforms.ToTensor(),
-                transforms.Normalize([0.485, 0.456, 0.406], [0.229, 0.224, 0.225]),
-            ]
+        train_transform = (
+            kwargs["train_transform"]
+            if "train_transform" in kwargs
+            else (
+                transforms.Compose(
+                    [
+                        transforms.RandomHorizontalFlip(),
+                        transforms.RandomCrop(32, 4),
+                        transforms.ToTensor(),
+                        transforms.Normalize(
+                            [0.485, 0.456, 0.406], [0.229, 0.224, 0.225]
+                        ),
+                    ]
+                )
+            )
         )
 
-        test_transform = transforms.Compose(
-            [
-                transforms.ToTensor(),
-                transforms.Normalize([0.485, 0.456, 0.406], [0.229, 0.224, 0.225]),
-            ]
+        test_transform = (
+            kwargs["test_transform"]
+            if "test_transform" in kwargs
+            else (
+                transforms.Compose(
+                    [
+                        transforms.ToTensor(),
+                        transforms.Normalize(
+                            [0.485, 0.456, 0.406], [0.229, 0.224, 0.225]
+                        ),
+                    ]
+                )
+            )
         )
 
         self.trainset = datasets.CIFAR100(

--- a/plato/datasources/cinic10.py
+++ b/plato/datasources/cinic10.py
@@ -31,20 +31,28 @@ class DataSource(base.DataSource):
             )
             DataSource.download(url, _path)
 
-        _transform = transforms.Compose(
-            [
-                transforms.ToTensor(),
-                transforms.Normalize(
-                    [0.47889522, 0.47227842, 0.43047404],
-                    [0.24205776, 0.23828046, 0.25874835],
-                ),
-            ]
+        train_transform = (
+            kwargs["train_transform"]
+            if "train_transform" in kwargs
+            else (
+                transforms.Compose(
+                    [
+                        transforms.ToTensor(),
+                        transforms.Normalize(
+                            [0.47889522, 0.47227842, 0.43047404],
+                            [0.24205776, 0.23828046, 0.25874835],
+                        ),
+                    ]
+                )
+            )
         )
+        test_transform = train_transform
+
         self.trainset = datasets.ImageFolder(
-            root=os.path.join(_path, "train"), transform=_transform
+            root=os.path.join(_path, "train"), transform=train_transform
         )
         self.testset = datasets.ImageFolder(
-            root=os.path.join(_path, "test"), transform=_transform
+            root=os.path.join(_path, "test"), transform=test_transform
         )
 
     def num_train_examples(self):

--- a/plato/datasources/cinic10.py
+++ b/plato/datasources/cinic10.py
@@ -18,27 +18,34 @@ from plato.datasources import base
 class DataSource(base.DataSource):
     """The CINIC-10 dataset."""
 
-    def __init__(self):
+    def __init__(self, **kwargs):
         super().__init__()
-        _path = Config().params['data_path']
+        _path = Config().params["data_path"]
 
         if not os.path.exists(_path):
-            logging.info(
-                "Downloading the CINIC-10 dataset. This may take a while.")
-            url = Config().data.download_url if hasattr(
-                Config().data, 'download_url'
-            ) else 'http://iqua.ece.toronto.edu/baochun/CINIC-10.tar.gz'
+            logging.info("Downloading the CINIC-10 dataset. This may take a while.")
+            url = (
+                Config().data.download_url
+                if hasattr(Config().data, "download_url")
+                else "http://iqua.ece.toronto.edu/baochun/CINIC-10.tar.gz"
+            )
             DataSource.download(url, _path)
 
-        _transform = transforms.Compose([
-            transforms.ToTensor(),
-            transforms.Normalize([0.47889522, 0.47227842, 0.43047404],
-                                 [0.24205776, 0.23828046, 0.25874835])
-        ])
-        self.trainset = datasets.ImageFolder(root=os.path.join(_path, 'train'),
-                                             transform=_transform)
-        self.testset = datasets.ImageFolder(root=os.path.join(_path, 'test'),
-                                            transform=_transform)
+        _transform = transforms.Compose(
+            [
+                transforms.ToTensor(),
+                transforms.Normalize(
+                    [0.47889522, 0.47227842, 0.43047404],
+                    [0.24205776, 0.23828046, 0.25874835],
+                ),
+            ]
+        )
+        self.trainset = datasets.ImageFolder(
+            root=os.path.join(_path, "train"), transform=_transform
+        )
+        self.testset = datasets.ImageFolder(
+            root=os.path.join(_path, "test"), transform=_transform
+        )
 
     def num_train_examples(self):
         return 90000

--- a/plato/datasources/coco.py
+++ b/plato/datasources/coco.py
@@ -1,6 +1,6 @@
 """
-The MS COCO- dataset stands for Common Objects in Context, and is 
-  designed to represent a vast array of objects that we 
+The MS COCO- dataset stands for Common Objects in Context, and is
+  designed to represent a vast array of objects that we
   regularly encounter in everyday life.
 
 We mainly utilize COCO-17 (25.20 GB):
@@ -56,7 +56,7 @@ from plato.datasources import multimodal_base
 class DataSource(multimodal_base.MultiModalDataSource):
     """ The COCO dataset."""
 
-    def __init__(self):
+    def __init__(self, **kwargs):
         super().__init__()
 
         self.data_name = Config().data.dataname

--- a/plato/datasources/emnist.py
+++ b/plato/datasources/emnist.py
@@ -14,19 +14,31 @@ class DataSource(base.DataSource):
         super().__init__()
         _path = Config().params["data_path"]
 
-        train_transform = transforms.Compose(
-            [
-                transforms.RandomHorizontalFlip(),
-                transforms.RandomAffine(
-                    degrees=10, translate=(0.2, 0.2), scale=(0.8, 1.2)
-                ),
-                transforms.ToTensor(),
-                transforms.Normalize(mean=[0.5], std=[0.5]),
-            ]
+        train_transform = (
+            kwargs["train_transform"]
+            if "train_transform" in kwargs
+            else (
+                transforms.Compose(
+                    [
+                        transforms.RandomHorizontalFlip(),
+                        transforms.RandomAffine(
+                            degrees=10, translate=(0.2, 0.2), scale=(0.8, 1.2)
+                        ),
+                        transforms.ToTensor(),
+                        transforms.Normalize(mean=[0.5], std=[0.5]),
+                    ]
+                )
+            )
         )
 
-        test_transform = transforms.Compose(
-            [transforms.ToTensor(), transforms.Normalize(mean=[0.5], std=[0.5])]
+        test_transform = (
+            kwargs["test_transform"]
+            if "test_transform" in kwargs
+            else (
+                transforms.Compose(
+                    [transforms.ToTensor(), transforms.Normalize(mean=[0.5], std=[0.5])]
+                )
+            )
         )
 
         self.trainset = datasets.EMNIST(

--- a/plato/datasources/emnist.py
+++ b/plato/datasources/emnist.py
@@ -8,36 +8,41 @@ from plato.datasources import base
 
 
 class DataSource(base.DataSource):
-    """ The EMNIST dataset. """
+    """The EMNIST dataset."""
 
-    def __init__(self):
+    def __init__(self, **kwargs):
         super().__init__()
-        _path = Config().params['data_path']
+        _path = Config().params["data_path"]
 
-        train_transform = transforms.Compose([
-            transforms.RandomHorizontalFlip(),
-            transforms.RandomAffine(degrees=10,
-                                    translate=(0.2, 0.2),
-                                    scale=(0.8, 1.2)),
-            transforms.ToTensor(),
-            transforms.Normalize(mean=[0.5], std=[0.5])
-        ])
+        train_transform = transforms.Compose(
+            [
+                transforms.RandomHorizontalFlip(),
+                transforms.RandomAffine(
+                    degrees=10, translate=(0.2, 0.2), scale=(0.8, 1.2)
+                ),
+                transforms.ToTensor(),
+                transforms.Normalize(mean=[0.5], std=[0.5]),
+            ]
+        )
 
-        test_transform = transforms.Compose([
-            transforms.ToTensor(),
-            transforms.Normalize(mean=[0.5], std=[0.5])
-        ])
+        test_transform = transforms.Compose(
+            [transforms.ToTensor(), transforms.Normalize(mean=[0.5], std=[0.5])]
+        )
 
-        self.trainset = datasets.EMNIST(root=_path,
-                                        split='balanced',
-                                        train=True,
-                                        download=True,
-                                        transform=train_transform)
-        self.testset = datasets.EMNIST(root=_path,
-                                       split='balanced',
-                                       train=False,
-                                       download=True,
-                                       transform=test_transform)
+        self.trainset = datasets.EMNIST(
+            root=_path,
+            split="balanced",
+            train=True,
+            download=True,
+            transform=train_transform,
+        )
+        self.testset = datasets.EMNIST(
+            root=_path,
+            split="balanced",
+            train=False,
+            download=True,
+            transform=test_transform,
+        )
 
     def num_train_examples(self):
         return 112800

--- a/plato/datasources/fashion_mnist.py
+++ b/plato/datasources/fashion_mnist.py
@@ -15,15 +15,23 @@ class DataSource(base.DataSource):
         super().__init__()
         _path = Config().params["data_path"]
 
-        _transform = transforms.Compose(
-            [transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))]
+        train_transform = (
+            kwargs["train_transform"]
+            if "train_transform" in kwargs
+            else (
+                transforms.Compose(
+                    [transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))]
+                )
+            )
         )
+        test_transform = train_transform
+
         self.trainset = datasets.FashionMNIST(
-            root=_path, train=True, download=True, transform=_transform
+            root=_path, train=True, download=True, transform=train_transform
         )
 
         self.testset = datasets.FashionMNIST(
-            root=_path, train=False, download=True, transform=_transform
+            root=_path, train=False, download=True, transform=test_transform
         )
 
     def num_train_examples(self):

--- a/plato/datasources/fashion_mnist.py
+++ b/plato/datasources/fashion_mnist.py
@@ -9,25 +9,22 @@ from plato.datasources import base
 
 
 class DataSource(base.DataSource):
-    """ The FashionMNIST dataset. """
+    """The FashionMNIST dataset."""
 
-    def __init__(self):
+    def __init__(self, **kwargs):
         super().__init__()
-        _path = Config().params['data_path']
+        _path = Config().params["data_path"]
 
-        _transform = transforms.Compose([
-            transforms.ToTensor(),
-            transforms.Normalize((0.1307, ), (0.3081, ))
-        ])
-        self.trainset = datasets.FashionMNIST(root=_path,
-                                              train=True,
-                                              download=True,
-                                              transform=_transform)
+        _transform = transforms.Compose(
+            [transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))]
+        )
+        self.trainset = datasets.FashionMNIST(
+            root=_path, train=True, download=True, transform=_transform
+        )
 
-        self.testset = datasets.FashionMNIST(root=_path,
-                                             train=False,
-                                             download=True,
-                                             transform=_transform)
+        self.testset = datasets.FashionMNIST(
+            root=_path, train=False, download=True, transform=_transform
+        )
 
     def num_train_examples(self):
         return 60000

--- a/plato/datasources/feature.py
+++ b/plato/datasources/feature.py
@@ -7,8 +7,9 @@ from plato.datasources import base
 
 
 class DataSource(base.DataSource):
-    """ The feature dataset. """
-    def __init__(self, features):
+    """The feature dataset."""
+
+    def __init__(self, features, **kwargs):
         super().__init__()
 
         # Faster way to deep flatten a list of lists compared to list comprehension

--- a/plato/datasources/femnist.py
+++ b/plato/datasources/femnist.py
@@ -64,7 +64,7 @@ class ReshapeListTransform:
 class DataSource(base.DataSource):
     """The FEMNIST dataset."""
 
-    def __init__(self, client_id=0):
+    def __init__(self, client_id=0, **kwargs):
         super().__init__()
         self.trainset = None
         self.testset = None

--- a/plato/datasources/femnist.py
+++ b/plato/datasources/femnist.py
@@ -30,17 +30,17 @@ from plato.datasources import base
 
 
 class CustomDictDataset(Dataset):
-    """ Custom dataset from a dictionary with support of transforms. """
+    """Custom dataset from a dictionary with support of transforms."""
 
     def __init__(self, loaded_data, transform=None):
-        """ Initializing the custom dataset. """
+        """Initializing the custom dataset."""
         super().__init__()
         self.loaded_data = loaded_data
         self.transform = transform
 
     def __getitem__(self, index):
-        sample = self.loaded_data['x'][index]
-        target = self.loaded_data['y'][index]
+        sample = self.loaded_data["x"][index]
+        target = self.loaded_data["y"][index]
 
         if self.transform:
             sample = self.transform(sample)
@@ -48,11 +48,11 @@ class CustomDictDataset(Dataset):
         return sample, target
 
     def __len__(self):
-        return len(self.loaded_data['y'])
+        return len(self.loaded_data["y"])
 
 
 class ReshapeListTransform:
-    """ The transform that reshapes an image. """
+    """The transform that reshapes an image."""
 
     def __init__(self, new_shape):
         self.new_shape = new_shape
@@ -69,17 +69,24 @@ class DataSource(base.DataSource):
         self.trainset = None
         self.testset = None
 
-        root_path = os.path.join(Config().params['data_path'], 'FEMNIST',
-                                 'packaged_data')
+        root_path = os.path.join(
+            Config().params["data_path"], "FEMNIST", "packaged_data"
+        )
         if client_id == 0:
             # If we are on the federated learning server
-            data_dir = os.path.join(root_path, 'test')
-            data_url = "http://iqua.ece.toronto.edu/baochun/FEMNIST/test/" \
-                       + str(client_id) + ".zip"
+            data_dir = os.path.join(root_path, "test")
+            data_url = (
+                "http://iqua.ece.toronto.edu/baochun/FEMNIST/test/"
+                + str(client_id)
+                + ".zip"
+            )
         else:
-            data_dir = os.path.join(root_path, 'train')
-            data_url = "http://iqua.ece.toronto.edu/baochun/FEMNIST/train/" \
-                       + str(client_id) + ".zip"
+            data_dir = os.path.join(root_path, "train")
+            data_url = (
+                "http://iqua.ece.toronto.edu/baochun/FEMNIST/train/"
+                + str(client_id)
+                + ".zip"
+            )
 
         if not os.path.exists(os.path.join(data_dir, str(client_id))):
             logging.info(
@@ -89,24 +96,32 @@ class DataSource(base.DataSource):
             self.download(url=data_url, data_path=data_dir)
 
         loaded_data = DataSource.read_data(
-            file_path=os.path.join(data_dir, str(client_id), 'data.json'))
+            file_path=os.path.join(data_dir, str(client_id), "data.json")
+        )
 
-        _transform = transforms.Compose([
-            ReshapeListTransform((28, 28, 1)),
-            transforms.ToPILImage(),
-            transforms.RandomCrop(28,
-                                  padding=2,
-                                  padding_mode="constant",
-                                  fill=1.0),
-            transforms.RandomResizedCrop(28,
-                                         scale=(0.8, 1.2),
-                                         ratio=(4. / 5., 5. / 4.)),
-            transforms.RandomRotation(5, fill=1.0),
-            transforms.ToTensor(),
-            transforms.Normalize(0.9637, 0.1597),
-        ])
-        dataset = CustomDictDataset(loaded_data=loaded_data,
-                                    transform=_transform)
+        train_transform = (
+            kwargs["train_transform"]
+            if train_transform in kwargs
+            else (
+                transforms.Compose(
+                    [
+                        ReshapeListTransform((28, 28, 1)),
+                        transforms.ToPILImage(),
+                        transforms.RandomCrop(
+                            28, padding=2, padding_mode="constant", fill=1.0
+                        ),
+                        transforms.RandomResizedCrop(
+                            28, scale=(0.8, 1.2), ratio=(4.0 / 5.0, 5.0 / 4.0)
+                        ),
+                        transforms.RandomRotation(5, fill=1.0),
+                        transforms.ToTensor(),
+                        transforms.Normalize(0.9637, 0.1597),
+                    ]
+                )
+            )
+        )
+
+        dataset = CustomDictDataset(loaded_data=loaded_data, transform=train_transform)
 
         if client_id == 0:  # testing dataset on the server
             self.testset = dataset
@@ -115,8 +130,8 @@ class DataSource(base.DataSource):
 
     @staticmethod
     def read_data(file_path):
-        """ Reading the dataset specific to a client_id. """
-        with open(file_path, 'r', encoding='utf-8') as fin:
+        """Reading the dataset specific to a client_id."""
+        with open(file_path, "r", encoding="utf-8") as fin:
             loaded_data = json.load(fin)
         return loaded_data
 

--- a/plato/datasources/flickr30k_entities.py
+++ b/plato/datasources/flickr30k_entities.py
@@ -209,7 +209,7 @@ class Flickr30KEDataset(multimodal_base.MultiModalDataset):
 class DataSource(multimodal_base.MultiModalDataSource):
     """The Flickr30K Entities dataset."""
 
-    def __init__(self):
+    def __init__(self, **kwargs):
         super().__init__()
 
         self.data_name = Config().data.dataname

--- a/plato/datasources/gym.py
+++ b/plato/datasources/gym.py
@@ -104,7 +104,7 @@ class GymDataset(multimodal_base.MultiModalDataset):
 class DataSource(multimodal_base.MultiModalDataSource):
     """The Gym dataset."""
 
-    def __init__(self):
+    def __init__(self, **kwargs):
         super().__init__()
 
         self.data_name = Config().data.datasource

--- a/plato/datasources/huggingface.py
+++ b/plato/datasources/huggingface.py
@@ -20,7 +20,7 @@ from plato.datasources import base
 class DataSource(base.DataSource):
     """A data source for the HuggingFace datasets."""
 
-    def __init__(self):
+    def __init__(self, **kwargs):
         super().__init__()
 
         dataset_name = Config().data.dataset_name

--- a/plato/datasources/kinetics.py
+++ b/plato/datasources/kinetics.py
@@ -139,7 +139,7 @@ class KineticsDataset(multimodal_base.MultiModalDataset):
 class DataSource(multimodal_base.MultiModalDataSource):
     """The Kinetics datasource."""
 
-    def __init__(self):
+    def __init__(self, **kwargs):
         super().__init__()
 
         self.data_name = Config().data.datasource

--- a/plato/datasources/mnist.py
+++ b/plato/datasources/mnist.py
@@ -10,7 +10,7 @@ from plato.datasources import base
 class DataSource(base.DataSource):
     """ The MNIST dataset. """
 
-    def __init__(self):
+    def __init__(self, **kwargs):
         super().__init__()
         _path = Config().params['data_path']
 

--- a/plato/datasources/pascal_voc.py
+++ b/plato/datasources/pascal_voc.py
@@ -11,7 +11,7 @@ from plato.datasources import base
 class DataSource(base.DataSource):
     """The PASCAL dataset."""
 
-    def __init__(self):
+    def __init__(self, **kwargs):
         super().__init__()
         _path = Config().params['data_path']
         self.mean = [0.45734706, 0.43338275, 0.40058118]

--- a/plato/datasources/pascal_voc.py
+++ b/plato/datasources/pascal_voc.py
@@ -13,25 +13,41 @@ class DataSource(base.DataSource):
 
     def __init__(self, **kwargs):
         super().__init__()
-        _path = Config().params['data_path']
+        _path = Config().params["data_path"]
         self.mean = [0.45734706, 0.43338275, 0.40058118]
         self.std = [0.23965294, 0.23532275, 0.2398498]
-        _transform = transforms.Compose([
-            transforms.Resize((96, 96)),
-            transforms.ToTensor(),
-        ])
-        self.trainset = datasets.VOCSegmentation(root=_path,
-                                                 year='2012',
-                                                 image_set='train',
-                                                 download=True,
-                                                 transform=_transform,
-                                                 target_transform=_transform)
-        self.testset = datasets.VOCSegmentation(root=_path,
-                                                year='2012',
-                                                image_set='val',
-                                                download=True,
-                                                transform=_transform,
-                                                target_transform=_transform)
+
+        train_transform = (
+            kwargs["train_transform"]
+            if train_transform in kwargs
+            else (
+                transforms.Compose(
+                    [
+                        transforms.Resize((96, 96)),
+                        transforms.ToTensor(),
+                    ]
+                )
+            )
+        )
+
+        test_transform = train_transform
+
+        self.trainset = datasets.VOCSegmentation(
+            root=_path,
+            year="2012",
+            image_set="train",
+            download=True,
+            transform=train_transform,
+            target_transform=train_transform,
+        )
+        self.testset = datasets.VOCSegmentation(
+            root=_path,
+            year="2012",
+            image_set="val",
+            download=True,
+            transform=test_transform,
+            target_transform=test_transform,
+        )
 
     def num_train_examples(self):
         return len(self.trainset)

--- a/plato/datasources/purchase.py
+++ b/plato/datasources/purchase.py
@@ -15,7 +15,7 @@ from plato.datasources import base
 class DataSource(base.DataSource):
     """The Purchase100 dataset."""
 
-    def __init__(self):
+    def __init__(self, **kwargs):
         super().__init__()
         root_path = Config().params["data_path"]
         dataset_path = os.path.join(root_path, "dataset_purchase")

--- a/plato/datasources/qoenflx.py
+++ b/plato/datasources/qoenflx.py
@@ -50,7 +50,7 @@ class QoENFLXDataset(torch.utils.data.Dataset):
 class DataSource(base.DataSource):
     """A data source for QoENFLX datasets."""
 
-    def __init__(self):
+    def __init__(self, **kwargs):
         super().__init__()
 
         logging.info("Dataset: QoENFLX")

--- a/plato/datasources/referitgame.py
+++ b/plato/datasources/referitgame.py
@@ -150,7 +150,7 @@ class ReferItGameDataset(multimodal_base.MultiModalDataset):
 class DataSource(multimodal_base.MultiModalDataSource):
     """The ReferItGame dataset."""
 
-    def __init__(self):
+    def __init__(self, **kwargs):
         super().__init__()
 
         self.split_configs = ["refcoco", "refcoco+", "refcocog"]

--- a/plato/datasources/registry.py
+++ b/plato/datasources/registry.py
@@ -63,7 +63,7 @@ else:
     registered_partitioned_datasources = {"FEMNIST": femnist}
 
 
-def get(client_id=0):
+def get(client_id: int = 0, **kwargs):
     """Get the data source with the provided name."""
     datasource_name = Config().data.datasource
 
@@ -71,37 +71,37 @@ def get(client_id=0):
     if datasource_name == "kinetics700":
         from plato.datasources import kinetics
 
-        return kinetics.DataSource()
+        return kinetics.DataSource(**kwargs)
 
     if datasource_name == "Gym":
         from plato.datasources import gym
 
-        return gym.DataSource()
+        return gym.DataSource(**kwargs)
 
     if datasource_name == "Flickr30KE":
         from plato.datasources import flickr30k_entities
 
-        return flickr30k_entities.DataSource()
+        return flickr30k_entities.DataSource(**kwargs)
 
     if datasource_name == "ReferItGame":
         from plato.datasources import referitgame
 
-        return referitgame.DataSource()
+        return referitgame.DataSource(**kwargs)
 
     if datasource_name == "COCO":
         from plato.datasources import coco
 
-        return coco.DataSource()
+        return coco.DataSource(**kwargs)
 
     if datasource_name == "YOLO":
         from plato.datasources import yolo
 
-        return yolo.DataSource()
+        return yolo.DataSource(**kwargs)
     elif datasource_name in registered_datasources:
-        dataset = registered_datasources[datasource_name].DataSource()
+        dataset = registered_datasources[datasource_name].DataSource(**kwargs)
     elif datasource_name in registered_partitioned_datasources:
         dataset = registered_partitioned_datasources[datasource_name].DataSource(
-            client_id
+            client_id, **kwargs
         )
     else:
         raise ValueError(f"No such data source: {datasource_name}")

--- a/plato/datasources/tiny_imagenet.py
+++ b/plato/datasources/tiny_imagenet.py
@@ -18,7 +18,7 @@ from plato.datasources import base
 class DataSource(base.DataSource):
     """The Tiny ImageNet 200 dataset."""
 
-    def __init__(self):
+    def __init__(self, **kwargs):
         super().__init__()
         _path = Config().params['data_path']
 

--- a/plato/datasources/tiny_imagenet.py
+++ b/plato/datasources/tiny_imagenet.py
@@ -20,27 +20,42 @@ class DataSource(base.DataSource):
 
     def __init__(self, **kwargs):
         super().__init__()
-        _path = Config().params['data_path']
+        _path = Config().params["data_path"]
 
         if not os.path.exists(_path):
             logging.info(
                 "Downloading the Tiny ImageNet 200 dataset. This may take a while."
             )
-            url = Config().data.download_url if hasattr(
-                Config().data, 'download_url'
-            ) else 'http://cs231n.stanford.edu/tiny-imagenet-200.zip'
+            url = (
+                Config().data.download_url
+                if hasattr(Config().data, "download_url")
+                else "http://cs231n.stanford.edu/tiny-imagenet-200.zip"
+            )
             DataSource.download(url, _path)
 
-        _transform = transforms.Compose([
-            transforms.RandomResizedCrop(299),
-            transforms.CenterCrop(299),
-            transforms.ToTensor(),
-            transforms.Normalize([0.485, 0.456, 0.406], [0.229, 0.224, 0.225])
-        ])
-        self.trainset = datasets.ImageFolder(root=os.path.join(_path, 'train'),
-                                             transform=_transform)
-        self.testset = datasets.ImageFolder(root=os.path.join(_path, 'test'),
-                                            transform=_transform)
+        train_transform = (
+            kwargs["train_transform"]
+            if "train_transform" in kwargs
+            else (
+                transforms.Compose(
+                    [
+                        transforms.RandomResizedCrop(299),
+                        transforms.CenterCrop(299),
+                        transforms.ToTensor(),
+                        transforms.Normalize(
+                            [0.485, 0.456, 0.406], [0.229, 0.224, 0.225]
+                        ),
+                    ]
+                )
+            )
+        )
+        test_transform = train_transform
+        self.trainset = datasets.ImageFolder(
+            root=os.path.join(_path, "train"), transform=train_transform
+        )
+        self.testset = datasets.ImageFolder(
+            root=os.path.join(_path, "test"), transform=test_transform
+        )
 
     def num_train_examples(self):
         return 100000

--- a/plato/datasources/yolo.py
+++ b/plato/datasources/yolo.py
@@ -44,7 +44,7 @@ class YOLODataset(torch.utils.data.Dataset):
 class DataSource(base.DataSource):
     """The YOLO dataset."""
 
-    def __init__(self):
+    def __init__(self, **kwargs):
         super().__init__()
         _path = Config().params["data_path"]
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This PR added the `**kwargs` to all listed datasets of datasource and `get()` of the registry. By doing so, users can apply their custom functions to data sources.

## Description
<!--- Describe your changes in detail -->
<!--- Describe motivation and context -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The basic motivation is adding the specific transform when defining one dataset for subsequent learning. For example, there are three needed transforms, A, B, and C, for the CIFAR10 dataset. The 'get()' can be called three times to define the same CIFAR10 with three different transforms. 

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

No test is required as this change does not influence the existing Plato's examples.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) Fixes #
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been formatted using Black and checked using PyLint.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
