### PR TITLE
Added multiparty computation to encrypt model updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,6 @@ tensorflow_datasets/
 
 # Homomorphic encryption
 .ckks_context/
+
+# Multiparty computation
+mpc_data/

--- a/configs/MNIST/fedavg_lenet5_mpc_additive.yml
+++ b/configs/MNIST/fedavg_lenet5_mpc_additive.yml
@@ -1,0 +1,69 @@
+clients:
+    # Type
+    type: mpc
+
+    # The total number of clients
+    total_clients: 10
+
+    # The number of clients selected in each round
+    per_round: 3
+
+    # Should the clients compute test accuracy locally?
+    do_test: false
+
+    # Processors for outbound data payloads
+    outbound_processors:
+        - mpc_model_encrypt_additive
+
+server:
+    type: fedavg_mpc_additive
+    address: 127.0.0.1
+    port: 8001
+    random_seed: 1
+    simulate_wall_time: true
+
+    # Uncomment to use S3 storage (Need to start zookeeper at the following address and port before training)
+    # # S3 bucket for communication between server and clients
+    # s3_bucket: "fl-mpc"
+    # s3_endpoint_url: "https://s3.us-east-1.amazonaws.com"
+
+    # # Zookeeper for distributed lock, need to start zookeeper at the following address and port before training
+    # zk_address: 127.0.0.1
+    # zk_port: 2181
+
+
+data: !include mnist_iid.yml
+
+trainer:
+    # The type of the trainer
+    type: basic
+
+    # The maximum number of training rounds
+    rounds: 5
+
+    # The maximum number of clients running concurrently
+    max_concurrency: 5
+
+    # The target accuracy
+    target_accuracy: 0.985
+
+    # The machine learning model
+    model_name: lenet5
+
+    # Number of epoches for local training in each communication round
+    epochs: 5
+    batch_size: 32
+    optimizer: SGD
+
+algorithm:
+    # Aggregation algorithm
+    type: fedavg
+
+parameters:
+    model:
+        num_classes: 10
+
+    optimizer:
+        lr: 0.01
+        momentum: 0.9
+        weight_decay: 0.0

--- a/configs/MNIST/fedavg_lenet5_mpc_shamir.yml
+++ b/configs/MNIST/fedavg_lenet5_mpc_shamir.yml
@@ -1,0 +1,68 @@
+clients:
+    # Type
+    type: mpc
+
+    # The total number of clients
+    total_clients: 10
+
+    # The number of clients selected in each round
+    per_round: 3
+
+    # Should the clients compute test accuracy locally?
+    do_test: false
+
+    # Processors for outbound data payloads
+    outbound_processors:
+        - mpc_model_encrypt_shamir
+
+server:
+    type: fedavg_mpc_shamir
+    address: 127.0.0.1
+    port: 8001
+    random_seed: 1
+    simulate_wall_time: true
+
+    # Uncomment to use S3 storage (Need to start zookeeper at the following address and port before training)
+    # # S3 bucket for communication between server and clients
+    # s3_bucket: "fl-mpc"
+    # s3_endpoint_url: "https://s3.us-east-1.amazonaws.com"
+
+    # # Zookeeper for distributed lock, need to start zookeeper at the following address and port before training
+    # zk_address: 127.0.0.1
+    # zk_port: 2181
+
+data: !include mnist_iid.yml
+
+trainer:
+    # The type of the trainer
+    type: basic
+
+    # The maximum number of training rounds
+    rounds: 5
+
+    # The maximum number of clients running concurrently
+    max_concurrency: 5
+
+    # The target accuracy
+    target_accuracy: 0.985
+
+    # The machine learning model
+    model_name: lenet5
+
+    # Number of epoches for local training in each communication round
+    epochs: 5
+    batch_size: 32
+    optimizer: SGD
+
+algorithm:
+    # Aggregation algorithm
+    type: fedavg
+
+parameters:
+    model:
+        num_classes: 10
+
+    optimizer:
+        lr: 0.01
+        momentum: 0.9
+        weight_decay: 0.0

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,7 +25,16 @@ Valid values are `true` or `false`. The default value is `false`.
 ## clients
 
 ```{admonition} **type**
-The type of the federated learning client. Valid values include `simple`, which represents a basic client who sends weight updates to the server; and `mistnet`, which is client following the MistNet algorithm; and `simple_personalized`, which controls the personalized learning logic.
+The type of the federated learning client. 
+
+- `simple` a basic client who sends weight updates to the server.
+
+- `mistnet` a client following the MistNet algorithm.
+
+- `simple_personalized` a client that controls the personalized learning logic.
+
+- `mpc` a client that encrypts model updates using multiparty computation. Raw and encrypted client model updates in each round are saved under `plato/mpc_data`.
+
 ```
 
 ```{admonition} **total_clients**
@@ -125,6 +134,11 @@ A list of processors for the client to apply on the payload before sending it ou
 - `model_compress` Compress model parameters with `Zstandard` compression algorithm. Must be placed as the last processor if applied.
 
 - `model_encrypt` Encrypts the model parameters using homomorphic encyrption.
+
+- `mpc_model_encrypt_additive` Encrypts the model parameters using multiparty computation with additive secret sharing.
+
+- `mpc_model_encrypt_shamir` Encrypts the model parameters using multiparty computation with Shamir secret sharing. It is slower than additive secret sharing, but supports detecting dishonest clients.
+
 ```
 
 ```{admonition} inbound_processors
@@ -162,6 +176,10 @@ The type of the server.
 
 - `fedavg_personalized` a Federated Averaging server that supports all-purpose personalized federated learning by controlling when and which group of clients are to perform local personalization.
 
+- `fedavg_mpc_additive` a Federated Averaging server that supports multiparty computation with additive secret sharing. It reconstructs the average model update from secret shares in the shared storage sent from clients. When this server is used, the clients need to enable outbound processor `mpc_model_encrypt_additive` to encrypt the model updates and the client type must be `mpc`.
+
+- `fedavg_mpc_shamir` a Federated Averaging server that supports multiparty computation with Shamir secret sharing. It reconstructs the average model update from secret shares in the shared storage sent from clients. When this server is used, the clients need to enable outbound processor `mpc_model_encrypt_shamir` to encrypt the model updates and the client type must be `mpc`.
+
 ```
 
 ```{admonition} **address**
@@ -182,6 +200,14 @@ The endpoint URL for an S3-compatible storage service, used for transferring pay
 
 ```{admonition} s3_bucket
 The bucket name for an S3-compatible storage service, used for transferring payloads between clients and servers.
+```
+
+```{admonition} zk_address
+The address where the ZooKeeper service is running. This is only needed when using s3 for multiparty computation.
+```
+
+```{admonition} zk_port
+The port where the ZooKeeper service is running. This is only needed when using s3 for multiparty computation.
 ```
 
 ```{admonition} random_seed

--- a/plato/client.py
+++ b/plato/client.py
@@ -10,7 +10,15 @@ from plato.clients import registry as client_registry
 from plato.config import Config
 
 
-def run(client_id, port, client=None, edge_server=None, edge_client=None, trainer=None):
+def run(
+    client_id,
+    port,
+    client=None,
+    edge_server=None,
+    edge_client=None,
+    trainer=None,
+    lock=None,
+):
     """Starting a client to connect to the server."""
     Config().args.id = client_id
     if port is not None:
