### PR TITLE
Fixes a parameter counting bug for single value parameters in MaskCrypt.

### DIFF
--- a/examples/secure_aggregation/maskcrypt/maskcrypt_CIFAR10_resnet18.yml
+++ b/examples/secure_aggregation/maskcrypt/maskcrypt_CIFAR10_resnet18.yml
@@ -1,0 +1,66 @@
+clients:
+  # Type
+  type: simple_he
+
+  # The total number of clients
+  total_clients: 10
+
+  # encrypt ratio
+  encrypt_ratio: 0.1
+  random_mask: False
+
+  # The number of clients selected in each round
+  per_round: 5
+
+  # Should the clients compute test accuracy locally?
+  do_test: false
+
+server:
+  address: 127.0.0.1
+  port: 8001
+  random_seed: 1
+  simulate_wall_time: true
+
+data:
+  # The training and testing dataset
+  datasource: CIFAR10
+
+  # Number of samples in each partition
+  partition_size: 1000
+
+  # IID or non-IID?
+  sampler: iid
+
+trainer:
+  # The maximum number of training rounds
+  rounds: 25
+
+  # The maximum number of clients running concurrently
+  max_concurrency: 5
+
+  # The target accuracy
+  target_accuracy: 0.99
+
+  # The machine learning model
+  model_name: resnet_18
+
+  # Number of epoches for local training in each communication round
+  epochs: 5
+  batch_size: 32
+  optimizer: SGD
+algorithm:
+  # Aggregation algorithm
+  type: fedavg
+
+results:
+  # Write the following parameter(s) into a CSV
+  types: round, elapsed_time, accuracy, comm_overhead
+
+parameters:
+  model:
+    num_classes: 10
+
+  optimizer:
+      lr: 0.01
+      momentum: 0.9
+      weight_decay: 0.0

--- a/plato/servers/fedavg_he.py
+++ b/plato/servers/fedavg_he.py
@@ -1,6 +1,7 @@
 """
 A federated learning server using federated averaging to aggregate updates after homomorphic encryption.
 """
+
 from functools import reduce
 from plato.servers import fedavg
 from plato.utils import homo_enc
@@ -36,7 +37,7 @@ class Server(fedavg.Server):
 
         for key in extract_model.keys():
             self.weight_shapes[key] = extract_model[key].size()
-            self.para_nums[key] = reduce(lambda a, b: a * b, self.weight_shapes[key])
+            self.para_nums[key] = extract_model[key].numel()
 
         self.encrypted_model = homo_enc.encrypt_weights(
             extract_model, True, self.context, []


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Describe motivation and context -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR fixes a bug where single value parameters (e.g., `num_batches_tracked` in BatchNorm layers) led to errors when counting parameter numbers, which previously assumed tensor parameter inputs. The bug is fixed by using the `numel()` method to obtain the number of parameters rather than multiplying tensor shapes.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
The functionality has been tested by running the MaskCrypt example with ResNet-18.
```
python examples/secure_aggregation/maskcrypt/maskcrypt.py -c examples/secure_aggregation/maskcrypt/maskcrypt_CIFAR10_resnet18.yml
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) Fixes #379 
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been formatted using Black and checked using PyLint.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.


