### PR TITLE
Improved the flexibility of callbacks

### DIFF
--- a/.github/workflows/delete_workflow_runs.yml
+++ b/.github/workflows/delete_workflow_runs.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   del_runs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Delete workflow runs
         uses: Mattraks/delete-workflow-runs@v2

--- a/.github/workflows/gpu_tests.yml.disabled
+++ b/.github/workflows/gpu_tests.yml.disabled
@@ -11,7 +11,7 @@ on:
 
 jobs:
   Tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/mindspore_tests.yml
+++ b/.github/workflows/mindspore_tests.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   MindSpore-Tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Checkout

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/pytorch_tests.yml
+++ b/.github/workflows/pytorch_tests.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   PyTorch-Tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Checkout

--- a/.github/workflows/pytorch_yolov5_tests.yml
+++ b/.github/workflows/pytorch_yolov5_tests.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   PyTorch-Tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Checkout

--- a/.github/workflows/tensorflow_tests.yml
+++ b/.github/workflows/tensorflow_tests.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
     TensorFlow-Tests:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-20.04
 
         steps:
             - uses: actions/checkout@v3

--- a/docs/client.md
+++ b/docs/client.md
@@ -92,7 +92,7 @@ For infrastructure changes, such as logging and recording metrics, we tend to cu
 
 Within the implementation of these callback methods, one can access additional information about the local training by using the `client` instance. 
 
-To use callbacks, subclass the `ClientCallback` class in `plato.callbacks.client`, and override the following methods:
+To use callbacks, subclass the `ClientCallback` class in `plato.callbacks.client`, and override the following methods, and then pass it to the client when it is initialized, or call `client.add_callbacks` after initialization. Examples can be found in `examples/callbacks`.
 
 
 ````{admonition} **on_inbound_received()**

--- a/docs/client.md
+++ b/docs/client.md
@@ -92,7 +92,7 @@ For infrastructure changes, such as logging and recording metrics, we tend to cu
 
 Within the implementation of these callback methods, one can access additional information about the local training by using the `client` instance. 
 
-To use callbacks, subclass the `ClientCallback` class in `plato.callbacks.client`, and override the following methods, and then pass it to the client when it is initialized, or call `client.add_callbacks` after initialization. Examples can be found in `examples/callbacks`.
+To use callbacks, subclass the `ClientCallback` class in `plato.callbacks.client`, and override the following methods, then pass it to the client when it is initialized, or call `client.add_callbacks` after initialization. Examples can be found in `examples/callbacks`.
 
 
 ````{admonition} **on_inbound_received()**

--- a/docs/server.md
+++ b/docs/server.md
@@ -226,11 +226,11 @@ Override this method to complete additional tasks before closing the server.
 
 ## Customizing servers using callbacks
 
-For infrastructure changes, such as logging and recording metrics, we tend to customize the global training process using callbacks instead. The advantage of using callbacks is that one can pass a list of multiple callbacks to the client when it is initialized, and they will be called in their order in the provided list. This helps when it is necessary to group features into different callback classes.
+For infrastructure changes, such as logging and recording metrics, we tend to customize the global training process using callbacks instead. The advantage of using callbacks is that one can pass a list of multiple callbacks to the server when it is initialized, and they will be called in their order in the provided list. This helps when it is necessary to group features into different callback classes.
 
 Within the implementation of these callback methods, one can access additional information about the global training by using the `server` instance. 
 
-To use callbacks, subclass the `ServerCallback` class in `plato.callbacks.server`, and override the following methods:
+To use callbacks, subclass the `ServerCallback` class in `plato.callbacks.server`, and override the following methods, and then pass it to the server when it is initialized, or call `server.add_callbacks` after initialization. Examples can be found in `examples/callbacks`.
 
 ````{admonition} **on_weights_received()**
 **`def on_weights_received(self, server, weights_received)`**

--- a/docs/server.md
+++ b/docs/server.md
@@ -230,7 +230,7 @@ For infrastructure changes, such as logging and recording metrics, we tend to cu
 
 Within the implementation of these callback methods, one can access additional information about the global training by using the `server` instance. 
 
