### PR TITLE
Improved Huggingface trainer.

### DIFF
--- a/plato/trainers/huggingface.py
+++ b/plato/trainers/huggingface.py
@@ -103,7 +103,7 @@ class Trainer(basic.Trainer):
         sampler: the sampler that extracts a partition for this client.
         """
 
-        self.training_args.num_train_epoches = config["epochs"]
+        self.training_args.num_train_epochs = config["epochs"]
         self.training_args.per_device_train_batch_size = config["batch_size"]
 
         self.trainer = SampledHuggingFaceTrainer(

--- a/plato/trainers/huggingface.py
+++ b/plato/trainers/huggingface.py
@@ -49,6 +49,12 @@ class SampledHuggingFaceTrainer(HuggingFaceTrainer):
 
         return self.sampler
 
+    def _get_eval_sampler(self, eval_dataset) -> Optional[Sampler]:
+        if self.sampler is None:
+            return super()._get_eval_sampler(eval_dataset)
+
+        return self.sampler
+
 
 class Trainer(basic.Trainer):
     """The trainer for HuggingFace transformer models for natural language processing."""
@@ -122,13 +128,17 @@ class Trainer(basic.Trainer):
             config: Configuration parameters as a dictionary.
             testset: The test dataset.
         """
-        self.trainer = HuggingFaceTrainer(
+        self.training_args.per_device_eval_batch_size = config["batch_size"]
+
+        self.trainer = SampledHuggingFaceTrainer(
             model=self.model,
             args=self.training_args,
             train_dataset=None,
             eval_dataset=testset,
             tokenizer=self.tokenizer,
             data_collator=default_data_collator,
+            sampler=sampler,
+            callbacks=None,
         )
 
         metrics = self.trainer.evaluate()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR aims to improve the existing huggingface trainer in the following aspects:
1. Added support for customized sampler during evaluation, which previously only used the whole testset.
2. Fixed a typo (`num_train_epoches` to `num_train_epochs`) in trainer arguments that results in undesired training epochs.
3. Added batch size to evaluation arguments to speed up the evaluation process.

## How has this been tested?
This PR has been tested by running
`./run -c configs/HuggingFace/fedavg_shakespeare_distilgpt2.yml` 
where we can see local training epoch number and evaluating batch size are now consistent with the configuration file, which previously was fixed at 3 and 8 respectively.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) Fixes #
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been formatted using Black and checked using PyLint.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
