### PR TITLE
Fix the bug of calling T2T module.

### DIFF
--- a/configs/ViT/fedavg_cifar10_t2tvit14.yml
+++ b/configs/ViT/fedavg_cifar10_t2tvit14.yml
@@ -43,7 +43,7 @@ trainer:
 
     # The machine learning model
     model_type: vit
-    model_name: T2t_vit_14
+    model_name: t2t_vit_14
 
     # Number of epoches for local training in each communication round
     epochs: 5

--- a/plato/models/vit.py
+++ b/plato/models/vit.py
@@ -15,8 +15,6 @@ from transformers import AutoConfig, AutoModelForImageClassification
 
 
 from plato.config import Config
-from plato.models import t2tvit
-from plato.models.dvit.models import deep_vision_transformer
 
 
 class ResolutionAdjustedModel(nn.Module):
@@ -68,8 +66,11 @@ class T2TVIT(nn.Module):
 
     def __init__(self, name) -> nn.Module:
         super().__init__()
+        # pylint:disable=import-outside-toplevel
+        from plato.models import t2tvit
+        from plato.models.t2tvit.models import t2t_vit
 
-        model_name = getattr(t2tvit, name)
+        model_name = getattr(t2t_vit, name)
         t2t = model_name(num_classes=Config().trainer.num_classes)
 
         if (
@@ -101,6 +102,8 @@ class DeepViT(nn.Module):
 
     def __init__(self, name) -> nn.Module:
         super().__init__()
+        # pylint:disable=import-outside-toplevel
+        from plato.models.dvit.models import deep_vision_transformer
 
         model_name = getattr(deep_vision_transformer, name)
         deepvit = model_name(
@@ -141,7 +144,7 @@ class Model:
     @staticmethod
     def get(model_name=None, **kwargs):  # pylint: disable=unused-argument
         """Returns a named model from HuggingFace."""
-        if "T2t" in model_name:
+        if "t2t" in model_name:
             return T2TVIT(model_name)
 
         if "deepvit" in model_name:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixed the bug when calling T2T module.

## Description
Previously the file in t2tvit module was modified. Now, we leverage the submodule to clone the t2tvit repo and we modify the vit.py to fit the current interface with t2tvit and do not need to change any files in the t2tvit. The main difference is changing the names of several modules when calling them.

<!--- Describe motivation and context -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
Run the command.
```
python3 ./run -c ./configs/ViT/fedavg_cifar10_t2tvit14.yml
```
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) Fixes #
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been formatted using Black and checked using PyLint.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
