### PR TITLE
Added a new fedavg algorithm supporting aggregating partial sub-modules of one model

### DIFF
--- a/plato/algorithms/fedavg_partial.py
+++ b/plato/algorithms/fedavg_partial.py
@@ -1,0 +1,153 @@
+"""
+The enhanced federated averaging algorithm to aggregate partial sub-modules of one whole model.
+
+Utilization condition:
+    In some scenarios, even given one defined model, the users want to utilize the partial
+    sub-modules as the global model in federated learning. Thus, solely these desired
+    sub-modules will be extracted and aggregated during the learning process.
+    Then, noticing that the names of parameters in one sub-module hold consistent names,
+    we propose this piece of code to support the aforementioned feature by setting the
+    hyper-parameter 'global_submodules_name' in the config file.
+
+The format of this hyper-parameter should be:
+{submodule1_prefix}__{submodule2_prefix}__{submodule3_prefix}__...
+
+names for different submodules are separated by two consecutive underscores.
+
+
+For example
+ A. Given the defined whole model: encoder + head, the hyper-parameter in the config
+    file 'global_submodules_name' under the 'trainer' can be set to:
+    - whole     : utilizing the whole model as the global model
+    - encoder   : utilizing the encoder as the global model
+    - head      : utilizing the head as the global model
+
+    Demo:
+
+        trainer:
+            global_submodules_name: encoder
+
+
+ B. Given the defined whole model: encoder1 + encoder2 + encoder3 + head1 + head2,
+    the hyper-parameter in the config file 'global_submodules_name' under the 'trainer'
+    can be set to
+    - whole                 : utilizing the whole model as the global model
+    - encoder1__encoder2    : utilizing solely encoder1 and encoder2 as the global model
+    - encoder2__head1       : utilizing solely encoder2 and head as the global model
+    - encoder2__head1__head2: utilizing solely encoder2, head1 and head2 as the global model
+
+    Demo:
+
+        trainer:
+            global_submodules_name: encoder1__encoder2
+
+"""
+
+import logging
+from typing import List, Optional
+from collections import OrderedDict
+
+import torch
+
+from plato.algorithms import fedavg
+from plato.config import Config
+from plato.trainers.base import Trainer
+
+
+class Algorithm(fedavg.Algorithm):
+    """Federated averaging algorithm for the partial aggregation, used by both the client and the server."""
+
+    def __init__(self, trainer: Trainer):
+        super().__init__(trainer=trainer)
+
+        # in this algorithm, the sub-module's name that is used as the global model
+        # shared among clients should be set.
+        # by default, the whole model will be used as the global model
+        # i.e., whole_model_name = "whole"
+        self.whole_model_name = "whole"
+
+        # the separator used to combine different names into one
+        # string.
+        # by default, two consecutive underscores are utilized.
+        self.separator = "__"
+
+    def extract_weights(
+        self,
+        model: Optional[torch.nn.Module] = None,
+        submodules_name: Optional[List[str]] = None,
+    ):
+        """Extract weights from submodules of the model.
+        By default, weights of the whole model will be extracted."""
+
+        submodules_name = (
+            submodules_name
+            if submodules_name is not None
+            else (
+                Config().trainer.global_submodules_name.split(self.separator)
+                if hasattr(Config().trainer, "global_submodules_name")
+                else self.whole_model_name.split(self.separator)
+            )
+        )
+
+        logging.info("Extracting parameters with names %s.", submodules_name)
+
+        model = self.model if model is None else model
+
+        if self.whole_model_name in submodules_name:
+            return model.cpu().state_dict()
+
+        full_weights = model.cpu().state_dict()
+        extracted_weights = OrderedDict(
+            [
+                (name, param)
+                for name, param in full_weights.items()
+                if any([name in param_name for param_name in submodules_name])
+            ]
+        )
+        return extracted_weights
+
+    def is_consistent_weights(self, weights):
+        """Whether the 'weights' holds the parameters' name the same as the self.model."""
+
+        model_params_name = self.model.state_dict().keys()
+        weights_params = weights.state_dict().keys()
+
+        search_func = lambda x, y: [x_i for x_i in x if x_i not in y]
+
+        inconsistent_params = []
+        if len(model_params_name) > len(weights_params):
+            inconsistent_params = search_func(model_params_name, weights_params)
+        else:
+            inconsistent_params = search_func(weights_params, model_params_name)
+
+        return len(inconsistent_params) == 0, inconsistent_params
+
+    def load_weights(
+        self,
+        weights: dict,
+        strict: bool = False,
+    ):
+        """Load the model weights passed in as a parameter."""
+        self.model.load_state_dict(weights, strict=strict)
+
+    @staticmethod
+    def extract_submodules_name(parameters_name):
+        """Extracting submodules name from given parameters' names."""
+
+        extracted_names = []
+
+        # the para name is presented as encoder.xxx.xxx
+        # that is combined by the key_word "."
+        # we aim to extract the encoder
+        split_str = "."
+        for para_name in parameters_name:
+            splitted_names = para_name.split(split_str)
+            core_name = splitted_names[0]
+            # add the obtained prefix to the list, if
+            #   - empty list
+            #   - a new prefix
+            # add to the empty list directly
+            if core_name not in extracted_names:
+                extracted_names.append(core_name)
+
+        return extracted_names

