### PR TITLE
Fixed a bug in real-world communication.

### DIFF
--- a/examples/customized/client.yml
+++ b/examples/customized/client.yml
@@ -11,6 +11,8 @@ clients:
     # Should the clients compute test accuracy locally?
     do_test: true
 
+    comm_simulation: false
+
 server:
     address: 127.0.0.1
     port: 8000

--- a/examples/customized/server.yml
+++ b/examples/customized/server.yml
@@ -11,12 +11,16 @@ clients:
     # Should the clients compute test accuracy locally?
     do_test: true
 
+
+    comm_simulation: false
 server:
     address: 127.0.0.1
     port: 8000
 
     # No client processes will be launched by the server
     disable_clients: true
+
+    comm_simulation: false
 
 data:
     # The training and testing dataset

--- a/plato/clients/base.py
+++ b/plato/clients/base.py
@@ -189,6 +189,8 @@ class Client:
         self.configure()
         self._allocate_data()
 
+        self.server_payload = None
+
         if self.comm_simulation:
             payload_filename = response["payload_filename"]
             with open(payload_filename, "rb") as payload_file:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Describe motivation and context -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR fixes a bug that in real-world communication environment (i.e., comm_simulate is false), the `server_payload` of client persists as a list when current iteration is done, leading to an error in next round since client expects `server_payload` to be state_dict instead of list.
```
TypeError: Expected state_dict to be dict-like, got <class 'list'>.
```

This bug is because `server_payload` was not reset to None after first round. When receiving new weights, client will [create a list and append the new weights](https://github.com/TL-System/plato/blob/2974ade33e7c2a9b596d64f96486252f2f4feb42/plato/clients/base.py#L304). As a result, in the second round, `server_payload` becomes a list of state_dict.

When comm_simulate is set to true, server_payload is always [reinitialized](https://github.com/TL-System/plato/blob/2974ade33e7c2a9b596d64f96486252f2f4feb42/plato/clients/base.py#L195C64-L195C64) from `pickle.loads` therefore it is always a dict.


## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

This PR has been tested by setting `comm_simulate` to false in `examples/customized` and run server and client by
```
python custom_server.py -c server.yml
python custom_client.py -c client.yml -i 1
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) Fixes #
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been formatted using Black and checked using PyLint.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