-To use callbacks, subclass the `ServerCallback` class in `plato.callbacks.server`, and override the following methods, and then pass it to the server when it is initialized, or call `server.add_callbacks` after initialization. Examples can be found in `examples/callbacks`.
+To use callbacks, subclass the `ServerCallback` class in `plato.callbacks.server`, and override the following methods, then pass it to the server when it is initialized, or call `server.add_callbacks` after initialization. Examples can be found in `examples/callbacks`.
 
 ````{admonition} **on_weights_received()**
 **`def on_weights_received(self, server, weights_received)`**

--- a/docs/trainer.md
+++ b/docs/trainer.md
@@ -203,7 +203,8 @@ For infrastructure changes, such as logging, recording metrics, and stopping the
 
 Within the implementation of these callback methods, one can access additional information about the training loop by using the `trainer` instance. For example, `trainer.sampler` can be used to access the sampler used by the train dataloader, `trainer.trainloader` can be used to access the current train dataloader, and `trainer.current_epoch` can be used to access the current epoch number.
 
-To use callbacks, subclass the `TrainerCallback` class in `plato.callbacks.trainer`, and override the following methods:
+To use callbacks, subclass the `TrainerCallback` class in `plato.callbacks.trainer`, and override the following methods, and then pass it to the trainer when it is initialized, or call `trainer.add_callbacks` after initialization. For built-in trainers that user has no access to the initialization, one can also call `client.add_trainer_callbacks` which will pass callbacks to trainer later. Examples can be found in `examples/callbacks`.
+
 
 ````{admonition} **on_train_run_start()**
 **`def on_train_run_start(self, trainer, config)`**

--- a/docs/trainer.md
+++ b/docs/trainer.md
@@ -203,7 +203,7 @@ For infrastructure changes, such as logging, recording metrics, and stopping the
 
 Within the implementation of these callback methods, one can access additional information about the training loop by using the `trainer` instance. For example, `trainer.sampler` can be used to access the sampler used by the train dataloader, `trainer.trainloader` can be used to access the current train dataloader, and `trainer.current_epoch` can be used to access the current epoch number.
 
-To use callbacks, subclass the `TrainerCallback` class in `plato.callbacks.trainer`, and override the following methods, and then pass it to the trainer when it is initialized, or call `trainer.add_callbacks` after initialization. For built-in trainers that user has no access to the initialization, one can also call `client.add_trainer_callbacks` which will pass callbacks to trainer later. Examples can be found in `examples/callbacks`.
+To use callbacks, subclass the `TrainerCallback` class in `plato.callbacks.trainer`, and override the following methods, then pass it to the trainer when it is initialized, or call `trainer.add_callbacks` after initialization. For built-in trainers that user has no access to the initialization, one can also pass the trainer callbacks to client through parameter `trainer_callbacks`, which will be delivered to trainers later. Examples can be found in `examples/callbacks`.
 
 
 ````{admonition} **on_train_run_start()**

--- a/examples/callbacks/callback_examples.py
+++ b/examples/callbacks/callback_examples.py
@@ -25,7 +25,7 @@ class dynamicServerCallback(ServerCallback):
         logging.info(f"[{server}] Server callback from dynamic adding.")
 
 
