### PR TITLE
Fix memory overflow issues during training. Heapq does not pop under some conditions.

### DIFF
--- a/plato/servers/base.py
+++ b/plato/servers/base.py
@@ -895,7 +895,12 @@ class Server:
             },
         )
 
-        heapq.heappush(self.reported_clients, client_info)
+        if (
+            self.asynchronous_mode
+            and self.simulate_wall_time
+            and len(self.current_reported_clients) >= len(self.selected_clients)
+        ):
+            heapq.heappush(self.reported_clients, client_info)
         self.current_reported_clients[client_info[2]["client_id"]] = True
         del self.training_clients[client_id]
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
In plato/servers/base.py, Heaq is pushed under all conditions, but only under certain conditions it is popped.  If it is not popped, the RAM consumption will increase as the increasing of training rounds. It could lead to RAM overflow. Therefore, an if statement is added before a heap push function, only when a heap will be popped then it will be pushed.
<!--- Describe motivation and context -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
It has been tested with normal Fedavg and Fedavg with encryption. After the fix, RAM consumption does not increase as the training round increases.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) Fixes #
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been formatted using Black and checked using PyLint.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
