### PR TITLE
[codex] Fix ty check errors

### DIFF
--- a/examples/model_search/fedtp/hypernetworks.py
+++ b/examples/model_search/fedtp/hypernetworks.py
@@ -50,7 +50,7 @@ class ViTHyper(nn.Module):
             num_embeddings=n_nodes, embedding_dim=embedding_dim
         )
 
-        layers = [
+        layers: list[nn.Module] = [
             spectral_norm(nn.Linear(embedding_dim, hidden_dim))
             if spec_norm
             else nn.Linear(embedding_dim, hidden_dim),
@@ -144,7 +144,7 @@ class ShakesHyper(nn.Module):
             num_embeddings=n_nodes, embedding_dim=embedding_dim
         )
 
-        layers = [
+        layers: list[nn.Module] = [
             spectral_norm(nn.Linear(embedding_dim, hidden_dim))
             if spec_norm
             else nn.Linear(embedding_dim, hidden_dim),

--- a/examples/reinforcement_learning/fei/fei_agent.py
+++ b/examples/reinforcement_learning/fei/fei_agent.py
@@ -73,8 +73,8 @@ class RLAgent(rl_agent.RLAgent):
             )
 
         # Record test accuracy of the latest 5 rounds/steps
-        self.pre_acc = deque(5 * [0], maxlen=5)
-        self.test_accuracy = None
+        self.pre_acc: deque[float] = deque(5 * [0.0], maxlen=5)
+        self.test_accuracy: float | None = None
         self.num_samples = None
         self.client_ids = []
 
@@ -166,6 +166,8 @@ class RLAgent(rl_agent.RLAgent):
     def get_done(self):
         """Get done condition for agent."""
         if Config().algorithm.mode == "train":
+            if self.test_accuracy is None:
+                return False
             self.pre_acc.append(self.test_accuracy)
             if stdev(self.pre_acc) < Config().algorithm.theta:
                 logging.info("[RL Agent] Episode #%d ended.", self.current_episode)

--- a/examples/server_aggregation/moon/moon_trainer.py
+++ b/examples/server_aggregation/moon/moon_trainer.py
@@ -116,7 +116,7 @@ class MoonTrainingStepStrategy(TrainingStepStrategy):
         moon_model = cast(MoonModel, model)
         _, local_projection, logits = moon_model.forward_with_projection(examples)
 
-        outputs = {
+        outputs: dict[str, torch.Tensor | list[torch.Tensor]] = {
             "logits": logits,
             "local_projection": local_projection,
         }

--- a/examples/split_learning/llm_split_learning/split_learning_trainer.py
+++ b/examples/split_learning/llm_split_learning/split_learning_trainer.py
@@ -14,6 +14,7 @@ from torch.utils.data import RandomSampler, Sampler
 from transformers import (
     AutoTokenizer,
     HfArgumentParser,
+    PreTrainedTokenizerBase,
     TrainingArguments,
     default_data_collator,
 )
@@ -67,7 +68,7 @@ class SampledHuggingFaceTrainer(HuggingFaceTrainer):
         args,
         train_dataset,
         eval_dataset,
-        tokenizer,
+        tokenizer: PreTrainedTokenizerBase,
         data_collator,
         sampler,
         callbacks,
@@ -78,7 +79,7 @@ class SampledHuggingFaceTrainer(HuggingFaceTrainer):
             args=args,
             train_dataset=train_dataset,
             eval_dataset=eval_dataset,
-            tokenizer=tokenizer,
+            processing_class=tokenizer,
             data_collator=data_collator,
             compute_metrics=compute_metrics,
             preprocess_logits_for_metrics=preprocess_logits_for_metrics,
@@ -116,7 +117,7 @@ class LLMSplitLearningTestingStrategy(TestingStrategy):
 
     def __init__(self, tokenizer, training_args):
         """Initialize with tokenizer and training arguments."""
-        self.tokenizer = tokenizer
+        self.tokenizer: PreTrainedTokenizerBase = tokenizer
         self.training_args = training_args
 
     def test_model(self, model, config, testset, sampler, context):
@@ -177,7 +178,7 @@ class LLMTokenizerCallback(TrainerCallback):
 
     def __init__(self):
         """Initialize the callback."""
-        self.tokenizer = None
+        self.tokenizer: PreTrainedTokenizerBase | None = None
 
     def on_trainer_initialized(self, trainer, **kwargs):
         """Initialize tokenizer and resize embeddings if needed."""
@@ -188,15 +189,19 @@ class LLMTokenizerCallback(TrainerCallback):
             "use_auth_token": None,
         }
         model_name = Config().trainer.model_name
-        self.tokenizer = AutoTokenizer.from_pretrained(model_name, **tokenizer_kwargs)
+        self.tokenizer = cast(
+            PreTrainedTokenizerBase,
+            AutoTokenizer.from_pretrained(model_name, **tokenizer_kwargs),
+        )
 
         # Resize embeddings to avoid index errors
         embedding_size = trainer.model.get_input_embeddings().weight.shape[0]
-        if len(self.tokenizer) > embedding_size:
-            trainer.model.resize_token_embeddings(len(self.tokenizer))
+        tokenizer = self.tokenizer
+        if len(tokenizer) > embedding_size:
+            trainer.model.resize_token_embeddings(len(tokenizer))
 
         # Store tokenizer in trainer for easy access
-        trainer.tokenizer = self.tokenizer
+        trainer.tokenizer = tokenizer
 
 
 class LLMTrainingArgsCallback(TrainerCallback):

--- a/examples/unlearning/knot/knot_huggingface_trainer.py
+++ b/examples/unlearning/knot/knot_huggingface_trainer.py
@@ -57,7 +57,7 @@ class ClusteredHuggingFaceTestingStrategy:
                 args=self.training_args,
                 train_dataset=None,
                 eval_dataset=testset,
-                tokenizer=self.tokenizer,
+                processing_class=self.tokenizer,
                 data_collator=default_data_collator,
             )
 

--- a/plato/datasources/datalib/data_utils.py
+++ b/plato/datasources/datalib/data_utils.py
@@ -10,6 +10,14 @@ import shutil
 import numpy as np
 
 
+def _asdict_if_available(value):
+    """Return a dict from namedtuple-like objects when `_asdict` exists."""
+    asdict_fn = getattr(value, "_asdict", None)
+    if callable(asdict_fn):
+        return asdict_fn()
+    return None
+
+
 def config_to_dict(plato_config):
     """Convert the plato config (can be nested one) instance to the dict."""
     # convert the whole to dict - OrderedDict
@@ -17,18 +25,16 @@ def config_to_dict(plato_config):
 
     def to_dict(elem):
         for key, value in elem.items():
-            try:
-                value = value._asdict()
+            value_dict = _asdict_if_available(value)
+            if value_dict is not None:
+                value = value_dict
                 elem[key] = to_dict(value)
-            except:
-                pass
             if isinstance(value, list):
                 for idx, value_item in enumerate(value):
-                    try:
-                        value_item = value_item._asdict()
+                    value_item_dict = _asdict_if_available(value_item)
+                    if value_item_dict is not None:
+                        value_item = value_item_dict
                         value[idx] = to_dict(value_item)
-                    except:
-                        pass
                 elem[key] = value
         return elem
 

--- a/plato/datasources/datalib/video_transform.py
+++ b/plato/datasources/datalib/video_transform.py
@@ -34,7 +34,7 @@ class VideoClassificationTrainTransformer:
         std=(0.22803, 0.22145, 0.216989),
         hflip_prob=0.5,
     ):