-class dynamicTrainerCallback(TrainerCallback):
+class customTrainerCallback(TrainerCallback):
     def on_train_run_start(self, trainer, config):
         logging.info(
             f"[Client {trainer.client_id}] Trainer callback from dynamic adding."

--- a/examples/callbacks/callback_examples.py
+++ b/examples/callbacks/callback_examples.py
@@ -1,0 +1,32 @@
+"""Callback examples  for test purpose"""
+import logging
+from plato.callbacks.client import ClientCallback
+from plato.callbacks.server import ServerCallback
+from transformers import TrainerCallback
+
+
+class argumentClientCallback(ClientCallback):
+    def on_inbound_received(self, client, inbound_processor):
+        logging.info(f"[{client}] Client callback from argument.")
+
+
+class dynamicClientCallback(ClientCallback):
+    def on_inbound_received(self, client, inbound_processor):
+        logging.info(f"[{client}] Client callback from dynamic adding.")
+
+
+class argumentServerCallback(ServerCallback):
+    def on_weights_received(self, server, weights_received):
+        logging.info(f"[{server}] Server callback from argument.")
+
+
+class dynamicServerCallback(ServerCallback):
+    def on_weights_received(self, server, weights_received):
+        logging.info(f"[{server}] Server callback from dynamic adding.")
+
+
+class dynamicTrainerCallback(TrainerCallback):
+    def on_epoch_begin(self, trainer, config):
+        logging.info(
+            f"[Client {trainer.client_id}] Trainer callback from dynamic adding."
+        )

--- a/examples/callbacks/callback_examples.py
+++ b/examples/callbacks/callback_examples.py
@@ -2,7 +2,7 @@
 import logging
 from plato.callbacks.client import ClientCallback
 from plato.callbacks.server import ServerCallback
-from transformers import TrainerCallback
+from plato.callbacks.trainer import TrainerCallback
 
 
 class argumentClientCallback(ClientCallback):
@@ -26,7 +26,7 @@ class dynamicServerCallback(ServerCallback):
 
 
 class dynamicTrainerCallback(TrainerCallback):
-    def on_epoch_begin(self, trainer, config):
+    def on_train_run_start(self, trainer, config):
         logging.info(
             f"[Client {trainer.client_id}] Trainer callback from dynamic adding."
         )

--- a/examples/callbacks/callbacks.py
+++ b/examples/callbacks/callbacks.py
@@ -11,17 +11,15 @@ def main():
     """
     A Plato federated learning training session customized by callbacks.
     """
-    # Pass the callbacks to client and server as arguments
-    client = simple.Client(callbacks=[argumentClientCallback])
+    # Pass callbacks as arguments
+    client = simple.Client(
+        callbacks=[argumentClientCallback], trainer_callbacks=[customTrainerCallback]
+    )
     server = fedavg.Server(callbacks=[argumentServerCallback])
 
-    # Dynamically add callbacks after instantiated
+    # Add callbacks after initialization
     client.add_callbacks(callbacks=[dynamicClientCallback])
     server.add_callbacks(callbacks=[dynamicServerCallback])
-
-    # Add callbacks to trainer
-    # We cannot use client.trainer.add_callbacks because the trainer is not created yet.
-    client.add_trainer_callbacks(trainer_callbacks=[dynamicTrainerCallback])
 
     # Run the session
     server.run(client)

--- a/examples/callbacks/callbacks.py
+++ b/examples/callbacks/callbacks.py
@@ -1,0 +1,28 @@
+"""
+This example shows how to use callbacks to customize server, client, and trainer.
+"""
+
+from plato.clients import simple
+from plato.servers import fedavg
+from callback_examples import *
+
+
+def main():
+    """
+    A Plato federated learning training session customized by callbacks.
+    """
+    # Pass the callbacks to client and server as arguments
+    client = simple.Client(callbacks=[argumentClientCallback])
+    server = fedavg.Server(callbacks=[argumentServerCallback])
+
+    # Dynamically add callbacks after instantiated
+    client.add_callbacks(callbacks=[dynamicClientCallback])
+    server.add_callbacks(callbacks=[dynamicServerCallback])
+    client.add_trainer_callbacks(trainer_callbacks=[dynamicTrainerCallback])
+
+    # Run the session
+    server.run(client)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/callbacks/callbacks.py
+++ b/examples/callbacks/callbacks.py
@@ -18,6 +18,9 @@ def main():
     # Dynamically add callbacks after instantiated
     client.add_callbacks(callbacks=[dynamicClientCallback])
     server.add_callbacks(callbacks=[dynamicServerCallback])
+
+    # Add callbacks to trainer
+    # We cannot use client.trainer.add_callbacks because the trainer is not created yet.
     client.add_trainer_callbacks(trainer_callbacks=[dynamicTrainerCallback])
 
     # Run the session

--- a/plato/callbacks/client.py
+++ b/plato/callbacks/client.py
@@ -1,5 +1,5 @@
 """
-Defines the TrainerCallback class, which is the abstract base class to be subclassed
+Defines the ClientCallback class, which is the abstract base class to be subclassed
 when creating new client callbacks.
 
 Defines a default callback to print local training progress.

--- a/plato/callbacks/server.py
+++ b/plato/callbacks/server.py
@@ -31,7 +31,7 @@ class ServerCallback(ABC):
         Event called after the updated weights have been aggregated.
         """
 
-    def on_client_selected(self, server, selected_clients, **kwargs):
+    def on_clients_selected(self, server, selected_clients, **kwargs):
         """
         Event called after a new client arrived.
         """

--- a/plato/clients/base.py
+++ b/plato/clients/base.py
@@ -421,6 +421,10 @@ class Client:
                 file_path = f"{model_path}/{filename}"
                 os.remove(file_path)
 
+    def add_callbacks(self, callbacks):
+        """Adds a list of callbacks to the client callback handler."""
+        self.callback_handler.add_callbacks(callbacks)
+
     @abstractmethod
     async def _train(self):
         """The machine learning training workload on a client."""

--- a/plato/clients/base.py
+++ b/plato/clients/base.py
@@ -101,6 +101,8 @@ class Client:
             self.callbacks.extend(callbacks)
         self.callback_handler = CallbackHandler(self.callbacks)
 
+        self.custom_trainer_callbacks = []
+
     def __repr__(self):
         return f"Client #{self.client_id}"
 
@@ -424,6 +426,11 @@ class Client:
     def add_callbacks(self, callbacks):
         """Adds a list of callbacks to the client callback handler."""
         self.callback_handler.add_callbacks(callbacks)
+
+    def add_trainer_callbacks(self, trainer_callbacks):
+        """Set up a list of trainer callbacks which will be added to trainer
+        when it is configured."""
+        self.custom_trainer_callbacks = trainer_callbacks
 
     @abstractmethod
     async def _train(self):

--- a/plato/clients/base.py
+++ b/plato/clients/base.py
@@ -101,8 +101,6 @@ class Client:
             self.callbacks.extend(callbacks)
         self.callback_handler = CallbackHandler(self.callbacks)
 
-        self.custom_trainer_callbacks = []
-
     def __repr__(self):
         return f"Client #{self.client_id}"
 
@@ -426,11 +424,6 @@ class Client:
     def add_callbacks(self, callbacks):
         """Adds a list of callbacks to the client callback handler."""
         self.callback_handler.add_callbacks(callbacks)
-
-    def add_trainer_callbacks(self, trainer_callbacks):
-        """Set up a list of trainer callbacks which will be added to trainer
-        when it is configured."""
-        self.custom_trainer_callbacks = trainer_callbacks
 
     @abstractmethod
     async def _train(self):

--- a/plato/clients/simple.py
+++ b/plato/clients/simple.py
@@ -51,8 +51,10 @@ class Client(base.Client):
 
         if self.trainer is None and self.custom_trainer is None:
             self.trainer = trainers_registry.get(model=self.model)
+            self.trainer.add_callbacks(self.custom_trainer_callbacks)
         elif self.trainer is None and self.custom_trainer is not None:
             self.trainer = self.custom_trainer(model=self.model)
+            self.trainer.add_callbacks(self.custom_trainer_callbacks)
 
         self.trainer.set_client_id(self.client_id)
 

--- a/plato/clients/simple.py
+++ b/plato/clients/simple.py
@@ -51,10 +51,15 @@ class Client(base.Client):
 
         if self.trainer is None and self.custom_trainer is None:
             self.trainer = trainers_registry.get(model=self.model)
-            self.trainer.add_callbacks(self.custom_trainer_callbacks)
         elif self.trainer is None and self.custom_trainer is not None:
             self.trainer = self.custom_trainer(model=self.model)
+
+        # Add customized callbacks to trainer if applicable
+        if len(self.custom_trainer_callbacks) and hasattr(
+            self.trainer, "add_callbacks"
+        ):
             self.trainer.add_callbacks(self.custom_trainer_callbacks)
+            self.custom_trainer_callbacks = []
 
         self.trainer.set_client_id(self.client_id)
 

--- a/plato/servers/base.py
+++ b/plato/servers/base.py
@@ -1314,6 +1314,10 @@ class Server:
 
         await self._close_connections()
         os._exit(0)
+    
+    def add_callbacks(self, callbacks):
+        """Adds a list of callbacks to the server callback handler."""
+        self.callback_handler.add_callbacks(callbacks)
 
     def customize_server_response(self, server_response: dict, client_id) -> dict:
         """Customizes the server response with any additional information."""

--- a/plato/trainers/basic.py
+++ b/plato/trainers/basic.py
@@ -500,6 +500,10 @@ class Trainer(base.Trainer):
 
         return correct / total
 
+    def add_callbacks(self, callbacks):
+        """Adds a list of callbacks to the trainer callback handler."""
+        self.callback_handler.add_callbacks(callbacks)
+
     def get_optimizer(self, model):
         """Returns the optimizer."""
         return optimizers.get(model)

--- a/plato/trainers/diff_privacy.py
+++ b/plato/trainers/diff_privacy.py
@@ -18,7 +18,7 @@ from plato.trainers import basic
 class Trainer(basic.Trainer):
     """A differentially private federated learning trainer, used by the client."""
 
-    def __init__(self, model=None):
+    def __init__(self, model=None, **kwargs):
         """Initializing the trainer with the provided model."""
         super().__init__(model=model)
 

--- a/plato/trainers/gan.py
+++ b/plato/trainers/gan.py
@@ -23,7 +23,7 @@ from plato.trainers import optimizers
 class Trainer(basic.Trainer):
     """A federated learning trainer for GAN models."""
 
-    def __init__(self, model=None):
+    def __init__(self, model=None, **kwargs):
         super().__init__()
 
         if model is None:

--- a/plato/trainers/huggingface.py
+++ b/plato/trainers/huggingface.py
@@ -57,7 +57,11 @@ class Trainer(basic.Trainer):
         super().__init__(model)
 
         self.trainer = None
-        self.trainer_callbacks = callbacks if callbacks else []
+        self.trainer_callbacks = []
+        if callbacks:
+            # Huggingface needs to check callback types
+            self.add_callbacks(callbacks)
+
         self.model.train()
 
         parser = HfArgumentParser(TrainingArguments)

--- a/plato/trainers/huggingface.py
+++ b/plato/trainers/huggingface.py
@@ -7,7 +7,7 @@ from typing import Optional
 
 from torch.utils.data import RandomSampler, Sampler
 
-from transformers import AutoConfig, AutoTokenizer, HfArgumentParser
+from transformers import AutoConfig, AutoTokenizer, HfArgumentParser, TrainerCallback
 from transformers import Trainer as HuggingFaceTrainer
 from transformers import TrainingArguments, default_data_collator
 
@@ -30,6 +30,7 @@ class SampledHuggingFaceTrainer(HuggingFaceTrainer):
         tokenizer,
         data_collator,
         sampler,
+        callbacks,
     ):
         super().__init__(
             model=model,
@@ -38,6 +39,7 @@ class SampledHuggingFaceTrainer(HuggingFaceTrainer):
             eval_dataset=eval_dataset,
             tokenizer=tokenizer,
             data_collator=data_collator,
+            callbacks=callbacks,
         )
         self.sampler = sampler
 