--- a/plato/algorithms/fedavg_partial.py
+++ b/plato/algorithms/fedavg_partial.py
@@ -101,24 +101,23 @@ class Algorithm(fedavg.Algorithm):
             [
                 (name, param)
                 for name, param in full_weights.items()
-                if any([name in param_name for param_name in submodules_name])
+                if any([param_name in name for param_name in submodules_name])
             ]
         )
         return extracted_weights
 
-    def is_consistent_weights(self, weights):
+    def is_consistent_weights(self, weights_param_name):
         """Whether the 'weights' holds the parameters' name the same as the self.model."""
 
         model_params_name = self.model.state_dict().keys()
-        weights_params = weights.state_dict().keys()
 
         search_func = lambda x, y: [x_i for x_i in x if x_i not in y]
 
         inconsistent_params = []
-        if len(model_params_name) > len(weights_params):
-            inconsistent_params = search_func(model_params_name, weights_params)
+        if len(model_params_name) > len(weights_param_name):
+            inconsistent_params = search_func(model_params_name, weights_param_name)
         else:
-            inconsistent_params = search_func(weights_params, model_params_name)
+            inconsistent_params = search_func(weights_param_name, model_params_name)
 
         return len(inconsistent_params) == 0, inconsistent_params
 

--- a/plato/algorithms/fedavg_partial.py
+++ b/plato/algorithms/fedavg_partial.py
@@ -1,5 +1,5 @@
 """
-The enhanced federated averaging algorithm to aggregate partial sub-modules of one whole model.
+The enhanced federated averaging algorithm to aggregate partial sub-modules of one model.
 
 Utilization condition:
     In some scenarios, even given one defined model, the users want to utilize the partial

--- a/plato/algorithms/registry.py
+++ b/plato/algorithms/registry.py
@@ -24,16 +24,13 @@ elif hasattr(Config().trainer, "use_tensorflow"):
 
     registered_algorithms = {"fedavg": fedavg_tensorflow.Algorithm}
 else:
-    from plato.algorithms import (
-        fedavg,
-        mistnet,
-        fedavg_gan,
-    )
+    from plato.algorithms import fedavg, mistnet, fedavg_gan, fedavg_partial
 
     registered_algorithms = {
         "fedavg": fedavg.Algorithm,
         "mistnet": mistnet.Algorithm,
         "fedavg_gan": fedavg_gan.Algorithm,
+        "fedavg_partial": fedavg_partial.Algorithm,
     }
 
 

--- a/tests/TestsConfig/fedavg_tests.yml
+++ b/tests/TestsConfig/fedavg_tests.yml
@@ -1,0 +1,60 @@
+clients:
+    # Type
+    type: simple
+
+    # The total number of clients
+    total_clients: 30
+
+    # The number of clients selected in each round
+    per_round: 30
+
+    # Should the clients compute test accuracy locally?
+    do_test: true
+
+server:
+    address: 127.0.0.1
+    port: 8000
+
+data:
+    # The training and testing dataset
+    datasource: MNIST
+
+    # Number of samples in each partition
+    partition_size: 2000
+
+    # IID or non-IID?
+    sampler: iid
+
+    # The random seed for sampling data
+    random_seed: 1
+
+trainer:
+    # The type of the trainer
+    type: basic
+
+    # The maximum number of training rounds
+    rounds: 5
+
+    # The maximum number of clients running concurrently
+    max_concurrency: 4
+
+    # The target accuracy
+    target_accuracy: 0.94
+
+    # Number of epoches for local training in each communication round
+    epochs: 5
+    batch_size: 32
+    optimizer: SGD
+
+    # The machine learning model
+    model_name: lenet5
+
+algorithm:
+    # Aggregation algorithm
+    type: fedavg
+
+parameters:
+    optimizer:
+        lr: 0.01
+        momentum: 0.9
+        weight_delay: 0.0

--- a/tests/TestsConfig/fedavg_tests.yml
+++ b/tests/TestsConfig/fedavg_tests.yml
@@ -48,10 +48,11 @@ trainer:
 
     # The machine learning model
     model_name: lenet5
+    global_submodules_name: head
 
 algorithm:
     # Aggregation algorithm
-    type: fedavg
+    type: fedavg_partial
 
 parameters:
     optimizer:

--- a/tests/fedavg_tests.py
+++ b/tests/fedavg_tests.py
@@ -3,11 +3,17 @@ import copy
 import unittest
 import numpy as np
 import torch
+import os
+
+
+os.environ["config_file"] = "tests/TestsConfig/fedavg_tests.yml"
+
 
 from plato.clients import simple
-from plato.algorithms import fedavg as fedavg_alg
+from plato.algorithms import registry as algorithms_registry
 from plato.servers import fedavg as fedavg_server
 from plato.trainers import basic
+from plato.config import Config
 
 
 class InnerProductModel(torch.nn.Module):
@@ -43,7 +49,7 @@ async def test_fedavg_aggregation(self):
     model = InnerProductModel
 
     trainer = basic.Trainer
-    algorithm = fedavg_alg.Algorithm
+    algorithm = algorithms_registry.registered_algorithms[Config().algorithm.type]
     server = fedavg_server.Server(model=model, algorithm=algorithm, trainer=trainer)
     server.init_trainer()
 
@@ -176,7 +182,7 @@ class FedAvgTest(unittest.TestCase):
         self.example = torch.ones(1, 10)
         self.label = torch.ones(1) * 40.0
         self.trainer = basic.Trainer(model=self.model)
-        self.algorithm = fedavg_alg.Algorithm(trainer=self.trainer)
+        self.algorithm = algorithms_registry.get(trainer=self.trainer)
         self.optimizer = torch.optim.SGD(self.trainer.model.parameters(), lr=0.01)
 
     def test_forward(self):

--- a/tests/fedavg_tests.py
+++ b/tests/fedavg_tests.py
@@ -3,6 +3,7 @@ import copy
 import unittest
 import numpy as np
 import torch
+from types import SimpleNamespace
 
 from plato.clients import simple
 from plato.algorithms import fedavg as fedavg_alg
@@ -11,7 +12,7 @@ from plato.trainers import basic
 
 
 class InnerProductModel(torch.nn.Module):
-    def __init__(self, n):
+    def __init__(self, n: int = 10):
         super().__init__()
         self.layer = torch.nn.Linear(n, 1, bias=False)
         self.layer.weight.data = torch.arange(n, dtype=torch.float32)
@@ -37,7 +38,7 @@ async def test_fedavg_aggregation(self):
 
     print("\nTesting federated averaging.")
     updates = []
-    model = copy.deepcopy(self.model)
+    model = InnerProductModel
 
     trainer = basic.Trainer
     algorithm = fedavg_alg.Algorithm
@@ -46,83 +47,160 @@ async def test_fedavg_aggregation(self):
 
     weights = copy.deepcopy(self.algorithm.extract_weights())
     print(f"Report 1 weights: {weights}")
-    updates.append((0, simple.Report(1, 100, 0, 0, 0), weights, 0))
+    updates.append(
+        SimpleNamespace(
+            client_id=1,
+            report=SimpleNamespace(
+                client_id=1,
+                num_samples=100,
+                accuracy=0,
+                training_time=0,
+                comm_time=0,
+                update_response=False,
+            ),
+            payload=weights,
+            staleness=0,
+        )
+    )
 
-    self.model.train()
+    self.trainer.model.train()
 
     self.optimizer.zero_grad()
-    self.model.loss_criterion(self.model(self.example), self.label).backward()
+    self.trainer.model.loss_criterion(
+        self.trainer.model(self.example), self.label
+    ).backward()
     self.optimizer.step()
-    self.assertEqual(44.0, self.model(self.example).item())
+    self.assertEqual(44.0, self.trainer.model(self.example).item())
     weights = copy.deepcopy(self.algorithm.extract_weights())
     print(f"Report 2 weights: {weights}")
-    updates.append((0, simple.Report(1, 100, 0, 0, 0), weights, 0))
+    updates.append(
+        SimpleNamespace(
+            client_id=2,
+            report=SimpleNamespace(
+                client_id=2,
+                num_samples=100,
+                accuracy=0,
+                training_time=0,
+                comm_time=0,
+                update_response=False,
+            ),
+            payload=weights,
+            staleness=0,
+        )
+    )
 
     self.optimizer.zero_grad()
-    self.model.loss_criterion(self.model(self.example), self.label).backward()
+    self.trainer.model.loss_criterion(
+        self.trainer.model(self.example), self.label
+    ).backward()
     self.optimizer.step()
-    self.assertEqual(43.2, np.round(self.model(self.example).item(), 4))
+    self.assertEqual(43.2, np.round(self.trainer.model(self.example).item(), 4))
     weights = copy.deepcopy(self.algorithm.extract_weights())
     print(f"Report 3 Weights: {weights}")
-    updates.append((0, simple.Report(1, 100, 0, 0, 0), weights, 0))
+    updates.append(
+        SimpleNamespace(
+            client_id=3,
+            report=SimpleNamespace(
+                client_id=3,
+                num_samples=100,
+                accuracy=0,
+                training_time=0,
+                comm_time=0,
+                update_response=False,
+            ),
+            payload=weights,
+            staleness=0,
+        )
+    )
 
     self.optimizer.zero_grad()
-    self.model.loss_criterion(self.model(self.example), self.label).backward()
+    self.trainer.model.loss_criterion(
+        self.trainer.model(self.example), self.label
+    ).backward()
     self.optimizer.step()
-    self.assertEqual(42.56, np.round(self.model(self.example).item(), 4))
+    self.assertEqual(42.56, np.round(self.trainer.model(self.example).item(), 4))
     weights = copy.deepcopy(self.algorithm.extract_weights())
     print(f"Report 4 Weights: {weights}")
-    updates.append((0, simple.Report(1, 100, 0, 0, 0), weights, 0))
+    updates.append(
+        SimpleNamespace(
+            client_id=4,
+            report=SimpleNamespace(
+                client_id=4,
+                num_samples=100,
+                accuracy=0,
+                training_time=0,
+                comm_time=0,
+                update_response=False,
+            ),
+            payload=weights,
+            staleness=0,
+        )
+    )
 
-    print(f"Weights before federated averaging: {server.model.layer.weight.data}")
+    print(
+        f"Weights before federated averaging: {server.trainer.model.layer.weight.data}"
+    )
+    weights_received = [update.payload for update in updates]
+    baseline_weights = server.algorithm.extract_weights()
+    deltas_received = server.algorithm.compute_weight_deltas(
+        baseline_weights, weights_received
+    )
+    deltas = await server.aggregate_deltas(updates, deltas_received)
 
-    deltas = await server.aggregate_deltas(updates)
     updated_weights = server.algorithm.update_weights(deltas)
-    server.algorithm.load_weights(updated_weights)
 
-    print(f"Weights after federated averaging: {server.model.layer.weight.data}")
-    self.assertEqual(42.56, np.round(self.model(self.example).item(), 4))
+    server.algorithm.load_weights(updated_weights)
+    print(
+        f"Weights after federated averaging: {server.trainer.model.layer.weight.data}"
+    )
+    self.assertEqual(42.56, np.round(self.trainer.model(self.example).item(), 4))
 
 
 class FedAvgTest(unittest.TestCase):
     def setUp(self):
         super().setUp()
-        self.model = InnerProductModel(10)
+        self.model = InnerProductModel
         self.example = torch.ones(1, 10)
         self.label = torch.ones(1) * 40.0
         self.trainer = basic.Trainer(model=self.model)
         self.algorithm = fedavg_alg.Algorithm(trainer=self.trainer)
-        self.optimizer = torch.optim.SGD(self.model.parameters(), lr=0.01)
+        self.optimizer = torch.optim.SGD(self.trainer.model.parameters(), lr=0.01)
 
     def test_forward(self):
         self.assertIsNotNone(self.model)
         weights = self.algorithm.extract_weights()
         print("\nTesting forward pass.")
         print(f"Weights: {weights}")
-        self.assertEqual(45.0, self.model(self.example).item())
+        self.assertEqual(45.0, self.trainer.model(self.example).item())
 
     def test_backward(self):
         print("\nTesting backward pass.")
-        self.model.train()
+        self.trainer.model.train()
 
         self.optimizer.zero_grad()
-        self.model.loss_criterion(self.model(self.example), self.label).backward()
+        self.trainer.model.loss_criterion(
+            self.trainer.model(self.example), self.label
+        ).backward()
         self.optimizer.step()
-        self.assertEqual(44.0, self.model(self.example).item())
+        self.assertEqual(44.0, self.trainer.model(self.example).item())
         weights = self.algorithm.extract_weights()
         print(f"Weights: {weights}")
 
         self.optimizer.zero_grad()
-        self.model.loss_criterion(self.model(self.example), self.label).backward()
+        self.trainer.model.loss_criterion(
+            self.trainer.model(self.example), self.label
+        ).backward()
         self.optimizer.step()
-        self.assertEqual(43.2, np.round(self.model(self.example).item(), 4))
+        self.assertEqual(43.2, np.round(self.trainer.model(self.example).item(), 4))
         weights = self.algorithm.extract_weights()
         print(f"Weights: {weights}")
 
         self.optimizer.zero_grad()
-        self.model.loss_criterion(self.model(self.example), self.label).backward()
+        self.trainer.model.loss_criterion(
+            self.trainer.model(self.example), self.label
+        ).backward()
         self.optimizer.step()
-        self.assertEqual(42.56, np.round(self.model(self.example).item(), 4))
+        self.assertEqual(42.56, np.round(self.trainer.model(self.example).item(), 4))
         weights = self.algorithm.extract_weights()
         print(f"Weights: {weights}")
 

--- a/tests/fedavg_tests.py
+++ b/tests/fedavg_tests.py
@@ -32,12 +32,7 @@ class InnerProductModel(torch.nn.Module):
         return torch.nn.MSELoss()
 
     def forward(self, x):
-        print("x: ", x)
-        layer_x = self.layer(x)
-        print("layer_x: ", layer_x)
-        head_o = self.head(layer_x)
-        print("head_o: ", head_o)
-        return head_o
+        return self.layer(x)
 
 
 async def test_fedavg_aggregation(self):
@@ -77,7 +72,9 @@ async def test_fedavg_aggregation(self):
         self.trainer.model(self.example), self.label
     ).backward()
     self.optimizer.step()
-    self.assertNotEqual(44.0, self.trainer.model(self.example).item())
+    self.trainer.model.head.weight.data -= 0.1
+
+    self.assertEqual(44.0, self.trainer.model(self.example).item())
     weights = copy.deepcopy(self.algorithm.extract_weights())
     print(f"Report 2 weights: {weights}")
     updates.append(
@@ -101,7 +98,8 @@ async def test_fedavg_aggregation(self):
         self.trainer.model(self.example), self.label
     ).backward()
     self.optimizer.step()
-    self.assertNotEqual(43.2, np.round(self.trainer.model(self.example).item(), 4))
+    self.trainer.model.head.weight.data -= 0.1
+    self.assertEqual(43.2, np.round(self.trainer.model(self.example).item(), 4))
     weights = copy.deepcopy(self.algorithm.extract_weights())
     print(f"Report 3 Weights: {weights}")
     updates.append(
@@ -125,7 +123,9 @@ async def test_fedavg_aggregation(self):
         self.trainer.model(self.example), self.label
     ).backward()
     self.optimizer.step()
-    self.assertNotEqual(42.56, np.round(self.trainer.model(self.example).item(), 4))
+    self.trainer.model.head.weight.data -= 0.1
+
+    self.assertEqual(42.56, np.round(self.trainer.model(self.example).item(), 4))
     weights = copy.deepcopy(self.algorithm.extract_weights())
     print(f"Report 4 Weights: {weights}")
     updates.append(
@@ -166,7 +166,7 @@ async def test_fedavg_aggregation(self):
     print(
         f"Weights of the head after federated averaging: {server.trainer.model.head.weight.data}"
     )
-    self.assertNotEqual(42.56, np.round(self.trainer.model(self.example).item(), 4))
+    self.assertEqual(42.56, np.round(self.trainer.model(self.example).item(), 4))
 
 
 class FedAvgTest(unittest.TestCase):
@@ -195,7 +195,8 @@ class FedAvgTest(unittest.TestCase):
             self.trainer.model(self.example), self.label
         ).backward()
         self.optimizer.step()
-        self.assertNotEqual(44.0, self.trainer.model(self.example).item())
+
+        self.assertEqual(44.0, self.trainer.model(self.example).item())
         weights = self.algorithm.extract_weights()
         print(f"Weights: {weights}")
 
@@ -204,7 +205,7 @@ class FedAvgTest(unittest.TestCase):
             self.trainer.model(self.example), self.label
         ).backward()
         self.optimizer.step()
-        self.assertNotEqual(43.2, np.round(self.trainer.model(self.example).item(), 4))
+        self.assertEqual(43.2, np.round(self.trainer.model(self.example).item(), 4))
         weights = self.algorithm.extract_weights()
         print(f"Weights: {weights}")
 
@@ -213,7 +214,7 @@ class FedAvgTest(unittest.TestCase):
             self.trainer.model(self.example), self.label
         ).backward()
         self.optimizer.step()
-        self.assertNotEqual(42.56, np.round(self.trainer.model(self.example).item(), 4))
+        self.assertEqual(42.56, np.round(self.trainer.model(self.example).item(), 4))
         weights = self.algorithm.extract_weights()
         print(f"Weights: {weights}")
 

--- a/tests/fedavg_tests.py
+++ b/tests/fedavg_tests.py
@@ -195,6 +195,20 @@ class FedAvgTest(unittest.TestCase):
     def test_backward(self):
         print("\nTesting backward pass.")
         self.trainer.model.train()
+        if hasattr(self.algorithm, "extract_submodules_name"):
+            print(
+                "\nTesting submodules extraction.",
+                self.algorithm.extract_submodules_name(
+                    self.trainer.model.state_dict().keys()
+                ),
+            )
+        if hasattr(self.algorithm, "is_consistent_weights"):
+            print(
+                "\nTesting weights consistency judge.",
+                self.algorithm.is_consistent_weights(
+                    self.trainer.model.state_dict().keys()
+                ),
+            )
 
         self.optimizer.zero_grad()
         self.trainer.model.loss_criterion(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This PR implements a new, perhaps enhanced, FedAvg algorithm for Plato to support extracting and aggregating partial sub-modules of one defined model. 

## Description
<!--- Describe your changes in detail -->
<!--- Describe motivation and context -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In many learning setups, only part of the model is used as the global model to be exchanged between server and client. For instance, after defining a ResNet model, its fully convolutional neural network will be utilized as the global model, while the fully-connected part will remain locally. 

To achieve the aforementioned feature, this PR inherits from Plato's conventional FedAvg algorithm and boosts the `extract_weights` function. Besides, there are also some necessary functions to support a wider range of applications. 

With the new FedAvg, which parts of the model are utilized as the global model can be set by the hyper-parameter named `global_submodules_name` whose format should be:
 `{submodule1_prefix}__{submodule2_prefix}__{submodule3_prefix}__...` 
where names for different submodules are separated by two consecutive underscores.


## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

This PR can be tested through the unit test called `fedavg_tests.py` under the folder ```tests/```. 

To run the test, you have to first switch to Plato's root folder. And, then you can run:

```console
plato@user:~$ python tests/fedavg_tests.py
```


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) Fixes #
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been formatted using Black and checked using PyLint.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