-        trans = [
+        trans: list[nn.Module] = [
             ConvertBHWCtoBCHW(),
             transforms.ConvertImageDtype(torch.float32),
             transforms.Resize(resize_size),

--- a/plato/datasources/huggingface.py
+++ b/plato/datasources/huggingface.py
@@ -109,7 +109,15 @@ def _coerce_token_sequence(value: Any, *, field_name: str) -> list[int]:
             f"Expected '{field_name}' to be a token sequence, got {type(value)}."
         )
 
-    return [int(token) for token in value]
+    tokens: list[int] = []
+    for token in value:
+        try:
+            tokens.append(int(cast(Any, token)))
+        except (TypeError, ValueError) as exc:
+            raise TypeError(
+                f"Expected '{field_name}' to contain token ids, got {type(token)}."
+            ) from exc
+    return tokens
 
 
 def _normalize_chat_template_output(
@@ -213,8 +221,10 @@ class DataSource(base.DataSource):
         }
 
         self.config = AutoConfig.from_pretrained(model_name, **config_kwargs)
-        self.tokenizer = AutoTokenizer.from_pretrained(
-            model_name, config=self.config, **tokenizer_kwargs
+        self.tokenizer: Any = AutoTokenizer.from_pretrained(
+            model_name,
+            config=self.config,
+            **tokenizer_kwargs,
         )
         self.tok_logger = hf_logging.get_logger("transformers.tokenization_utils_base")
 
@@ -229,15 +239,22 @@ class DataSource(base.DataSource):
         self.block_size = getattr(data_cfg, "block_size", 128)
         self.saved_data_path = saved_data_path
 
-        self.train_split_name = _resolve_split_name(self.dataset, train_split_name)
+        if not isinstance(self.dataset, Mapping):
+            raise TypeError(
+                "HuggingFace datasource expects a dataset mapping keyed by split name."
+            )
+        dataset_mapping = cast(Mapping[str, Any], self.dataset)
+        self.train_split_name = _resolve_split_name(dataset_mapping, train_split_name)
         self.validation_split_name = _resolve_split_name(
-            self.dataset,
+            dataset_mapping,
             requested_validation_split,
             fallback="test" if requested_validation_split == "validation" else None,
         )
 
-        self.trainset = self.preprocess_split(self.dataset[self.train_split_name])
-        self.testset = self.preprocess_split(self.dataset[self.validation_split_name])
+        self.trainset = self.preprocess_split(dataset_mapping[self.train_split_name])
+        self.testset = self.preprocess_split(
+            dataset_mapping[self.validation_split_name]
+        )
 
     def num_train_examples(self):
         return len(self.require_trainset())

--- a/plato/datasources/lora.py
+++ b/plato/datasources/lora.py
@@ -5,7 +5,7 @@ LoRA-friendly datasource built on HuggingFace datasets.
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, cast
 
 from datasets import Dataset, load_dataset
 from transformers import AutoTokenizer, LlamaTokenizer
@@ -59,10 +59,12 @@ class DataSource(base.DataSource):
         column_names: list[str] = [str(name) for name in column_names_raw]
 
         model_name = Config().trainer.model_name
+        tokenizer: Any
         if "llama" in model_name.lower():
             tokenizer = LlamaTokenizer.from_pretrained(model_name)
         else:
             tokenizer = AutoTokenizer.from_pretrained(model_name)
+        tokenizer = cast(Any, tokenizer)
 
         if tokenizer.pad_token_id is None:
             tokenizer.pad_token = tokenizer.eos_token

--- a/plato/evaluators/lighteval.py
+++ b/plato/evaluators/lighteval.py
@@ -7,7 +7,7 @@ import tempfile
 from contextlib import contextmanager
 from dataclasses import dataclass
 from numbers import Real
-from typing import Any, Iterator
+from typing import Any, Iterator, Protocol, cast
 
 from plato.config import Config
 from plato.evaluators import registry
@@ -49,6 +49,14 @@ class LightevalModelReference:
     tokenizer_name: str | None = None
 
 
+class _ProgressAdvancer(Protocol):
+    def advance(self, message: str) -> None: ...
+
+
+class _ProgressReporter(_ProgressAdvancer, Protocol):
+    def note(self, message: str) -> None: ...
+
+
 def _config_value(config: dict[str, Any] | Any, key: str, default: Any = None) -> Any:
     if isinstance(config, dict):
         return config.get(key, default)
@@ -62,17 +70,20 @@ class _LightevalProgress:
         self.total = total
         self.enabled = bool(_config_value(config, "show_progress", True))
         self._current = 0
-        self._bar = None
+        self._bar: Any | None = None
 
     def __enter__(self):
         if self.enabled:
+            tqdm_factory: Any | None = None
             try:
                 from tqdm.auto import tqdm
             except ImportError:  # pragma: no cover - tqdm is normally available
-                tqdm = None
+                pass
+            else:
+                tqdm_factory = tqdm
 
-            if tqdm is not None:
-                self._bar = tqdm(
+            if tqdm_factory is not None:
+                self._bar = tqdm_factory(
                     total=self.total,
                     desc="Server Lighteval evaluation",
                     unit="stage",
@@ -110,6 +121,12 @@ def _is_numeric_metric(value: Any) -> bool:
     return isinstance(value, Real) and not isinstance(value, bool)
 
 
+def _to_float_metric(value: Any, *, metric_name: str) -> float:
+    if not _is_numeric_metric(value):
+        raise TypeError(f"Lighteval metric '{metric_name}' must be numeric.")
+    return float(cast(Real, value))
+
+
 def _canonical_task_name(task_name: str) -> str:
     prefix, separator, suffix = task_name.rpartition(":")
     if separator and suffix.isdigit():
@@ -141,13 +158,13 @@ def _preferred_task_value(task_metrics: dict[str, Any], task_name: str) -> float
     for metric_name in TASK_METRIC_PREFERENCES.get(task_name, ()):  # pragma: no branch
         metric_value = task_metrics.get(metric_name)
         if _is_numeric_metric(metric_value):
-            return float(metric_value)
+            return _to_float_metric(metric_value, metric_name=metric_name)
 
     for metric_name, metric_value in task_metrics.items():
         if metric_name.endswith("_stderr"):
             continue
         if _is_numeric_metric(metric_value):
-            return float(metric_value)
+            return _to_float_metric(metric_value, metric_name=metric_name)
     return None
 
 
@@ -190,11 +207,20 @@ def _normalize_nested_metrics(raw_metrics: dict[str, Any]) -> dict[str, float]:
         strict_acc = ifeval_metrics.get("prompt_level_strict_acc")
         loose_acc = ifeval_metrics.get("prompt_level_loose_acc")
         if _is_numeric_metric(strict_acc) and _is_numeric_metric(loose_acc):
-            metrics["ifeval_avg"] = (float(strict_acc) + float(loose_acc)) / 2.0
+            metrics["ifeval_avg"] = (
+                _to_float_metric(strict_acc, metric_name="prompt_level_strict_acc")
+                + _to_float_metric(loose_acc, metric_name="prompt_level_loose_acc")
+            ) / 2.0
         elif _is_numeric_metric(strict_acc):
-            metrics["ifeval_avg"] = float(strict_acc)
+            metrics["ifeval_avg"] = _to_float_metric(
+                strict_acc,
+                metric_name="prompt_level_strict_acc",
+            )
         elif _is_numeric_metric(loose_acc):
-            metrics["ifeval_avg"] = float(loose_acc)
+            metrics["ifeval_avg"] = _to_float_metric(
+                loose_acc,
+                metric_name="prompt_level_loose_acc",
+            )
         else:
             fallback = _preferred_task_value(ifeval_metrics, "ifeval")
             if fallback is not None:
@@ -283,7 +309,7 @@ def _resolve_model_reference(
 @contextmanager
 def _materialize_model_reference(
     request: EvaluationInput,
-    progress: _LightevalProgress | None = None,
+    progress: _ProgressReporter | None = None,
 ) -> Iterator[LightevalModelReference]:
     model = request.model
     tokenizer = request.tokenizer
@@ -322,7 +348,7 @@ def _run_lighteval_pipeline(
     tasks: list[str],
     backend: str,
     config: dict[str, Any] | Any,
-    progress: _LightevalProgress | None = None,
+    progress: _ProgressAdvancer | None = None,
 ) -> dict[str, Any]:
     try:
         from lighteval.logging.evaluation_tracker import EvaluationTracker

--- a/plato/processors/registry.py
+++ b/plato/processors/registry.py
@@ -31,7 +31,7 @@ from plato.processors import (
     unstructured_pruning,
 )
 
-registered_processors = {
+registered_processors: dict[str, type[base.Processor]] = {
     "base": base.Processor,
     "compress": compress.Processor,
     "decompress": decompress.Processor,

--- a/plato/samplers/orthogonal.py
+++ b/plato/samplers/orthogonal.py
@@ -70,9 +70,9 @@ class Sampler(base.Sampler):
                 1.0 / len(class_id_list) for i in range(len(class_id_list))
             ]
 
-        target_proportions = [0 for i in range(len(class_list))]
+        target_proportions = [0.0 for i in range(len(class_list))]
         for index, class_id in enumerate(class_id_list):
-            target_proportions[class_id] = class_proportions[index]
+            target_proportions[class_id] = float(class_proportions[index])
         target_proportions = np.asarray(target_proportions)
 
         self.sample_weights = target_proportions[target_list]

--- a/plato/trainers/huggingface.py
+++ b/plato/trainers/huggingface.py
@@ -538,8 +538,10 @@ class Trainer(ComposableTrainer):
             getattr(Config(), "parameters", None), "huggingface_token", None
         )
 
-        tokenizer_loader = LlamaTokenizer if "llama" in tokenizer_name else AutoTokenizer
-        tokenizer_kwargs = {
+        tokenizer_loader: Any = (
+            LlamaTokenizer if "llama" in tokenizer_name else AutoTokenizer
+        )
+        tokenizer_kwargs: dict[str, Any] = {
             "config": self.config,
             "cache_dir": cache_dir,
             "use_fast": use_fast_tokenizer,
@@ -547,15 +549,16 @@ class Trainer(ComposableTrainer):
         }
         if isinstance(auth_token, str) and auth_token:
             tokenizer_kwargs["use_auth_token"] = auth_token
-        self.tokenizer = tokenizer_loader.from_pretrained(
+        self.tokenizer: Any = tokenizer_loader.from_pretrained(
             tokenizer_name,
             **tokenizer_kwargs,
         )
 
-        if getattr(self.tokenizer, "pad_token_id", None) is None:
-            eos_token = getattr(self.tokenizer, "eos_token", None)
+        tokenizer = cast(Any, self.tokenizer)
+        if getattr(tokenizer, "pad_token_id", None) is None:
+            eos_token = getattr(tokenizer, "eos_token", None)
             if eos_token is not None:
-                self.tokenizer.pad_token = eos_token
+                tokenizer.pad_token = eos_token
 
         grad_accum_steps = getattr(Config().trainer, "gradient_accumulation_steps", 1)
         try:
@@ -563,7 +566,7 @@ class Trainer(ComposableTrainer):
         except (TypeError, ValueError):
             grad_accum_steps = 1
         self._gradient_accumulation_steps = max(grad_accum_steps, 1)
-        self._collate_wrapper = HuggingFaceCollateWrapper(self.tokenizer)
+        self._collate_wrapper = HuggingFaceCollateWrapper(tokenizer)
         self.training_args.gradient_accumulation_steps = (
             self._gradient_accumulation_steps
         )

--- a/plato/trainers/loss_criterion.py
+++ b/plato/trainers/loss_criterion.py
@@ -75,7 +75,7 @@ def _resolve_loss_criterion(name: str) -> type[Any]:
     raise ValueError(f"Unknown loss criterion: {name}")
 
 
-def get(**kwargs: str | dict):
+def get(**kwargs: Any):
     """Get a loss function with its name from the configuration file."""
     if "loss_criterion" in kwargs:
         loss_criterion_name = kwargs["loss_criterion"]
@@ -83,6 +83,9 @@ def get(**kwargs: str | dict):
         loss_criterion_name = Config().trainer.loss_criterion
     else:
         loss_criterion_name = "CrossEntropyLoss"
+
+    if not isinstance(loss_criterion_name, str):
+        raise TypeError("loss_criterion must be provided as a string.")
 
     if "loss_criterion_params" in kwargs:
         loss_criterion_params = kwargs["loss_criterion_params"]

--- a/plato/trainers/nanochat.py
+++ b/plato/trainers/nanochat.py
@@ -186,7 +186,14 @@ class NanochatOptimizerStrategy(OptimizerStrategy):
         if not isinstance(optimizers, Iterable):
             raise TypeError("setup_optimizers() must return an iterable of optimizers.")
 
-        optimizer_list: list[torch.optim.Optimizer] = list(optimizers)
+        optimizer_candidates = list(optimizers)
+        optimizer_list: list[torch.optim.Optimizer] = []
+        for optimizer in optimizer_candidates:
+            if not isinstance(optimizer, torch.optim.Optimizer):
+                raise TypeError(
+                    "setup_optimizers() must yield torch.optim.Optimizer instances."
+                )
+            optimizer_list.append(optimizer)
         if not optimizer_list:
             raise ValueError("setup_optimizers() returned an empty optimizer list.")
         return _OptimizerBundle(optimizer_list)

--- a/plato/trainers/optimizers.py
+++ b/plato/trainers/optimizers.py
@@ -2,7 +2,7 @@
 Optimizers for training workloads.
 """
 
-from typing import Union
+from typing import Any, Union
 
 import torch_optimizer as torch_optim
 from timm import optim as timm_optim
@@ -11,7 +11,7 @@ from torch import optim
 from plato.config import Config
 
 
-def get(model, **kwargs: str | dict) -> optim.Optimizer:
+def get(model, **kwargs: Any) -> optim.Optimizer:
     """Get an optimizer with its name and parameters obtained from the configuration file."""
     registered_optimizers = {
         "Adam": optim.Adam,
@@ -40,6 +40,8 @@ def get(model, **kwargs: str | dict) -> optim.Optimizer:
         if "optimizer_name" in kwargs
         else Config().trainer.optimizer
     )
+    if not isinstance(optimizer_name, str):
+        raise TypeError("optimizer_name must be provided as a string.")
     if "optimizer_params" in kwargs:
         optimizer_params = kwargs["optimizer_params"]
     else:

--- a/plato/utils/tree.py
+++ b/plato/utils/tree.py
@@ -172,10 +172,12 @@ def flatten_tree(tree: Any) -> tuple[dict[str, np.ndarray], dict[str, TreeMetada
     def recurse(node: Any, path: str) -> None:
         if isinstance(node, dict):
             metadata[path] = TreeMetadata(
-                type="dict", children=list(node.keys()), container=None
+                type="dict",
+                children=[str(key) for key in node.keys()],
+                container=None,
             )
             for key, value in node.items():
-                recurse(value, _join_path(path, key))
+                recurse(value, _join_path(path, str(key)))
             return
 
         if isinstance(node, (list, tuple)):

--- a/tests/datasources/test_huggingface_datasource.py
+++ b/tests/datasources/test_huggingface_datasource.py
@@ -145,11 +145,13 @@ def test_huggingface_datasource_keeps_validation_split_for_corpus_mode(
     )
 
     datasource = huggingface_datasource.DataSource()
+    trainset = datasource.require_trainset()
+    testset = datasource.require_testset()
 
     assert datasource.train_split_name == "train"
     assert datasource.validation_split_name == "validation"
-    assert datasource.trainset.num_rows == 1
-    assert datasource.testset.num_rows == 1
+    assert trainset.num_rows == 1
+    assert testset.num_rows == 1
 
 
 def test_huggingface_datasource_falls_back_to_test_split(temp_config, monkeypatch):
@@ -190,9 +192,10 @@ def test_huggingface_datasource_falls_back_to_test_split(temp_config, monkeypatc
     )
 
     datasource = huggingface_datasource.DataSource()
+    testset = datasource.require_testset()
 
     assert datasource.validation_split_name == "test"
-    assert datasource.testset.num_rows == 1
+    assert testset.num_rows == 1
 
 
 def test_huggingface_datasource_loads_legacy_cache_path_when_present(
@@ -247,9 +250,10 @@ def test_huggingface_datasource_loads_legacy_cache_path_when_present(
     )
 
     datasource = huggingface_datasource.DataSource()
+    trainset = datasource.require_trainset()
 
     assert loaded_paths == [legacy_path]
-    assert datasource.trainset.num_rows == 1
+    assert trainset.num_rows == 1
 
 
 class LargeContextDummyTokenizer(DummyTokenizer):
@@ -362,9 +366,10 @@ def test_chat_sft_preprocesses_messages_without_corpus_concatenation(
     )
 
     datasource = huggingface_datasource.DataSource()
+    trainset = datasource.require_trainset()
 
-    assert datasource.trainset.num_rows == 2
-    example = datasource.trainset[0]
+    assert trainset.num_rows == 2
+    example = trainset[0]
     assert set(example) == {"input_ids", "attention_mask", "labels"}
     assert len(example["input_ids"]) == len(example["attention_mask"])
     assert len(example["input_ids"]) == len(example["labels"])
@@ -427,7 +432,7 @@ def test_chat_sft_masks_non_assistant_tokens_with_minus_100(temp_config, monkeyp
     )
 
     datasource = huggingface_datasource.DataSource()
-    example = datasource.trainset[0]
+    example = datasource.require_trainset()[0]
 
     assert example["labels"][:3] == [-100, -100, -100]
     assert example["labels"][3:] == example["input_ids"][3:]
@@ -490,7 +495,7 @@ def test_chat_sft_honors_max_seq_length_and_messages_field(temp_config, monkeypa
     )
 
     datasource = huggingface_datasource.DataSource()
-    example = datasource.trainset[0]
+    example = datasource.require_trainset()[0]
 
     assert len(example["input_ids"]) == 4
     assert len(example["labels"]) == 4
@@ -554,7 +559,7 @@ def test_chat_sft_normalizes_mapping_chat_template_outputs(temp_config, monkeypa
     )
 
     datasource = huggingface_datasource.DataSource()
-    example = datasource.trainset[0]
+    example = datasource.require_trainset()[0]
 
     assert isinstance(example["input_ids"], list)
     assert isinstance(example["attention_mask"], list)

--- a/tests/evaluators/test_lighteval.py
+++ b/tests/evaluators/test_lighteval.py
@@ -4,6 +4,7 @@ import sys
 import types
 from enum import Enum, auto
 from pathlib import Path
+from typing import Any, cast
 
 import pytest
 
@@ -14,6 +15,13 @@ from plato.evaluators.base import EvaluationInput
 def _clear_evaluation_config() -> None:
     if hasattr(Config, "evaluation"):
         delattr(Config, "evaluation")
+
+
+def _fake_module(name: str, **attributes: object) -> Any:
+    module = cast(Any, types.ModuleType(name))
+    for attribute_name, value in attributes.items():
+        setattr(module, attribute_name, value)
+    return module
 
 
 def test_lighteval_registry_resolves_without_importing_optional_backend(temp_config):
@@ -125,20 +133,24 @@ def test_lighteval_pipeline_matches_supported_api_contract(monkeypatch, temp_con
                 }
             }
 
-    lighteval_pkg = types.ModuleType("lighteval")
-    logging_pkg = types.ModuleType("lighteval.logging")
-    tracker_pkg = types.ModuleType("lighteval.logging.evaluation_tracker")
-    tracker_pkg.EvaluationTracker = FakeEvaluationTracker
-    models_pkg = types.ModuleType("lighteval.models")
-    transformers_pkg = types.ModuleType("lighteval.models.transformers")
-    transformers_model_pkg = types.ModuleType(
-        "lighteval.models.transformers.transformers_model"
+    lighteval_pkg = _fake_module("lighteval")
+    logging_pkg = _fake_module("lighteval.logging")
+    tracker_pkg = _fake_module(
+        "lighteval.logging.evaluation_tracker",
+        EvaluationTracker=FakeEvaluationTracker,
     )
-    transformers_model_pkg.TransformersModelConfig = FakeTransformersModelConfig
-    pipeline_pkg = types.ModuleType("lighteval.pipeline")
-    pipeline_pkg.Pipeline = FakePipeline
-    pipeline_pkg.PipelineParameters = FakePipelineParameters
-    pipeline_pkg.ParallelismManager = FakeParallelismManager
+    models_pkg = _fake_module("lighteval.models")
+    transformers_pkg = _fake_module("lighteval.models.transformers")
+    transformers_model_pkg = _fake_module(
+        "lighteval.models.transformers.transformers_model",
+        TransformersModelConfig=FakeTransformersModelConfig,
+    )
+    pipeline_pkg = _fake_module(
+        "lighteval.pipeline",
+        Pipeline=FakePipeline,
+        PipelineParameters=FakePipelineParameters,
+        ParallelismManager=FakeParallelismManager,
+    )
 
     monkeypatch.setitem(sys.modules, "lighteval", lighteval_pkg)
     monkeypatch.setitem(sys.modules, "lighteval.logging", logging_pkg)
@@ -238,20 +250,24 @@ def test_lighteval_pipeline_forwards_runtime_overrides(monkeypatch, temp_config)
         def get_results(self):
             return {"results": {"ifeval": 0.31}}
 
-    lighteval_pkg = types.ModuleType("lighteval")
-    logging_pkg = types.ModuleType("lighteval.logging")
-    tracker_pkg = types.ModuleType("lighteval.logging.evaluation_tracker")
-    tracker_pkg.EvaluationTracker = FakeEvaluationTracker
-    models_pkg = types.ModuleType("lighteval.models")
-    transformers_pkg = types.ModuleType("lighteval.models.transformers")
-    transformers_model_pkg = types.ModuleType(
-        "lighteval.models.transformers.transformers_model"
+    lighteval_pkg = _fake_module("lighteval")
+    logging_pkg = _fake_module("lighteval.logging")
+    tracker_pkg = _fake_module(
+        "lighteval.logging.evaluation_tracker",
+        EvaluationTracker=FakeEvaluationTracker,
     )
-    transformers_model_pkg.TransformersModelConfig = FakeTransformersModelConfig
-    pipeline_pkg = types.ModuleType("lighteval.pipeline")
-    pipeline_pkg.Pipeline = FakePipeline
-    pipeline_pkg.PipelineParameters = FakePipelineParameters
-    pipeline_pkg.ParallelismManager = FakeParallelismManager
+    models_pkg = _fake_module("lighteval.models")
+    transformers_pkg = _fake_module("lighteval.models.transformers")
+    transformers_model_pkg = _fake_module(
+        "lighteval.models.transformers.transformers_model",
+        TransformersModelConfig=FakeTransformersModelConfig,
+    )
+    pipeline_pkg = _fake_module(
+        "lighteval.pipeline",
+        Pipeline=FakePipeline,
+        PipelineParameters=FakePipelineParameters,
+        ParallelismManager=FakeParallelismManager,
+    )
 
     monkeypatch.setitem(sys.modules, "lighteval", lighteval_pkg)
     monkeypatch.setitem(sys.modules, "lighteval.logging", logging_pkg)
@@ -341,20 +357,24 @@ def test_lighteval_pipeline_uses_trainer_precision_for_default_dtype(
         def get_results(self):
             return {"results": {"ifeval": 0.31}}
 
-    lighteval_pkg = types.ModuleType("lighteval")
-    logging_pkg = types.ModuleType("lighteval.logging")
-    tracker_pkg = types.ModuleType("lighteval.logging.evaluation_tracker")
-    tracker_pkg.EvaluationTracker = FakeEvaluationTracker
-    models_pkg = types.ModuleType("lighteval.models")
-    transformers_pkg = types.ModuleType("lighteval.models.transformers")
-    transformers_model_pkg = types.ModuleType(
-        "lighteval.models.transformers.transformers_model"
+    lighteval_pkg = _fake_module("lighteval")
+    logging_pkg = _fake_module("lighteval.logging")
+    tracker_pkg = _fake_module(
+        "lighteval.logging.evaluation_tracker",
+        EvaluationTracker=FakeEvaluationTracker,
     )
-    transformers_model_pkg.TransformersModelConfig = FakeTransformersModelConfig
-    pipeline_pkg = types.ModuleType("lighteval.pipeline")
-    pipeline_pkg.Pipeline = FakePipeline
-    pipeline_pkg.PipelineParameters = FakePipelineParameters
-    pipeline_pkg.ParallelismManager = FakeParallelismManager
+    models_pkg = _fake_module("lighteval.models")
+    transformers_pkg = _fake_module("lighteval.models.transformers")
+    transformers_model_pkg = _fake_module(
+        "lighteval.models.transformers.transformers_model",
+        TransformersModelConfig=FakeTransformersModelConfig,
+    )
+    pipeline_pkg = _fake_module(
+        "lighteval.pipeline",
+        Pipeline=FakePipeline,
+        PipelineParameters=FakePipelineParameters,
+        ParallelismManager=FakeParallelismManager,
+    )
 
     monkeypatch.setitem(sys.modules, "lighteval", lighteval_pkg)
     monkeypatch.setitem(sys.modules, "lighteval.logging", logging_pkg)
@@ -427,20 +447,24 @@ def test_lighteval_pipeline_forwards_max_samples_to_each_task(monkeypatch, temp_
         def get_results(self):
             return {"results": {"ifeval": 0.31}}
 
-    lighteval_pkg = types.ModuleType("lighteval")
-    logging_pkg = types.ModuleType("lighteval.logging")
-    tracker_pkg = types.ModuleType("lighteval.logging.evaluation_tracker")
-    tracker_pkg.EvaluationTracker = FakeEvaluationTracker
-    models_pkg = types.ModuleType("lighteval.models")
-    transformers_pkg = types.ModuleType("lighteval.models.transformers")
-    transformers_model_pkg = types.ModuleType(
-        "lighteval.models.transformers.transformers_model"
+    lighteval_pkg = _fake_module("lighteval")
+    logging_pkg = _fake_module("lighteval.logging")
+    tracker_pkg = _fake_module(
+        "lighteval.logging.evaluation_tracker",
+        EvaluationTracker=FakeEvaluationTracker,
     )
-    transformers_model_pkg.TransformersModelConfig = FakeTransformersModelConfig
-    pipeline_pkg = types.ModuleType("lighteval.pipeline")
-    pipeline_pkg.Pipeline = FakePipeline
-    pipeline_pkg.PipelineParameters = FakePipelineParameters
-    pipeline_pkg.ParallelismManager = FakeParallelismManager
+    models_pkg = _fake_module("lighteval.models")
+    transformers_pkg = _fake_module("lighteval.models.transformers")
+    transformers_model_pkg = _fake_module(
+        "lighteval.models.transformers.transformers_model",
+        TransformersModelConfig=FakeTransformersModelConfig,
+    )
+    pipeline_pkg = _fake_module(
+        "lighteval.pipeline",
+        Pipeline=FakePipeline,
+        PipelineParameters=FakePipelineParameters,
+        ParallelismManager=FakeParallelismManager,
+    )
 
     monkeypatch.setitem(sys.modules, "lighteval", lighteval_pkg)
     monkeypatch.setitem(sys.modules, "lighteval.logging", logging_pkg)

--- a/tests/integration/test_huggingface_smollm_smoke.py
+++ b/tests/integration/test_huggingface_smollm_smoke.py
@@ -68,6 +68,8 @@ class SmokeHFModel(nn.Module):
 
     def forward(self, input_ids=None, attention_mask=None, labels=None, **kwargs):
         del attention_mask, kwargs
+        if input_ids is None:
+            raise ValueError("input_ids must be provided.")
         batch, seq = input_ids.shape
         vocab_size = self.embedding.num_embeddings
         logits = torch.zeros((batch, seq, vocab_size), dtype=torch.float32)

--- a/tests/trainers/test_huggingface_trainer.py
+++ b/tests/trainers/test_huggingface_trainer.py
@@ -53,6 +53,9 @@ class DummyHFModel(nn.Module):
         self.resized_to = None
 
     def forward(self, input_ids=None, attention_mask=None, labels=None, **kwargs):
+        del attention_mask, labels, kwargs
+        if input_ids is None:
+            raise ValueError("input_ids must be provided.")
         batch, seq = input_ids.shape
         vocab_size = self.embedding.num_embeddings
         logits = torch.zeros((batch, seq, vocab_size), dtype=torch.float32)
@@ -97,6 +100,7 @@ def test_huggingface_collate_wrapper_dynamically_pads_variable_length_labels():
 
     assert batch["input_ids"].shape == (2, 3)
     assert batch["attention_mask"].tolist() == [[1, 1, 1], [1, 1, 0]]
+    assert labels is not None
     assert labels.tolist() == [[-100, 2, 3], [-100, 5, -100]]
 
 
@@ -126,6 +130,7 @@ def test_huggingface_collate_wrapper_unwraps_nested_batch_encodings():
 
     assert batch["input_ids"].tolist() == [[1, 2, 3], [4, 5, 0]]
     assert batch["attention_mask"].tolist() == [[1, 1, 1], [1, 1, 0]]
+    assert labels is not None
     assert labels.tolist() == [[-100, 2, 3], [-100, 5, -100]]
 
 


### PR DESCRIPTION
## What changed
- fixed the `ty check` failures across the Hugging Face datasource/trainer stack, the Lighteval evaluator, and several example modules
- tightened container and optional-value typing so `ty` no longer infers incorrect narrow unions
- updated affected tests and mocks to reflect the runtime contracts used by these code paths

## Why
- `ty check` was reporting a large batch of type errors caused by stale API usage, ambiguous optional values, and imprecise inferred container types
- this PR brings the repository back to a clean type-checking baseline without changing the intended runtime behavior

## Impact
- `uv run ty check` now passes cleanly
- the Hugging Face and Lighteval paths covered by the updated tests remain green
- no config or public interface changes were introduced

## Root cause
- several modules relied on dynamically typed third-party APIs without enough local narrowing for the type checker
- a few tests also depended on runtime guarantees that were not expressed explicitly enough for static analysis

## Validation
- `uv run ty check`
- `uv run pytest tests/datasources/test_huggingface_datasource.py tests/evaluators/test_lighteval.py tests/trainers/test_huggingface_trainer.py tests/integration/test_huggingface_smollm_smoke.py`
- `uv run ruff check ... --select I` on the edited files