@@ -55,6 +57,7 @@ class Trainer(basic.Trainer):
         super().__init__(model)
 
         self.trainer = None
+        self.trainer_callbacks = []
         self.model.train()
 
         parser = HfArgumentParser(TrainingArguments)
@@ -101,11 +104,14 @@ class Trainer(basic.Trainer):
             tokenizer=self.tokenizer,
             data_collator=default_data_collator,
             sampler=sampler,
+            callbacks=self.trainer_callbacks,
         )
 
         self.trainer.train()
 
-    def test_model(self, config, testset, sampler=None, **kwargs):  # pylint: disable=unused-argument
+    def test_model(
+        self, config, testset, sampler=None, **kwargs
+    ):  # pylint: disable=unused-argument
         """The testing loop for HuggingFace models.
 
         Arguments:
@@ -129,3 +135,12 @@ class Trainer(basic.Trainer):
             perplexity = float("inf")
 
         return perplexity
+
+    def add_callbacks(self, callbacks):
+        """Callbacks will be handled by Huggingface instead of Plato."""
+        for callback in callbacks:
+            if not issubclass(callback, TrainerCallback):
+                raise ValueError(
+                    f"Huggingface trainer expects subclass of {TrainerCallback}, got {callback} instead."
+                )
+        self.trainer_callbacks.extend(callbacks)

--- a/plato/trainers/huggingface.py
+++ b/plato/trainers/huggingface.py
@@ -53,11 +53,11 @@ class SampledHuggingFaceTrainer(HuggingFaceTrainer):
 class Trainer(basic.Trainer):
     """The trainer for HuggingFace transformer models for natural language processing."""
 
-    def __init__(self, model=None):
+    def __init__(self, model=None, callbacks=None):
         super().__init__(model)
 
         self.trainer = None
-        self.trainer_callbacks = []
+        self.trainer_callbacks = callbacks if callbacks else []
         self.model.train()
 
         parser = HfArgumentParser(TrainingArguments)

--- a/plato/trainers/mindspore/basic.py
+++ b/plato/trainers/mindspore/basic.py
@@ -24,7 +24,7 @@ class Trainer(base.Trainer):
     the client and the server.
     """
 