@@ -51,7 +59,10 @@ def run(client_id, port, client=None, edge_server=None, edge_client=None, traine
 
     else:
         if client is None:
-            client = client_registry.get()
+            if lock is None:
+                client = client_registry.get()
+            else:
+                client = client_registry.get(lock=lock)
             logging.info("Starting a %s client #%d.", Config().clients.type, client_id)
         else:
             client.client_id = client_id

--- a/plato/clients/mpc.py
+++ b/plato/clients/mpc.py
@@ -1,0 +1,259 @@
+"""
+A federated learning client who sends weight updates to the server with MPC.
+"""
+
+import logging
+import time
+import pickle
+import os
+from types import SimpleNamespace
+from kazoo.client import KazooClient
+from kazoo.recipe.lock import Lock
+
+from plato.algorithms import registry as algorithms_registry
+from plato.clients import base
+from plato.config import Config
+from plato.datasources import registry as datasources_registry
+from plato.processors import registry as processor_registry
+from plato.samplers import registry as samplers_registry
+from plato.trainers import registry as trainers_registry
+from plato.utils import fonts
+from plato.utils import s3
+
+
+class Client(base.Client):
+    """A basic federated learning client who sends weight updates with MPC."""
+
+    def __init__(
+        self,
+        model=None,
+        datasource=None,
+        algorithm=None,
+        trainer=None,
+        callbacks=None,
+        lock=None,
+    ):
+        super().__init__(callbacks=callbacks)
+        self.custom_model = model
+        self.model = None
+
+        self.custom_datasource = datasource
+        self.datasource = None
+
+        self.custom_algorithm = algorithm
+        self.algorithm = None
+
+        self.custom_trainer = trainer
+        self.trainer = None
+
+        self.trainset = None  # Training dataset
+        self.testset = None  # Testing dataset
+        self.sampler = None
+        self.testset_sampler = None  # Sampler for the test set
+
+        self._report = None
+
+        self.s3_client = None
+        self.zk = None
+        self.lock = lock
+
+    def configure(self) -> None:
+        """Prepares this client for training."""
+        super().configure()
+
+        if self.model is None and self.custom_model is not None:
+            self.model = self.custom_model
+
+        if self.trainer is None and self.custom_trainer is None:
+            self.trainer = trainers_registry.get(model=self.model)
+        elif self.trainer is None and self.custom_trainer is not None:
+            self.trainer = self.custom_trainer(model=self.model)
+
+        self.trainer.set_client_id(self.client_id)
+
+        if self.algorithm is None and self.custom_algorithm is None:
+            self.algorithm = algorithms_registry.get(trainer=self.trainer)
+        elif self.algorithm is None and self.custom_algorithm is not None:
+            self.algorithm = self.custom_algorithm(trainer=self.trainer)
+
+        self.algorithm.set_client_id(self.client_id)
+
+        # Pass inbound and outbound data payloads through processors for
+        # additional data processing
+
+        self.outbound_processor, self.inbound_processor = processor_registry.get(
+            "Client",
+            client_id=self.client_id,
+            trainer=self.trainer,
+            file_lock=self.lock,
+        )
+
+        if hasattr(Config().server, "s3_endpoint_url"):
+            self.s3_client = s3.S3()
+            # Use Zookeeper for distributed locking
+            self.zk = KazooClient(
+                hosts=f"{Config().server.zk_address}:{Config().server.zk_port}"
+            )
+
+    def _load_data(self) -> None:
+        """Generates data and loads them onto this client."""
+        logging.info("[%s] Loading its data source...", self)
+
+        if (
+            self.datasource is None
+            and self.custom_datasource is None
+            or (hasattr(Config().data, "reload_data") and Config().data.reload_data)
+        ):
+            # The only case where Config().data.reload_data is set to true is
+            # when clients with different client IDs need to load from different datasets,
+            # such as in the pre-partitioned Federated EMNIST dataset. We do not support
+            # reloading data from a custom datasource at this time.
+            self.datasource = datasources_registry.get(client_id=self.client_id)
+        elif self.datasource is None and self.custom_datasource is not None:
+            self.datasource = self.custom_datasource()
+
+        logging.info(
+            "[%s] Dataset size: %s", self, self.datasource.num_train_examples()
+        )
+
+        # Setting up the data sampler
+        self.sampler = samplers_registry.get(self.datasource, self.client_id)
+
+        if hasattr(Config().trainer, "use_mindspore"):
+            # MindSpore requires samplers to be used while constructing
+            # the dataset
+            self.trainset = self.datasource.get_train_set(self.sampler)
+        else:
+            # PyTorch uses samplers when loading data with a data loader
+            self.trainset = self.datasource.get_train_set()
+
+        if hasattr(Config().clients, "do_test") and Config().clients.do_test:
+            # Set the testset if local testing is needed
+            self.testset = self.datasource.get_test_set()
+            if hasattr(Config().data, "testset_sampler"):
+                # Set the sampler for test set
+                self.testset_sampler = samplers_registry.get(
+                    self.datasource, self.client_id, testing=True
+                )
+
+    def _load_payload(self, server_payload) -> None:
+        """Loads the server model onto this client."""
+        self.algorithm.load_weights(server_payload)
+
+    async def _train(self):
+        """The machine learning training workload on a client."""
+        logging.info(
+            fonts.colourize(
+                f"[{self}] Started training in communication round #{self.current_round}."
+            )
+        )
+
+        # Perform model training
+        try:
+            if hasattr(self.trainer, "current_round"):
+                self.trainer.current_round = self.current_round
+            training_time = self.trainer.train(self.trainset, self.sampler)
+        except ValueError as exc:
+            logging.info(
+                fonts.colourize(f"[{self}] Error occurred during training: {exc}")
+            )
+            await self.sio.disconnect()
+
+        # Extract model weights and biases
+        weights = self.algorithm.extract_weights()
+
+        # Generate a report for the server, performing model testing if applicable
+        if (hasattr(Config().clients, "do_test") and Config().clients.do_test) and (
+            not hasattr(Config().clients, "test_interval")
+            or self.current_round % Config().clients.test_interval == 0
+        ):
+            accuracy = self.trainer.test(self.testset, self.testset_sampler)
+
+            if accuracy == -1:
+                # The testing process failed, disconnect from the server
+                await self.sio.disconnect()
+
+            if hasattr(Config().trainer, "target_perplexity"):
+                logging.info("[%s] Test perplexity: %.2f", self, accuracy)
+            else:
+                logging.info("[%s] Test accuracy: %.2f%%", self, 100 * accuracy)
+        else:
+            accuracy = 0
+
+        comm_time = time.time()
+
+        if (
+            hasattr(Config().clients, "sleep_simulation")
+            and Config().clients.sleep_simulation
+        ):
+            sleep_seconds = Config().client_sleep_times[self.client_id - 1]
+            avg_training_time = Config().clients.avg_training_time
+
+            training_time = (
+                avg_training_time + sleep_seconds
+            ) * Config().trainer.epochs
+
+        report = SimpleNamespace(
+            client_id=self.client_id,
+            num_samples=self.sampler.num_samples(),
+            accuracy=accuracy,
+            training_time=training_time,
+            comm_time=comm_time,
+            update_response=False,
+        )
+
+        # Save num_samples info in round_info
+        try:
+            if self.s3_client is not None:
+                # Use Zookeeper for distributed locking
+                self.zk.start()
+                lock = Lock(self.zk, "/my/lock/path")
+                lock.acquire()
+                logging.info("[%s] Acquired Zookeeper lock", self)
+
+                s3_key = "round_info"
+                logging.debug("Retrieving round_info from S3")
+                round_info = self.s3_client.receive_from_s3(s3_key)
+            else:
+                round_info_filename = "./mpc_data/round_info"
+                logging.debug("Retrieving round_info from file")
+                self.lock.acquire()
+                with open(round_info_filename, "rb") as round_info_file:
+                    round_info = pickle.load(round_info_file)
+
+            round_info[f"client_{self.client_id}_info"][
+                "num_samples"
+            ] = self.sampler.num_samples()
+
+            if self.s3_client is not None:
+                logging.debug("Saving round_info with current_client_info to S3")
+                self.s3_client.put_to_s3(s3_key, round_info)
+            else:
+                logging.debug("Saving round_info with current_client_info to file")
+                with open(round_info_filename, "wb") as round_info_file:
+                    pickle.dump(round_info, round_info_file)
+        finally:
+            if self.s3_client is not None:
+                lock.release()
+                logging.info("[%s] Released Zookeeper lock", self)
+                self.zk.stop()
+            else:
+                self.lock.release()
+
+        self._report = self.customize_report(report)
+
+        return self._report, weights
+
+    async def _obtain_model_update(self, client_id, requested_time):
+        """Retrieves a model update corresponding to a particular wall clock time."""
+        model = self.trainer.obtain_model_update(client_id, requested_time)
+        weights = self.algorithm.extract_weights(model)
+        self._report.comm_time = time.time()
+        self._report.client_id = client_id
+        self._report.update_response = True
+
+        return self._report, weights
+
+    def customize_report(self, report: SimpleNamespace) -> SimpleNamespace:
+        """Customizes the report with any additional information."""
+        return report

--- a/plato/clients/registry.py
+++ b/plato/clients/registry.py
@@ -10,17 +10,19 @@ from plato.config import Config
 from plato.clients import (
     simple,
     mistnet,
-    simple_personalized
+    simple_personalized,
+    mpc,
 )
 
 registered_clients = {
     "simple": simple.Client,
     "simple_personalized": simple_personalized.Client,
     "mistnet": mistnet.Client,
+    "mpc": mpc.Client,
 }
 
 
-def get(model=None, datasource=None, algorithm=None, trainer=None):
+def get(model=None, datasource=None, algorithm=None, trainer=None, lock=None):
     """Get an instance of the server."""
     if hasattr(Config().clients, "type"):
         client_type = Config().clients.type
@@ -29,9 +31,18 @@ def get(model=None, datasource=None, algorithm=None, trainer=None):
 
     if client_type in registered_clients:
         logging.info("Client: %s", client_type)
-        registered_client = registered_clients[client_type](
-            model=model, datasource=datasource, algorithm=algorithm, trainer=trainer
-        )
+        if client_type == "mpc":
+            registered_client = registered_clients[client_type](
+                model=model,
+                datasource=datasource,
+                algorithm=algorithm,
+                trainer=trainer,
+                lock=lock,
+            )
+        else:
+            registered_client = registered_clients[client_type](
+                model=model, datasource=datasource, algorithm=algorithm, trainer=trainer
+            )
     else:
         raise ValueError(f"No such client: {client_type}")
 

--- a/plato/processors/mpc_model_encrypt_additive.py
+++ b/plato/processors/mpc_model_encrypt_additive.py
@@ -1,0 +1,131 @@
+"""
+Implements additive secret sharing algorithm to encrypt model parameters.
+"""
+import copy
+import pickle
+import random
+import logging
+from typing import Any
+
+from kazoo.client import KazooClient
+from kazoo.recipe.lock import Lock
+
+from plato.processors import model
+from plato.config import Config
+from plato.utils import s3
+
+
+class Processor(model.Processor):
+    """
+    A processor that decrypts model tensors
+    """
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.client_share_index = 0
+        self.s3_client = None
+        self.client_id = kwargs["client_id"]
+        self.zk = None
+        self.lock = kwargs["file_lock"]
+
+    # Randomly split a tensor into num_shares
+    def split_tensor(self, tensor, num_shares):
+        if num_shares == 1:
+            tensors = [tensor]
+            return tensors
+
+        # First split evenly
+        tensors = [tensor / num_shares for i in range(num_shares)]
+
+        # Generate a random number for each share
+        start = -0.5
+        end = 0.5
+        rand_nums = [random.uniform(start, end) for i in range(num_shares - 1)]
+        rand_nums.append(0 - sum(rand_nums))
+
+        # Add the random numbers to secret shares
+        for i in range(num_shares):
+            tensors[i] += rand_nums[i]
+
+        return tensors
+
+    def process(self, data: Any) -> Any:
+        # Load round_info object
+        if hasattr(Config().server, "s3_endpoint_url"):
+            self.zk = KazooClient(
+                hosts=f"{Config().server.zk_address}:{Config().server.zk_port}"
+            )
+            self.zk.start()
+            lock = Lock(self.zk, "/my/lock/path")
+            lock.acquire()
+            logging.info("[%s] Acquired Zookeeper lock", self)
+
+            self.s3_client = s3.S3()
+            s3_key = "round_info"
+            logging.debug("Retrieving round_info from S3")
+            round_info = self.s3_client.receive_from_s3(s3_key)
+        else:
+            round_info_filename = "mpc_data/round_info"
+            self.lock.acquire()
+            with open(round_info_filename, "rb") as round_info_file:
+                round_info = pickle.load(round_info_file)
+
+        num_clients = len(round_info["selected_clients"])
+
+        # Store the client's weights before encryption in a file for testing
+        weights_filename = (
+            f"mpc_data/raw_weights_round{round_info['round_number']}"
+            f"_client{self.client_id}"
+        )
+        file = open(weights_filename, "w", encoding="utf8")
+        file.write(str(data))
+        file.close()
+
+        # Split weights randomly into n shares
+        # Initialize data_shares to the shape of data
+        data_shares = [copy.deepcopy(data) for i in range(num_clients)]
+
+        # Iterate over the keys of data to split
+        for key in data.keys():
+            # multiply by num_samples used to train the client
+            data[key] *= round_info[f"client_{self.client_id}_info"]["num_samples"]
+
+            # Split tensor randomly into num_clients shares
+            tensor_shares = self.split_tensor(data[key], num_clients)
+
+            # Store tensor_shares into data_shares for the particular key
+            for i in range(num_clients):
+                data_shares[i][key] = tensor_shares[i]
+
+        # Store secret shares in round_info
+        for i, client_id in enumerate(round_info["selected_clients"]):
+            # Skip the client itself
+            if client_id == self.client_id:
+                self.client_share_index = (
+                    i  # keep track of the index to return the client's share in the end
+                )
+                continue
+
+            if round_info[f"client_{client_id}_info"]["data"] is None:
+                round_info[f"client_{client_id}_info"]["data"] = data_shares[i]
+            else:
+                for key in data.keys():
+                    round_info[f"client_{client_id}_info"]["data"][key] += data_shares[
+                        i
+                    ][key]
+
+        logging.debug("Print round_info keys before filling client data")
+        logging.debug(round_info.keys())
+
+        # Store round_info object
+        if hasattr(Config().server, "s3_endpoint_url"):
+            self.s3_client.put_to_s3(s3_key, round_info)
+            lock.release()
+            logging.info("[%s] Released Zookeeper lock", self)
+            self.zk.stop()
+        else:
+            with open(round_info_filename, "wb") as round_info_file:
+                pickle.dump(round_info, round_info_file)
+            self.lock.release()
+
+        return data_shares[self.client_share_index]

--- a/plato/processors/mpc_model_encrypt_shamir.py
+++ b/plato/processors/mpc_model_encrypt_shamir.py
@@ -1,0 +1,170 @@
+"""
+Implements Shamir secret sharing algorithm to encrypt model parameters.
+"""
+
+import pickle
+import logging
+import math
+import copy
+from random import randint
+from typing import Any
+
+import torch
+from kazoo.client import KazooClient
+from kazoo.recipe.lock import Lock
+from plato.processors import model
+from plato.config import Config
+from plato.utils import s3
+
+
+class Processor(model.Processor):
+    """
+    A processor that decrypts model tensors
+    """
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.client_share_index = 0
+        self.s3_client = None
+        self.client_id = kwargs["client_id"]
+        self.zk = None
+        self.lock = kwargs["file_lock"]
+
+    def calculate_y(self, x, poly):
+        """
+        compute y value for a given x value
+        e.g. y = poly[0] + x*poly[1] + x^2*poly[2]
+        """
+        y = 0
+        tmp = 1
+
+        for coeff in poly:
+            y = y + coeff * tmp
+            tmp = tmp * x
+        return y
+
+    def secret_sharing(self, S, N, K):
+        """
+        Function to encode a given secret, given by S
+        Generates a K-degree polynomial, and N points
+        """
+        S = round(S.item() * 1000000)
+        poly = torch.zeros(K)
+        poly[0] = S  # the y-intercept
+        for i in range(1, K):
+            val = randint(1, 999)
+            while val in poly:  # avoid having duplicate x values
+                val = randint(1, 999)
+            poly[i] = val
+        points = torch.zeros([N, 2])
+
+        # Generate N points from the polynomial
+        for j in range(1, N + 1):
+            points[j - 1][0] = j  # x value of point
+            points[j - 1][1] = self.calculate_y(j, poly)  # y value of point
+
+        return points
+
+    def split_tensor(self, secret_data, N, K=None):
+        """Encrypt tensor using Shamir"""
+        if N == 1:
+            return secret_data.unsqueeze(0)
+
+        if K is None:
+            K = max(N - 2, 1)  # threshold chosen by the user
+
+        orig_size = list(secret_data.size())
+        dimen_len = math.prod(orig_size)  # number of entries
+        arr_one_dimen = secret_data.view(dimen_len)
+
+        coords_size = [N, dimen_len, 2]  # num clients, num points, 2-D point
+        coords = torch.empty(coords_size)
+
+        for i in range(dimen_len):  # iterate through each weight value
+            points = self.secret_sharing(arr_one_dimen[i], N, K)  # size [N, 2] tensor
+            for j in range(N):
+                coords[j][i] = points[
+                    j
+                ]  # coordinates[j] is the data points sending to client j
+
+        encrypted_size = orig_size
+        encrypted_size.insert(0, N)
+        encrypted_size.append(2)  # using 2-D points
+        encrypted = coords.view(encrypted_size)
+
+        return encrypted  # size [N, (orig_size), 2]
+
+    def process(self, data: Any) -> Any:
+        """Load round_info object"""
+        if hasattr(Config().server, "s3_endpoint_url"):
+            self.zk = KazooClient(
+                hosts=f"{Config().server.zk_address}:{Config().server.zk_port}"
+            )
+            self.zk.start()
+            lock = Lock(self.zk, "/my/lock/path")
+            lock.acquire()
+            logging.info("[%s] Acquired Zookeeper lock", self)
+
+            self.s3_client = s3.S3()
+            s3_key = "round_info"
+            logging.debug("Retrieving round_info from S3")
+            round_info = self.s3_client.receive_from_s3(s3_key)
+        else:
+            round_info_filename = "mpc_data/round_info"
+            self.lock.acquire()
+            with open(round_info_filename, "rb") as round_info_file:
+                round_info = pickle.load(round_info_file)
+
+        num_clients = len(round_info["selected_clients"])
+
+        # Store the client's weights before encryption in a file for testing
+        weights_filename = (
+            f"mpc_data/raw_weights_round{round_info['round_number']}"
+            f"_client{self.client_id}"
+        )
+        file = open(weights_filename, "w", encoding="utf8")
+        file.write(str(data))
+        file.close()
+
+        # Split weights randomly into n shares
+        # Initialize data_shares to the shape of data
+        data_shares = [copy.deepcopy(data) for i in range(num_clients)]
+
+        # Iterate over the keys of data to split
+        for key in data.keys():
+            # multiply by num_samples used to train the client
+            data[key] *= round_info[f"client_{self.client_id}_info"]["num_samples"]
+
+            tensor_shares = self.split_tensor(data[key], num_clients)
+
+            # Store tensor_shares into data_shares for the particular key
+            for i in range(num_clients):
+                data_shares[i][key] = tensor_shares[i]
+
+        # Store secret shares in round_info
+        for i, client_id in enumerate(round_info["selected_clients"]):
+            # Skip the client itself
+            if client_id == self.client_id:
+                # keep track of the index to return the client's share in the end
+                self.client_share_index = i
+                continue
+
+            round_info[f"client_{client_id}_{self.client_id}_info"][
+                "data"
+            ] = data_shares[i]
+
+        logging.debug("Print round_info keys before filling client data")
+        logging.debug(round_info.keys())
+
+        # Store round_info object
+        if hasattr(Config().server, "s3_endpoint_url"):
+            self.s3_client.put_to_s3(s3_key, round_info)
+            lock.release()
+            logging.info("[%s] Released Zookeeper lock", self)
+            self.zk.stop()
+        else:
+            with open(round_info_filename, "wb") as round_info_file:
+                pickle.dump(round_info, round_info_file)
+            self.lock.release()
+
+        return data_shares[self.client_share_index]

--- a/plato/processors/registry.py
+++ b/plato/processors/registry.py
@@ -38,6 +38,8 @@ if not (
         send_mask,
         structured_pruning,
         unstructured_pruning,
+        mpc_model_encrypt_additive,
+        mpc_model_encrypt_shamir,
     )
 
     registered_processors = {
@@ -63,6 +65,8 @@ if not (
         "send_mask": send_mask.Processor,
         "structured_pruning": structured_pruning.Processor,
         "unstructured_pruning": unstructured_pruning.Processor,
+        "mpc_model_encrypt_additive": mpc_model_encrypt_additive.Processor,
+        "mpc_model_encrypt_shamir": mpc_model_encrypt_shamir.Processor,
     }
 
 

--- a/plato/servers/base.py
+++ b/plato/servers/base.py
@@ -392,6 +392,8 @@ class Server:
         if mp.get_start_method(allow_none=True) != "spawn":
             mp.set_start_method("spawn", force=True)
 
+        lock = mp.Lock()
+
         for client_id in range(starting_id, total_processes + starting_id):
             if as_server:
                 port = int(Config().server.port) + client_id
@@ -405,10 +407,20 @@ class Server:
                 proc.start()
             else:
                 logging.info("Starting client #%d's process.", client_id)
-                proc = mp.Process(
-                    target=run, args=(client_id, None, client, None, None, None)
-                )
+                if hasattr(Config.clients, "type") and Config().clients.type == "mpc":
+                    # clients of "mpc" type needs synchronization, when communicating through files
+                    proc = mp.Process(
+                        target=run,
+                        args=(client_id, None, client, None, None, None, lock),
+                    )
+                else:
+                    proc = mp.Process(
+                        target=run, args=(client_id, None, client, None, None, None)
+                    )
                 proc.start()
+        # sleep is inserted to bypass this issue:
+        # https://superfastpython.com/filenotfounderror-multiprocessing-python/
+        time.sleep(5)
 
     async def _close_connections(self):
         """Closes all socket.io connections after training completes."""

--- a/plato/servers/fedavg_mpc_additive.py
+++ b/plato/servers/fedavg_mpc_additive.py
@@ -1,0 +1,369 @@
+"""
+A simple federated learning server using federated averaging and MPC with additive secret sharing.
+"""
+
+import asyncio
+import logging
+import os
+import random
+import pickle
+
+from plato.algorithms import registry as algorithms_registry
+from plato.config import Config
+from plato.datasources import registry as datasources_registry
+from plato.processors import registry as processor_registry
+from plato.samplers import all_inclusive
+from plato.servers import base
+from plato.trainers import registry as trainers_registry
+from plato.utils import csv_processor, fonts
+from plato.utils import s3
+
+
+class Server(base.Server):
+    """Federated learning server using federated averaging and MPC with additive secret sharing."""
+
+    def __init__(
+        self, model=None, datasource=None, algorithm=None, trainer=None, callbacks=None
+    ):
+        super().__init__(callbacks=callbacks)
+
+        self.custom_model = model
+        self.model = None
+
+        self.custom_algorithm = algorithm
+        self.algorithm = None
+
+        self.custom_trainer = trainer
+        self.trainer = None
+
+        self.custom_datasource = datasource
+        self.datasource = None
+
+        self.testset = None
+        self.testset_sampler = None
+        self.total_samples = 0
+
+        self.total_clients = Config().clients.total_clients
+        self.clients_per_round = Config().clients.per_round
+
+        self.s3_client = None
+
+        logging.info(
+            "[Server #%d] Started training on %d clients with %d per round.",
+            os.getpid(),
+            self.total_clients,
+            self.clients_per_round,
+        )
+
+    def configure(self) -> None:
+        """
+        Booting the federated learning server by setting up the data, model, and
+        creating the clients.
+        """
+        super().configure()
+
+        total_rounds = Config().trainer.rounds
+        target_accuracy = None
+        target_perplexity = None
+
+        if hasattr(Config().trainer, "target_accuracy"):
+            target_accuracy = Config().trainer.target_accuracy
+        elif hasattr(Config().trainer, "target_perplexity"):
+            target_perplexity = Config().trainer.target_perplexity
+
+        if target_accuracy:
+            logging.info(
+                "Training: %s rounds or accuracy above %.1f%%\n",
+                total_rounds,
+                100 * target_accuracy,
+            )
+        elif target_perplexity:
+            logging.info(
+                "Training: %s rounds or perplexity below %.1f\n",
+                total_rounds,
+                target_perplexity,
+            )
+        else:
+            logging.info("Training: %s rounds\n", total_rounds)
+
+        self.init_trainer()
+
+        # Prepares this server for processors that processes outbound and inbound
+        # data payloads
+        self.outbound_processor, self.inbound_processor = processor_registry.get(
+            "Server", server_id=os.getpid(), trainer=self.trainer
+        )
+
+        if not (hasattr(Config().server, "do_test") and not Config().server.do_test):
+            if self.datasource is None and self.custom_datasource is None:
+                self.datasource = datasources_registry.get(client_id=0)
+            elif self.datasource is None and self.custom_datasource is not None:
+                self.datasource = self.custom_datasource()
+
+            self.testset = self.datasource.get_test_set()
+            if hasattr(Config().data, "testset_size"):
+                self.testset_sampler = all_inclusive.Sampler(
+                    self.datasource, testing=True
+                )
+
+        # Initialize the test accuracy csv file if clients compute locally
+        if hasattr(Config().clients, "do_test") and Config().clients.do_test:
+            accuracy_csv_file = (
+                f"{Config().params['result_path']}/{os.getpid()}_accuracy.csv"
+            )
+            accuracy_headers = ["round", "client_id", "accuracy"]
+            csv_processor.initialize_csv(
+                accuracy_csv_file, accuracy_headers, Config().params["result_path"]
+            )
+
+        if hasattr(Config().clients, "type") and Config().clients.type == "mpc":
+            if "mpc_data" not in os.listdir("./"):
+                os.mkdir("mpc_data")
+            # erase the file before we start training
+            temp = open("./mpc_data/round_info", "wb")
+            temp.close()
+
+        if hasattr(Config().server, "s3_endpoint_url"):
+            self.s3_client = s3.S3()
+
+    def init_trainer(self) -> None:
+        """Setting up the global model, trainer, and algorithm."""
+        if self.model is None and self.custom_model is not None:
+            self.model = self.custom_model
+
+        if self.trainer is None and self.custom_trainer is None:
+            self.trainer = trainers_registry.get(model=self.model)
+        elif self.trainer is None and self.custom_trainer is not None:
+            self.trainer = self.custom_trainer(model=self.model)
+
+        if self.algorithm is None and self.custom_algorithm is None:
+            self.algorithm = algorithms_registry.get(trainer=self.trainer)
+        elif self.algorithm is None and self.custom_algorithm is not None:
+            self.algorithm = self.custom_algorithm(trainer=self.trainer)
+
+    async def aggregate_deltas(self, updates, deltas_received):
+        """Aggregate weight updates from the clients using federated averaging."""
+        # Extract the total number of samples
+        self.total_samples = sum(update.report.num_samples for update in updates)
+
+        # Perform weighted averaging
+        avg_update = {
+            name: self.trainer.zeros(delta.shape)
+            for name, delta in deltas_received[0].items()
+        }
+
+        for i, update in enumerate(deltas_received):
+            report = updates[i].report
+            num_samples = report.num_samples
+
+            for name, delta in update.items():
+                # Use weighted average by the number of samples
+                avg_update[name] += delta * (num_samples / self.total_samples)
+
+            # Yield to other tasks in the server
+            await asyncio.sleep(0)
+
+        return avg_update
+
+    async def aggregate_weights(self, updates, baseline_weights, weights_received):
+        """Process the client reports by aggregating their weights."""
+        self.total_samples = sum(update.report.num_samples for update in updates)
+
+        aggregated_weights = weights_received[
+            0
+        ]  # initialize with the first client's weights
+
+        # Aggregate weights
+        for i, client_weights in enumerate(weights_received):
+            if i == 0:
+                continue
+
+            for key in aggregated_weights.keys():
+                aggregated_weights[key] += client_weights[key]
+
+        # Divide by total number of samples
+        for key in aggregated_weights.keys():
+            aggregated_weights[key] /= self.total_samples
+
+        return aggregated_weights
+
+    async def _process_reports(self):
+        """Process the client reports by aggregating their weights."""
+        weights_received = [update.payload for update in self.updates]
+
+        weights_received = self.weights_received(weights_received)
+        self.callback_handler.call_event("on_weights_received", self, weights_received)
+
+        # Extract the current model weights as the baseline
+        baseline_weights = self.algorithm.extract_weights()
+
+        if hasattr(self, "aggregate_weights"):
+            # Runs a server aggregation algorithm using weights rather than deltas
+            logging.info(
+                "[Server #%d] Aggregating model weights directly rather than weight deltas.",
+                os.getpid(),
+            )
+            updated_weights = await self.aggregate_weights(
+                self.updates, baseline_weights, weights_received
+            )
+
+            # Loads the new model weights
+            self.algorithm.load_weights(updated_weights)
+        else:
+            # Computes the weight deltas by comparing the weights received with
+            # the current global model weights
+            deltas_received = self.algorithm.compute_weight_deltas(
+                baseline_weights, weights_received
+            )
+            # Runs a framework-agnostic server aggregation algorithm, such as
+            # the federated averaging algorithm
+            logging.info("[Server #%d] Aggregating model weight deltas.", os.getpid())
+            deltas = await self.aggregate_deltas(self.updates, deltas_received)
+            # Updates the existing model weights from the provided deltas
+            updated_weights = self.algorithm.update_weights(deltas)
+            # Loads the new model weights
+            self.algorithm.load_weights(updated_weights)
+
+        # The model weights have already been aggregated, now calls the
+        # corresponding hook and callback
+        self.weights_aggregated(self.updates)
+        self.callback_handler.call_event("on_weights_aggregated", self, self.updates)
+
+        # Testing the global model accuracy
+        if hasattr(Config().server, "do_test") and not Config().server.do_test:
+            # Compute the average accuracy from client reports
+            self.accuracy = self.accuracy_averaging(self.updates)
+            logging.info(
+                "[%s] Average client accuracy: %.2f%%.", self, 100 * self.accuracy
+            )
+        else:
+            # Testing the updated model directly at the server
+            logging.info("[%s] Started model testing.", self)
+            self.accuracy = self.trainer.test(self.testset, self.testset_sampler)
+
+        if hasattr(Config().trainer, "target_perplexity"):
+            logging.info(
+                fonts.colourize(
+                    f"[{self}] Global model perplexity: {self.accuracy:.2f}\n"
+                )
+            )
+        else:
+            logging.info(
+                fonts.colourize(
+                    f"[{self}] Global model accuracy: {100 * self.accuracy:.2f}%\n"
+                )
+            )
+
+        self.clients_processed()
+        self.callback_handler.call_event("on_clients_processed", self)
+
+    def clients_processed(self) -> None:
+        """Additional work to be performed after client reports have been processed."""
+
+    def get_logged_items(self) -> dict:
+        """Get items to be logged by the LogProgressCallback class in a .csv file."""
+        return {
+            "round": self.current_round,
+            "accuracy": self.accuracy,
+            "elapsed_time": self.wall_time - self.initial_wall_time,
+            "comm_time": max(update.report.comm_time for update in self.updates),
+            "round_time": max(
+                update.report.training_time + update.report.comm_time
+                for update in self.updates
+            ),
+            "comm_overhead": self.comm_overhead,
+        }
+
+    @staticmethod
+    def accuracy_averaging(updates):
+        """Compute the average accuracy across clients."""
+        # Get total number of samples
+        total_samples = sum(update.report.num_samples for update in updates)
+
+        # Perform weighted averaging
+        accuracy = 0
+        for update in updates:
+            accuracy += update.report.accuracy * (
+                update.report.num_samples / total_samples
+            )
+
+        return accuracy
+
+    def weights_received(self, weights_received):
+        """
+        Method called after the updated weights have been received.
+        """
+        # Load round_info object
+        if self.s3_client is not None:
+            s3_key = "round_info"
+            logging.debug("Retrieving round_info from S3")
+            round_info = self.s3_client.receive_from_s3(s3_key)
+        else:
+            round_info_filename = "./mpc_data/round_info"
+            logging.debug("Retrieving round_info from file")
+            with open(round_info_filename, "rb") as round_info_file:
+                round_info = pickle.load(round_info_file)
+
+        # If there is only 1 client per round, skip the following step
+        if len(round_info["selected_clients"]) == 1:
+            return weights_received
+
+        # Combine the client's weights share with weights shares sent from other clients
+        for i, client in enumerate(round_info["selected_clients"]):
+            for key in weights_received[i].keys():
+                weights_received[i][key] += round_info[f"client_{client}_info"]["data"][
+                    key
+                ]
+
+        # Store the combined weights in files for testing
+        for i, client in enumerate(round_info["selected_clients"]):
+            encrypted_weights_filename = (
+                "mpc_data/encrypted_weights_round%s_client%s"
+                % (round_info["round_number"], client)
+            )
+            with open(encrypted_weights_filename, "w") as file:
+                # pickle.dump(weights_received[i], file)
+                file.write(str(weights_received[i]))
+
+        return weights_received
+
+    def weights_aggregated(self, updates):
+        """
+        Method called after the updated weights have been aggregated.
+        """
+
+    def choose_clients(self, clients_pool, clients_count):
+        """Chooses a subset of the clients to participate in each round."""
+        assert clients_count <= len(clients_pool)
+        random.setstate(self.prng_state)
+
+        # Select clients randomly
+        selected_clients = random.sample(clients_pool, clients_count)
+
+        round_info = {
+            "round_number": self.current_round,
+            "selected_clients": selected_clients,
+        }
+
+        for client in selected_clients:
+            round_info[f"client_{client}_info"] = {"num_samples": None, "data": None}
+
+        # Store selected clients info into a file or S3 bucket
+        if self.s3_client is not None:
+            s3_key = "round_info"
+            self.s3_client.put_to_s3(s3_key, round_info)
+            logging.debug(
+                "[%s] Stored information for the current round in an S3 bucket", self
+            )
+        else:
+            round_info_filename = "mpc_data/round_info"
+            with open(round_info_filename, "wb") as round_info_file:
+                pickle.dump(round_info, round_info_file)
+            logging.debug(
+                "[%s] Stored information for the current round in file mpc_data/round_info",
+                self,
+            )
+
+        self.prng_state = random.getstate()
+        logging.info("[%s] Selected clients: %s", self, selected_clients)
+        return selected_clients

--- a/plato/servers/fedavg_mpc_shamir.py
+++ b/plato/servers/fedavg_mpc_shamir.py
@@ -1,0 +1,480 @@
+"""
+A simple federated learning server using federated averaging and MPC with Shamir secret sharing.
+"""
+
+import asyncio
+import logging
+import os
+import random
+import pickle
+import math
+
+import torch
+import numpy as np
+
+from plato.algorithms import registry as algorithms_registry
+from plato.config import Config
+from plato.datasources import registry as datasources_registry
+from plato.processors import registry as processor_registry
+from plato.samplers import all_inclusive
+from plato.servers import base
+from plato.trainers import registry as trainers_registry
+from plato.utils import csv_processor, fonts
+from plato.utils import s3
+
+
+class fraction:
+    """Used in computation of Lagrange terms in decryption of Shamir tensors"""
+
+    num = 0  # numerator
+    den = 0  # denominator
+
+    def __init__(self, num, den):
+        self.num = num
+        self.den = den
+
+    def reduce_frac(self):
+        """Divide numerator and denominator by their greatest common divisor"""
+        gcd = math.gcd(int(self.num), int(self.den))
+        if gcd == 0:
+            return
+        self.num = int(self.num / gcd)
+        self.den = int(self.den / gcd)
+
+    def mult(self, frac):
+        """Multiply two fractions"""
+        temp_frac = fraction(self.num * frac.num, self.den * frac.den)
+        temp_frac.reduce_frac()
+        return temp_frac
+
+    def add(self, frac):
+        """Add two fractions"""
+        temp_frac = fraction(
+            self.num * frac.den + self.den * frac.num, self.den * frac.den
+        )
+        temp_frac.reduce_frac()
+        return temp_frac
+
+
+class Server(base.Server):
+    """Federated learning server using federated averaging and MPC with Shamir secret sharing."""
+
+    def __init__(
+        self, model=None, datasource=None, algorithm=None, trainer=None, callbacks=None
+    ):
+        super().__init__(callbacks=callbacks)
+
+        self.custom_model = model
+        self.model = None
+
+        self.custom_algorithm = algorithm
+        self.algorithm = None
+
+        self.custom_trainer = trainer
+        self.trainer = None
+
+        self.custom_datasource = datasource
+        self.datasource = None
+
+        self.testset = None
+        self.testset_sampler = None
+        self.total_samples = 0
+
+        self.total_clients = Config().clients.total_clients
+        self.clients_per_round = Config().clients.per_round
+
+        self.s3_client = None
+
+        logging.info(
+            "[Server #%d] Started training on %d clients with %d per round.",
+            os.getpid(),
+            self.total_clients,
+            self.clients_per_round,
+        )
+
+    def configure(self) -> None:
+        """
+        Booting the federated learning server by setting up the data, model, and
+        creating the clients.
+        """
+        super().configure()
+
+        total_rounds = Config().trainer.rounds
+        target_accuracy = None
+        target_perplexity = None
+
+        if hasattr(Config().trainer, "target_accuracy"):
+            target_accuracy = Config().trainer.target_accuracy
+        elif hasattr(Config().trainer, "target_perplexity"):
+            target_perplexity = Config().trainer.target_perplexity
+
+        if target_accuracy:
+            logging.info(
+                "Training: %s rounds or accuracy above %.1f%%\n",
+                total_rounds,
+                100 * target_accuracy,
+            )
+        elif target_perplexity:
+            logging.info(
+                "Training: %s rounds or perplexity below %.1f\n",
+                total_rounds,
+                target_perplexity,
+            )
+        else:
+            logging.info("Training: %s rounds\n", total_rounds)
+
+        self.init_trainer()
+
+        # Prepares this server for processors that processes outbound and inbound
+        # data payloads
+        self.outbound_processor, self.inbound_processor = processor_registry.get(
+            "Server", server_id=os.getpid(), trainer=self.trainer
+        )
+
+        if not (hasattr(Config().server, "do_test") and not Config().server.do_test):
+            if self.datasource is None and self.custom_datasource is None:
+                self.datasource = datasources_registry.get(client_id=0)
+            elif self.datasource is None and self.custom_datasource is not None:
+                self.datasource = self.custom_datasource()
+
+            self.testset = self.datasource.get_test_set()
+            if hasattr(Config().data, "testset_size"):
+                self.testset_sampler = all_inclusive.Sampler(
+                    self.datasource, testing=True
+                )
+
+        # Initialize the test accuracy csv file if clients compute locally
+        if hasattr(Config().clients, "do_test") and Config().clients.do_test:
+            accuracy_csv_file = (
+                f"{Config().params['result_path']}/{os.getpid()}_accuracy.csv"
+            )
+            accuracy_headers = ["round", "client_id", "accuracy"]
+            csv_processor.initialize_csv(
+                accuracy_csv_file, accuracy_headers, Config().params["result_path"]
+            )
+
+        if hasattr(Config().server, "s3_endpoint_url"):
+            self.s3_client = s3.S3()
+
+    def init_trainer(self) -> None:
+        """Setting up the global model, trainer, and algorithm."""
+        if self.model is None and self.custom_model is not None:
+            self.model = self.custom_model
+
+        if self.trainer is None and self.custom_trainer is None:
+            self.trainer = trainers_registry.get(model=self.model)
+        elif self.trainer is None and self.custom_trainer is not None:
+            self.trainer = self.custom_trainer(model=self.model)
+
+        if self.algorithm is None and self.custom_algorithm is None:
+            self.algorithm = algorithms_registry.get(trainer=self.trainer)
+        elif self.algorithm is None and self.custom_algorithm is not None:
+            self.algorithm = self.custom_algorithm(trainer=self.trainer)
+
+    async def aggregate_deltas(self, updates, deltas_received):
+        """Aggregate weight updates from the clients using federated averaging."""
+        # Extract the total number of samples
+        self.total_samples = sum(update.report.num_samples for update in updates)
+
+        # Perform weighted averaging
+        avg_update = {
+            name: self.trainer.zeros(delta.shape)
+            for name, delta in deltas_received[0].items()
+        }
+
+        for i, update in enumerate(deltas_received):
+            report = updates[i].report
+            num_samples = report.num_samples
+
+            for name, delta in update.items():
+                # Use weighted average by the number of samples
+                avg_update[name] += delta * (num_samples / self.total_samples)
+
+            # Yield to other tasks in the server
+            await asyncio.sleep(0)
+
+        return avg_update
+
+    async def aggregate_weights(self, updates, baseline_weights, weights_received):
+        """Process the client reports by aggregating their weights."""
+        self.total_samples = sum(update.report.num_samples for update in updates)
+
+        aggregated_weights = weights_received[
+            0
+        ]  # initialize with the first client's weights
+
+        # Aggregate weights
+        for i, client_weights in enumerate(weights_received):
+            if i == 0:
+                continue
+
+            for key in aggregated_weights.keys():
+                aggregated_weights[key] += client_weights[key]
+
+        # Divide by total number of samples
+        for key in aggregated_weights.keys():
+            aggregated_weights[key] /= self.total_samples
+
+        return aggregated_weights
+
+    async def _process_reports(self):
+        """Process the client reports by aggregating their weights."""
+        weights_received = [update.payload for update in self.updates]
+
+        weights_received = self.weights_received(weights_received)
+        self.callback_handler.call_event("on_weights_received", self, weights_received)
+
+        # Extract the current model weights as the baseline
+        baseline_weights = self.algorithm.extract_weights()
+
+        if hasattr(self, "aggregate_weights"):
+            # Runs a server aggregation algorithm using weights rather than deltas
+            logging.info(
+                "[Server #%d] Aggregating model weights directly rather than weight deltas.",
+                os.getpid(),
+            )
+            updated_weights = await self.aggregate_weights(
+                self.updates, baseline_weights, weights_received
+            )
+
+            # Loads the new model weights
+            self.algorithm.load_weights(updated_weights)
+        else:
+            # Computes the weight deltas by comparing the weights received with
+            # the current global model weights
+            deltas_received = self.algorithm.compute_weight_deltas(
+                baseline_weights, weights_received
+            )
+            # Runs a framework-agnostic server aggregation algorithm, such as
+            # the federated averaging algorithm
+            logging.info("[Server #%d] Aggregating model weight deltas.", os.getpid())
+            deltas = await self.aggregate_deltas(self.updates, deltas_received)
+            # Updates the existing model weights from the provided deltas
+            updated_weights = self.algorithm.update_weights(deltas)
+            # Loads the new model weights
+            self.algorithm.load_weights(updated_weights)
+
+        # The model weights have already been aggregated, now calls the
+        # corresponding hook and callback
+        self.weights_aggregated(self.updates)
+        self.callback_handler.call_event("on_weights_aggregated", self, self.updates)
+
+        # Testing the global model accuracy
+        if hasattr(Config().server, "do_test") and not Config().server.do_test:
+            # Compute the average accuracy from client reports
+            self.accuracy = self.accuracy_averaging(self.updates)
+            logging.info(
+                "[%s] Average client accuracy: %.2f%%.", self, 100 * self.accuracy
+            )
+        else:
+            # Testing the updated model directly at the server
+            logging.info("[%s] Started model testing.", self)
+            self.accuracy = self.trainer.test(self.testset, self.testset_sampler)
+
+        if hasattr(Config().trainer, "target_perplexity"):
+            logging.info(
+                fonts.colourize(
+                    f"[{self}] Global model perplexity: {self.accuracy:.2f}\n"
+                )
+            )
+        else:
+            logging.info(
+                fonts.colourize(
+                    f"[{self}] Global model accuracy: {100 * self.accuracy:.2f}%\n"
+                )
+            )
+
+        self.clients_processed()
+        self.callback_handler.call_event("on_clients_processed", self)
+
+    def clients_processed(self) -> None:
+        """Additional work to be performed after client reports have been processed."""
+
+    def get_logged_items(self) -> dict:
+        """Get items to be logged by the LogProgressCallback class in a .csv file."""
+        return {
+            "round": self.current_round,
+            "accuracy": self.accuracy,
+            "elapsed_time": self.wall_time - self.initial_wall_time,
+            "comm_time": max(update.report.comm_time for update in self.updates),
+            "round_time": max(
+                update.report.training_time + update.report.comm_time
+                for update in self.updates
+            ),
+            "comm_overhead": self.comm_overhead,
+        }
+
+    @staticmethod
+    def accuracy_averaging(updates):
+        """Compute the average accuracy across clients."""
+        # Get total number of samples
+        total_samples = sum(update.report.num_samples for update in updates)
+
+        # Perform weighted averaging
+        accuracy = 0
+        for update in updates:
+            accuracy += update.report.accuracy * (
+                update.report.num_samples / total_samples
+            )
+
+        return accuracy
+
+    def recover_secret(self, x, y, M):
+        """
+        recover the secret from the given points
+        Uses Lagrange Basis Polynomial, finds poly[0]
+        """
+        ans = fraction(0, 1)
+
+        for i in range(0, M):
+            l = fraction(y[i], 1)
+            for j in range(0, M):
+                # compute the lagrange terms
+                if i != j:
+                    temp = fraction(0 - x[j], x[i] - x[j])
+                    l = l.mult(temp)
+            ans = ans.add(l)
+
+        return (ans.num / ans.den) / 1000000
+
+    def decrypt_tensor(self, tensors, M=None):
+        """Iteratively decrypt a tensor by calling recover_secret"""
+        tensor_size = list(tensors.size())
+        N = tensor_size[0]  # number of participating clients
+        if M is None:  # number of points used in decryption
+            M = max(N - 2, 1)
+
+        num_weights = int(math.prod(tensor_size) / (N * 2))
+        coords_shape = [N, num_weights, 2]
+        coords = tensors.view(coords_shape)
+
+        secret_arr = torch.zeros([num_weights])
+        for i in range(num_weights):
+            list_points = torch.zeros([N, 2])
+            # picking the first M points from the N points received (can pick randomly)
+            for j in range(N):
+                list_points[j] = coords[j][i]
+
+            x = np.zeros(N)
+            y = np.zeros(N)
+            for j in range(N):
+                x[j] = list_points[j][0]
+                y[j] = list_points[j][1]
+
+            # get the first M non-repeating x values
+            freq_dict = {}
+            result_x = np.zeros(M)
+            result_y = np.zeros(M)
+            result_idx = 0
+            for idx, elem in enumerate(x):
+                freq_dict[elem] = freq_dict.get(elem, 0) + 1
+                if freq_dict[elem] == 1:
+                    result_x[result_idx] = elem
+                    result_y[result_idx] = y[idx]
+                    result_idx = result_idx + 1
+                    if result_idx == M:
+                        break
+
+            secret_arr[i] = self.recover_secret(result_x, result_y, M)
+
+        tensor_size.pop(0)
+        tensor_size.pop(-1)
+        return secret_arr.view(tensor_size)
+
+    def weights_received(self, weights_received):
+        """
+        Method called after the updated weights have been received.
+        """
+        # Load round_info object
+        if self.s3_client is not None:
+            s3_key = "round_info"
+            logging.debug("Retrieving round_info from S3")
+            round_info = self.s3_client.receive_from_s3(s3_key)
+        else:
+            round_info_filename = "mpc_data/round_info"
+            logging.debug("Retrieving round_info from file")
+            with open(round_info_filename, "rb") as round_info_file:
+                round_info = pickle.load(round_info_file)
+
+        # Store the combined weights in files for testing
+        # for i, client in enumerate(round_info['selected_clients']):
+        #     encrypted_weights_filename = "mpc_data/encrypted_weights_round%s_client%s" % (round_info['round_number'], client)
+        #     with open(encrypted_weights_filename, 'w') as file:
+        #         #pickle.dump(weights_received[i], file)
+        #         file.write(str(weights_received[i]))
+
+        # If there is only 1 client per round, skip the following step
+        if len(round_info["selected_clients"]) == 1:
+            return weights_received
+
+        # Combine the client's weights share with weights shares sent from other clients
+        for i, from_client in enumerate(round_info["selected_clients"]):
+            encrypted_weights_filename = (
+                "mpc_data/encrypted_weights_round%s_client%s"
+                % (round_info["round_number"], from_client)
+            )
+            file = open(encrypted_weights_filename, "w")
+
+            for key in weights_received[i].keys():
+                tensor_size = list(weights_received[i][key].size())
+                tensor_size.insert(0, len(round_info["selected_clients"]))
+                cur_val = torch.zeros(tensor_size)
+                cur_val[0] = weights_received[i][key]
+                insert_idx = 1
+
+                for j, to_client in enumerate(round_info["selected_clients"]):
+                    if j == i:
+                        continue
+                    cur_val[insert_idx] = round_info[
+                        f"client_{to_client}_{from_client}_info"
+                    ]["data"][key]
+                    insert_idx = insert_idx + 1
+                file.write(key)
+                file.write(str(cur_val))
+                weights_received[i][key] = self.decrypt_tensor(cur_val)
+            file.close()
+
+        return weights_received
+
+    def weights_aggregated(self, updates):
+        """
+        Method called after the updated weights have been aggregated.
+        """
+
+    def choose_clients(self, clients_pool, clients_count):
+        """Chooses a subset of the clients to participate in each round."""
+        assert clients_count <= len(clients_pool)
+        random.setstate(self.prng_state)
+
+        # Select clients randomly
+        selected_clients = random.sample(clients_pool, clients_count)
+
+        round_info = {
+            "round_number": self.current_round,
+            "selected_clients": selected_clients,
+        }
+
+        for client_to in selected_clients:
+            round_info[f"client_{client_to}_info"] = {"num_samples": None}
+            for client_from in selected_clients:
+                round_info[f"client_{client_to}_{client_from}_info"] = {"data": None}
+
+        # Store selected clients info into a file or S3 bucket
+        if self.s3_client is not None:
+            s3_key = "round_info"
+            self.s3_client.put_to_s3(s3_key, round_info)
+            logging.debug(
+                "[%s] Stored information for the current round in an S3 bucket", self
+            )
+        else:
+            round_info_filename = "mpc_data/round_info"
+            with open(round_info_filename, "wb") as round_info_file:
+                pickle.dump(round_info, round_info_file)
+            logging.debug(
+                "[%s] Stored information for the current round in file mpc_data/round_info",
+                self,
+            )
+
+        self.prng_state = random.getstate()
+        logging.info("[%s] Selected clients: %s", self, selected_clients)
+        return selected_clients

--- a/plato/servers/registry.py
+++ b/plato/servers/registry.py
@@ -9,7 +9,15 @@ import logging
 
 from plato.config import Config
 
-from plato.servers import fedavg, fedavg_cs, mistnet, fedavg_gan, fedavg_personalized
+from plato.servers import (
+    fedavg,
+    fedavg_cs,
+    mistnet,
+    fedavg_gan,
+    fedavg_personalized,
+    fedavg_mpc_additive,
+    fedavg_mpc_shamir,
+)
 
 if hasattr(Config().server, "type") and Config().server.type == "fedavg_he":
     # FedAvg server with homomorphic encryption supports PyTorch only
@@ -23,7 +31,9 @@ else:
         "fedavg_cross_silo": fedavg_cs.Server,
         "mistnet": mistnet.Server,
         "fedavg_gan": fedavg_gan.Server,
-        "fedavg_personalized": fedavg_personalized.Server
+        "fedavg_personalized": fedavg_personalized.Server,
+        "fedavg_mpc_additive": fedavg_mpc_additive.Server,
+        "fedavg_mpc_shamir": fedavg_mpc_shamir.Server,
     }
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This change adds multiparty computation capability to Plato. It adds an MPC client, 2 MPC servers and 2 MPC outbound_processors to support 2 MPC algorithms: additive and Shamir secret sharing. Training with MPC can be performed both locally with shared files and remotely with S3 as shared storage and ZooKeeper as a distributed lock. To run Plato with MPC, use config files configs/MNIST/fedavg_lenet5_mpc_additive.yml and configs/MNIST/fedavg_lenet5_mpc_shamir.yml. Raw and encrypted model updates are saved under plato/mpc_data for easy comparison.
<!--- Describe motivation and context -->
This work is the ECE496 Capstone project of team 2022539. The purpose of this project is to make Plato's aggregation of model updates more secure using MPC.
<!--- Why is this change required? What problem does it solve? -->
If client model updates are sent to the server in plaintext, it is possible for the attacker to perform model inversion attack to reveal clients' training data based on the model updates. MPC solves this problem by aggregating client model updates without revealing any client's model updates to the server or other clients.
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
Both functional and performance testing of 2 MPC algorithms has been performed. For the functional testing, we verified that the 2 MPC algorithms have no impact on the final accuracy of training and can be performed both locally using shared files and remotely using S3. For the performance testing, we tested both algorithms under local and remote settings with different numbers of rounds and clients. The conclusion is that under a local setting, additive secret sharing has almost no performance overhead (e.g. for 50 rounds, fedavg_lenet5 took 2496.54 seconds, fedavg_lenet5_mpc_additive took 2496.88 seconds), and Shamir secret sharing has a high exponential performance overhead; for the remote setting, both algorithms have high overhead due to the use of S3 and distributed lock.

In addition, regression testings have also been performed to verify that the change has no impact on Plato's normal functionalities.
<!--- Include details of your testing environment, tests ran to see how -->
The testing was performed on a local MacBook laptop with conda environment specified in Plato's documentation. Most tests were based on lenet5 model and fedavg algorithm.
<!--- your change affects other areas of the code, etc. -->
This change should have no impact on other areas of the code. The new MPC client and servers are implemented as child classes and the MPC encryption part is added as outbound_processors. Only minimum changes were made to the base client and server to add locking, which will only have an impact if MPC client or server is used.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) Fixes #
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been formatted using Black and checked using PyLint.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
