### PR TITLE
Fixed the version of protobuf error raised because of new version of tensorflow.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ gym
 zstd
 torch-optimizer
 timm
-protobuf<=3.20.3,>=3.9.2
+protobuf==3.20.x

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ gym
 zstd
 torch-optimizer
 timm
-protobuf<=3.20,>=3.9.2
+protobuf<=3.20.3,>=3.9.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ gym
 zstd
 torch-optimizer
 timm
-protobuf<3.20,>=3.9.2
+protobuf<=3.20,>=3.9.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ gym
 zstd
 torch-optimizer
 timm
+protobuf<3.20,>=3.9.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ zstd
 torch-optimizer
 timm
 protobuf<3.21,>=3.9.2
+tensorflow_datasets==4.8.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ gym
 zstd
 torch-optimizer
 timm
-protobuf==3.20.x
+protobuf<3.21,>=3.9.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ zstd
 torch-optimizer
 timm
 protobuf<3.21,>=3.9.2
-tensorflow_datasets==4.8.2
+tensorflow==2.11.0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
In previous tensorflow version 2.11 , it will install the required package protobuf<3.20,>=3.9.2. In TensorFlow version 2.12, it does not have such restrictions on version when installing required packages. But this will conflict with tensorflow_datasets. So, we added version restrictions in the requirements. txt.
## Description
<!--- Describe your changes in detail -->
<!--- Describe motivation and context -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) Fixes #
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been formatted using Black and checked using PyLint.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