-    def __init__(self, model=None):
+    def __init__(self, model=None, **kwargs):
         """Initializing the trainer with the provided model.
 
         Arguments:

--- a/plato/trainers/pascal_voc.py
+++ b/plato/trainers/pascal_voc.py
@@ -11,19 +11,20 @@ from plato.trainers import basic
 class Evaluator(object):
     def __init__(self, num_class):
         self.num_class = num_class
-        self.confusion_matrix = np.zeros((self.num_class, ) * 2)
+        self.confusion_matrix = np.zeros((self.num_class,) * 2)
 
     def Mean_Intersection_over_Union(self):
-        MIoU = np.diag(
-            self.confusion_matrix) / (np.sum(self.confusion_matrix, axis=1) +
-                                      np.sum(self.confusion_matrix, axis=0) -
-                                      np.diag(self.confusion_matrix))
+        MIoU = np.diag(self.confusion_matrix) / (
+            np.sum(self.confusion_matrix, axis=1)
+            + np.sum(self.confusion_matrix, axis=0)
+            - np.diag(self.confusion_matrix)
+        )
         MIoU = np.nanmean(MIoU)
         return MIoU
 
     def _generate_matrix(self, gt_image, pre_image):
         mask = (gt_image >= 0) & (gt_image < self.num_class)
-        label = self.num_class * gt_image[mask].astype('int') + pre_image[mask]
+        label = self.num_class * gt_image[mask].astype("int") + pre_image[mask]
         count = np.bincount(label, minlength=self.num_class**2)
         confusion_matrix = count.reshape(self.num_class, self.num_class)
         return confusion_matrix
@@ -33,12 +34,13 @@ class Evaluator(object):
         self.confusion_matrix += self._generate_matrix(gt_image, pre_image)
 
     def reset(self):
-        self.confusion_matrix = np.zeros((self.num_class, ) * 2)
+        self.confusion_matrix = np.zeros((self.num_class,) * 2)
 
 
 class Trainer(basic.Trainer):
     """The federated learning trainer for the image segmentation on PASCAL VOC"""
-    def __init__(self, model=None):
+
+    def __init__(self, model=None, **kwargs):
         """Initializing the trainer with the provided model.
 
         Arguments:
@@ -52,15 +54,15 @@ class Trainer(basic.Trainer):
 
     def test_model(self, config, testset, sampler=None, **kwargs):
         test_loader = torch.utils.data.DataLoader(
-            testset, batch_size=config['batch_size'], shuffle=False)
+            testset, batch_size=config["batch_size"], shuffle=False
+        )
 
         total = 0
         evaluator = Evaluator(self.num_class)
         evaluator.reset()
         with torch.no_grad():
             for examples, labels in test_loader:
-                examples, labels = examples.to(self.device), labels.to(
-                    self.device)
+                examples, labels = examples.to(self.device), labels.to(self.device)
 
                 outputs = self.model(examples)
 
@@ -68,8 +70,8 @@ class Trainer(basic.Trainer):
                 total += labels.size(0)
                 labels = torch.squeeze(labels, 1).cpu().numpy()
                 predicted = predicted.cpu().numpy()
-                print('shape of pred: ', predicted.shape)
-                print('shape of labels: ', labels.shape)
+                print("shape of pred: ", predicted.shape)
+                print("shape of labels: ", labels.shape)
                 evaluator.add_batch(labels, predicted)
 
             accuracy = evaluator.Mean_Intersection_over_Union()

--- a/plato/trainers/registry.py
+++ b/plato/trainers/registry.py
@@ -44,7 +44,7 @@ def get(model=None, callbacks=None):
     elif Config().trainer.type == "HuggingFace":
         from plato.trainers import huggingface
 
-        return huggingface.Trainer(model)
+        return huggingface.Trainer(model=model, callbacks=callbacks)
     elif trainer_name in registered_trainers:
         return registered_trainers[trainer_name](model=model, callbacks=callbacks)
     else:

--- a/plato/trainers/registry.py
+++ b/plato/trainers/registry.py
@@ -32,7 +32,7 @@ else:
     }
 
 
-def get(model=None):
+def get(model=None, callbacks=None):
     """Get the trainer with the provided name."""
     trainer_name = Config().trainer.type
     logging.info("Trainer: %s", trainer_name)
@@ -46,6 +46,6 @@ def get(model=None):
 
         return huggingface.Trainer(model)
     elif trainer_name in registered_trainers:
-        return registered_trainers[trainer_name](model)
+        return registered_trainers[trainer_name](model=model, callbacks=callbacks)
     else:
         raise ValueError(f"No such trainer: {trainer_name}")

--- a/plato/trainers/tensorflow/basic.py
+++ b/plato/trainers/tensorflow/basic.py
@@ -18,7 +18,7 @@ class Trainer(base.Trainer):
     the client and the server.
     """
 
-    def __init__(self, model=None):
+    def __init__(self, model=None, **kwargs):
         """Initializing the trainer with the provided model.
 
         Arguments:

--- a/plato/trainers/yolov5.py
+++ b/plato/trainers/yolov5.py
@@ -11,7 +11,7 @@ from torch.cuda import amp
 from torch.optim.lr_scheduler import LambdaLR
 from tqdm import tqdm
 from yolov5.utils.general import (
-    NCOLS,
+    TQDM_BAR_FORMAT,
     box_iou,
     check_dataset,
     non_max_suppression,
@@ -317,12 +317,8 @@ class Trainer(basic.Trainer):
             0.0,
         )
         stats, ap = [], []
-        pbar = tqdm(
-            test_loader,
-            desc=s,
-            ncols=NCOLS,
-            bar_format="{l_bar}{bar:10}{r_bar}{bar:-10b}",
-        )  # progress bar
+
+        pbar = tqdm(test_loader, desc=s, bar_format=TQDM_BAR_FORMAT)  # progress bar
 
         for __, (img, targets, paths, shapes) in enumerate(pbar):
             t1 = time_sync()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR aims to improve the flexibility of callback mechanism in Plato. To customize the built-in trainers with callbacks, user needs to define a new trainer class instead of directly passing callbacks to the trainer. This is because currently callbacks can only be declared when the instances are created, and Plato creates built-in trainers with `registry.get` where user has no access.

To improve this, the following changes are made:

1. Added function `add_callbacks` to server, client and trainer, which enables adding callbacks after instances are created.
2. The trainer is not instantiated by clients until the training begins, so we further add parameter `trainer_callbacks` to client which sets up the callbacks that will be passed to trainer later.
3. Provided an example about how to customize Plato with callbacks in `examples/callbacks` 


## How has this been tested?
The changes have been tested by running `python examples/callbacks/callbacks.py -c configs/MNIST/fedavg_lenet5.yml`


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) Fixes #
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been formatted using Black and checked using PyLint.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
